### PR TITLE
fix: clarify mkcert password prompt is for sudo

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -338,7 +338,7 @@ check_mkcert_ca() {
     echo ""
     echo "      mkcert -install"
     echo ""
-    echo "  You will be prompted for your administrator password."
+    echo "  You will be prompted for your system administrator password (sudo)."
     echo "  This is a one-time setup per machine."
     echo ""
     echo "  Firefox: Install certutil first (brew install nss / apt install libnss3-tools)"


### PR DESCRIPTION
## Problem

Password prompt during `aap-demo deploy` says "administrator password" without specifying which password — users confused whether it's AAP admin, API key, pull secret, or system password.

## Changes

Updated `check_mkcert_ca()` message from:
```
You will be prompted for your administrator password.
```

to:
```
You will be prompted for your system administrator password (sudo).
```

## Testing

Message displays correctly during mkcert CA check before first deploy.

Fixes #24