### PR TITLE
fix: prevent aap-demo start from exiting under set -e

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -1812,11 +1812,11 @@ cmd_start() {
 
   # Re-apply CoreDNS config (fixes DNS after restarts)
   if [ -f "${SCRIPT_DIR}/includes/crc-create.sh" ]; then
-    # Extract and re-run just the CoreDNS config function
     bash -c "
+      AAP_DEMO_CONFIGURE_COREDNS_ONLY=1
       source '${SCRIPT_DIR}/includes/crc-create.sh'
-      configure_coredns 2>/dev/null || true
-    "
+      configure_coredns
+    " || true
   fi
 
   echo "✓ CRC cluster started"
@@ -1826,7 +1826,9 @@ cmd_start() {
 
 _start_crc_cluster() {
   crc start || true
-  [ -f /etc/resolver/testing ] && sudo rm -f /etc/resolver/testing
+  if [ -f /etc/resolver/testing ]; then
+    sudo rm -f /etc/resolver/testing
+  fi
 }
 
 cmd_create() {

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -19,6 +19,102 @@ _YELLOW='\033[0;33m'
 _BOLD='\033[1m'
 _NC='\033[0m'
 
+configure_coredns() {
+  local current_preset route_domain current_domain escaped_domain current_corefile corefile
+  local crc_ssh_key crc_ssh_opts
+
+  crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+  current_preset="${CURRENT_PRESET:-}"
+  if [ -z "$current_preset" ]; then
+    current_preset=$(crc config get preset 2>/dev/null || echo "")
+    [ -n "$current_preset" ] && current_preset=$(echo "$current_preset" | awk '{print $NF}')
+  fi
+  current_preset="${current_preset:-${CRC_PRESET:-microshift}}"
+
+  printf "${_GREEN}▸${_NC} Configuring CoreDNS for in-cluster route resolution...\n"
+
+  export KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
+
+  if [ "$current_preset" = "microshift" ]; then
+    route_domain="apps.crc.testing"
+    current_domain=$(ssh -p 2222 $crc_ssh_opts core@127.0.0.1 'grep -h baseDomain /etc/microshift/config.d/99-aap-demo-dns.yaml /etc/microshift/config.yaml 2>/dev/null | head -1' 2>/dev/null | awk '{print $2}' || true)
+    if [ -n "$current_domain" ]; then
+      route_domain="apps.${current_domain}"
+    fi
+  else
+    route_domain="apps-crc.testing"
+  fi
+
+  escaped_domain=$(echo "$route_domain" | sed 's/\./\\./g')
+
+  current_corefile=$(kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null || echo "")
+  if echo "$current_corefile" | grep -q "router-internal-default"; then
+    echo "  ✓ CoreDNS already configured for ${route_domain}"
+    return 0
+  fi
+
+  echo "  Patching CoreDNS ConfigMap..."
+  corefile=$(
+    cat <<COREFILE_EOF
+.:5353 {
+    bufsize 1232
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    rewrite stop {
+        name regex (.*)\.${escaped_domain} router-internal-default.openshift-ingress.svc.cluster.local
+        answer auto
+    }
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}
+COREFILE_EOF
+  )
+  kubectl patch configmap dns-default -n openshift-dns --type merge \
+    -p "{\"data\":{\"Corefile\":$(echo "$corefile" | jq -Rs .)}}"
+  kubectl rollout restart daemonset/dns-default -n openshift-dns 2>/dev/null || true
+  kubectl rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || true
+
+  sleep 5
+  if kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null | grep -q "router-internal-default"; then
+    echo "  ✓ CoreDNS configured: ${route_domain} → router service"
+    return 0
+  fi
+
+  echo "  CoreDNS config was overwritten by DNS operator — re-patching..."
+  kubectl patch configmap dns-default -n openshift-dns --type merge \
+    -p "{\"data\":{\"Corefile\":$(echo "$corefile" | jq -Rs .)}}"
+  kubectl rollout restart daemonset/dns-default -n openshift-dns 2>/dev/null || true
+  kubectl rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || true
+  sleep 5
+  if kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null | grep -q "router-internal-default"; then
+    echo "  ✓ CoreDNS configured (re-patched): ${route_domain} → router service"
+  else
+    printf "  ${_YELLOW}WARNING: CoreDNS config not persisting — DNS operator keeps overwriting${_NC}\n"
+    echo "  If pods can't resolve nip.io routes, run: crc start"
+  fi
+}
+
+# When sourced for CoreDNS only (aap-demo start), skip cluster creation.
+[[ "${AAP_DEMO_CONFIGURE_COREDNS_ONLY:-}" == "1" ]] && return 0
+
 echo ""
 printf "${_BOLD}aap-demo create${_NC} - Creating CRC cluster...\n"
 echo ""
@@ -369,85 +465,7 @@ fi
 # (Deferred to end of create flow — MicroShift's DNS controller overwrites
 # the configmap during startup, so we must wait for it to finish first)
 # ---------------------------------------------------------------------------
-printf "${_GREEN}▸${_NC} Configuring CoreDNS for in-cluster route resolution...\n"
-
-export KUBECONFIG="$HOME/.crc/machines/crc/kubeconfig"
-
-# Determine route domain
-if [ "$CURRENT_PRESET" = "microshift" ]; then
-  ROUTE_DOMAIN="apps.crc.testing"
-  CURRENT_DOMAIN=$(ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 'grep -h baseDomain /etc/microshift/config.d/99-aap-demo-dns.yaml /etc/microshift/config.yaml 2>/dev/null | head -1' 2>/dev/null | awk '{print $2}' || true)
-  if [ -n "$CURRENT_DOMAIN" ]; then
-    ROUTE_DOMAIN="apps.${CURRENT_DOMAIN}"
-  fi
-else
-  ROUTE_DOMAIN="apps-crc.testing"
-fi
-
-ESCAPED_DOMAIN=$(echo "$ROUTE_DOMAIN" | sed 's/\./\\./g')
-
-# Check if CoreDNS already configured with our rewrite rule
-CURRENT_COREFILE=$(kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null || echo "")
-if echo "$CURRENT_COREFILE" | grep -q "router-internal-default"; then
-  echo "  ✓ CoreDNS already configured for ${ROUTE_DOMAIN}"
-else
-  echo "  Patching CoreDNS ConfigMap..."
-  COREFILE=$(
-    cat <<COREFILE_EOF
-.:5353 {
-    bufsize 1232
-    errors
-    log . {
-        class error
-    }
-    health {
-        lameduck 20s
-    }
-    ready
-    rewrite stop {
-        name regex (.*)\.${ESCAPED_DOMAIN} router-internal-default.openshift-ingress.svc.cluster.local
-        answer auto
-    }
-    kubernetes cluster.local in-addr.arpa ip6.arpa {
-        pods insecure
-        fallthrough in-addr.arpa ip6.arpa
-    }
-    prometheus 127.0.0.1:9153
-    forward . /etc/resolv.conf {
-        policy sequential
-    }
-    cache 900 {
-        denial 9984 30
-    }
-    reload
-}
-COREFILE_EOF
-  )
-  kubectl patch configmap dns-default -n openshift-dns --type merge \
-    -p "{\"data\":{\"Corefile\":$(echo "$COREFILE" | jq -Rs .)}}"
-  kubectl rollout restart daemonset/dns-default -n openshift-dns 2>/dev/null || true
-  kubectl rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || true
-
-  # Wait for rollout to complete, then verify config persisted
-  # MicroShift's DNS operator may reconcile the configmap — re-patch if needed
-  sleep 5
-  if kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null | grep -q "router-internal-default"; then
-    echo "  ✓ CoreDNS configured: ${ROUTE_DOMAIN} → router service"
-  else
-    echo "  CoreDNS config was overwritten by DNS operator — re-patching..."
-    kubectl patch configmap dns-default -n openshift-dns --type merge \
-      -p "{\"data\":{\"Corefile\":$(echo "$COREFILE" | jq -Rs .)}}"
-    kubectl rollout restart daemonset/dns-default -n openshift-dns 2>/dev/null || true
-    kubectl rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || true
-    sleep 5
-    if kubectl get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}' 2>/dev/null | grep -q "router-internal-default"; then
-      echo "  ✓ CoreDNS configured (re-patched): ${ROUTE_DOMAIN} → router service"
-    else
-      printf "  ${_YELLOW}WARNING: CoreDNS config not persisting — DNS operator keeps overwriting${_NC}\n"
-      echo "  If pods can't resolve nip.io routes, run: crc start"
-    fi
-  fi
-fi
+configure_coredns
 
 # ---------------------------------------------------------------------------
 # Set sysctl for performance (inotify limits for operator watchers)


### PR DESCRIPTION
## Summary
`aap-demo start` was failing with exit code 1 even when CRC started successfully. Two issues caused this under `set -e`: `_start_crc_cluster` returned a false failure when `/etc/resolver/testing` was absent, and sourcing `crc-create.sh` re-ran the full cluster create flow instead of only re-applying CoreDNS.

## Changes
- [ ] Feature Enhancement
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Other (please specify):

### Description of Changes
- Use an `if` block for optional `/etc/resolver/testing` cleanup so `_start_crc_cluster` does not return exit code 1 when the file is missing
- Extract CoreDNS configuration into a reusable `configure_coredns()` function in `includes/crc-create.sh`
- Add `AAP_DEMO_CONFIGURE_COREDNS_ONLY` guard so `aap-demo start` can source the function without triggering cluster creation
- Update `cmd_start` to call `configure_coredns` safely after CRC starts

## Checklist
- [x] I have tested this change and it works as expected
- [ ] I have updated documentation (if applicable)
- [x] This PR follows the repository’s contribution guidelines

## Additional Information
Verified with:
- `QUIET=true ./aap-demo.sh start` (exit 0, CoreDNS re-applied)
- `./test/test-core-commands.sh` (8/8 tests passed)


Made with [Cursor](https://cursor.com)