### PR TITLE
feat: auto-install dependencies and remove operator-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ aap-demo deploys Ansible Automation Platform 2.7 to OpenShift Local (MicroShift)
 ### Prerequisites
 
 #### System Requirements
-A typical Microshift and AAP 2.7 environment requires 16GB of RAM, 2 cores, and 100 GB of storage. We recommend having a total of 32GB RAM available on your system. 
+
+A typical Microshift and AAP 2.7 environment requires 16GB of RAM, 2 cores, and
+100 GB of storage. We recommend having a total of 32GB RAM available on your system.
 
 #### MacOS
 

--- a/install.sh
+++ b/install.sh
@@ -50,9 +50,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 1
   fi
 
-  if ! command -v operator-sdk &>/dev/null; then
-    MISSING_DEPS="$MISSING_DEPS operator-sdk"
-  fi
 fi
 
 # Auto-install missing dependencies
@@ -66,9 +63,6 @@ if [ -n "$MISSING_DEPS" ]; then
       case "$dep" in
         kubectl)
           brew install kubectl
-          ;;
-        operator-sdk)
-          brew install operator-sdk
           ;;
         ansible)
           brew install ansible
@@ -89,12 +83,10 @@ if [ -n "$MISSING_DEPS" ]; then
     echo "  Fedora/RHEL:"
     echo "    sudo dnf install ansible-core jq python3-pip"
     echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
-    echo "    # operator-sdk: https://sdk.operatorframework.io/docs/installation/"
     echo ""
     echo "  Ubuntu/Debian:"
     echo "    sudo apt install ansible jq python3-pip"
     echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
-    echo "    # operator-sdk: https://sdk.operatorframework.io/docs/installation/"
     echo ""
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -76,19 +76,43 @@ if [ -n "$MISSING_DEPS" ]; then
       esac
     done
   else
-    echo "ERROR: Missing required dependencies:$MISSING_DEPS"
-    echo ""
-    echo "Install with:"
-    echo ""
-    echo "  Fedora/RHEL:"
-    echo "    sudo dnf install ansible-core jq python3-pip"
-    echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
-    echo ""
-    echo "  Ubuntu/Debian:"
-    echo "    sudo apt install ansible jq python3-pip"
-    echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
-    echo ""
-    exit 1
+    # Auto-install on Linux
+    echo "Installing missing dependencies..."
+    for dep in $MISSING_DEPS; do
+      case "$dep" in
+        kubectl)
+          echo "Installing kubectl..."
+          KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+          KUBECTL_ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
+          curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl"
+          chmod +x kubectl
+          mkdir -p ~/.local/bin
+          mv kubectl ~/.local/bin/
+          echo "✓ kubectl installed to ~/.local/bin/kubectl"
+          ;;
+        ansible|jq|python3)
+          # Try package manager
+          if command -v dnf &>/dev/null; then
+            PKG_CMD="sudo dnf install -y"
+            case "$dep" in
+              ansible) PKG="ansible-core" ;;
+              *) PKG="$dep" ;;
+            esac
+          elif command -v apt &>/dev/null; then
+            PKG_CMD="sudo apt install -y"
+            PKG="$dep"
+          else
+            echo "ERROR: No supported package manager (dnf/apt) found for $dep"
+            exit 1
+          fi
+          echo "Installing $dep via package manager..."
+          $PKG_CMD $PKG || {
+            echo "ERROR: Failed to install $dep"
+            exit 1
+          }
+          ;;
+      esac
+    done
   fi
 
   echo ""

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ if [ -n "$MISSING_DEPS" ]; then
           mv kubectl ~/.local/bin/
           echo "✓ kubectl installed to ~/.local/bin/kubectl"
           ;;
-        ansible|jq|python3)
+        ansible | jq | python3)
           # Try package manager
           if command -v dnf &>/dev/null; then
             PKG_CMD="sudo dnf install -y"

--- a/install.sh
+++ b/install.sh
@@ -55,26 +55,53 @@ if [[ "$(uname)" == "Darwin" ]]; then
   fi
 fi
 
-# Report missing dependencies
+# Auto-install missing dependencies
 if [ -n "$MISSING_DEPS" ]; then
-  echo "ERROR: Missing required dependencies:$MISSING_DEPS"
+  echo "Missing dependencies:$MISSING_DEPS"
   echo ""
-  echo "Install with:"
-  echo ""
+
   if [[ "$(uname)" == "Darwin" ]]; then
-    echo "  macOS:"
-    echo "    brew install kubectl ansible jq python3 operator-sdk"
+    echo "Installing via Homebrew..."
+    for dep in $MISSING_DEPS; do
+      case "$dep" in
+        kubectl)
+          brew install kubectl
+          ;;
+        operator-sdk)
+          brew install operator-sdk
+          ;;
+        ansible)
+          brew install ansible
+          ;;
+        jq)
+          brew install jq
+          ;;
+        python3)
+          brew install python3
+          ;;
+      esac
+    done
   else
+    echo "ERROR: Missing required dependencies:$MISSING_DEPS"
+    echo ""
+    echo "Install with:"
+    echo ""
     echo "  Fedora/RHEL:"
     echo "    sudo dnf install ansible-core jq python3-pip"
     echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+    echo "    # operator-sdk: https://sdk.operatorframework.io/docs/installation/"
     echo ""
     echo "  Ubuntu/Debian:"
     echo "    sudo apt install ansible jq python3-pip"
     echo "    # kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+    echo "    # operator-sdk: https://sdk.operatorframework.io/docs/installation/"
+    echo ""
+    exit 1
   fi
+
   echo ""
-  exit 1
+  echo "  ✓ Dependencies installed"
+  echo ""
 fi
 
 echo "  ✓ All required dependencies found"


### PR DESCRIPTION
## Summary
Auto-install missing dependencies on macOS/Linux during install.sh execution.

## Changes
- **macOS**: Auto-install kubectl via Homebrew when missing
- **Linux**: Auto-install kubectl from upstream binary (latest stable) to ~/.local/bin/
- **Linux**: Auto-install ansible/jq/python3 via dnf/apt
- Removed operator-sdk from required dependencies (only used by dormant deploy_operator_sdk() function)
- Preserves existing dependency checks

## Test Plan
- [x] Syntax validated with `bash -n`
- [x] Pre-commit hooks pass (shellcheck, commitizen, etc.)
- [x] Logic tested with mock environment

Signed off by: @chadmf 
🤖 Generated with [Claude Code](https://claude.com/claude-code)