### PR TITLE
fix: configure git safe.directory for AWX controller

### DIFF
--- a/config/crs/aap-minimal-noingress.yaml
+++ b/config/crs/aap-minimal-noingress.yaml
@@ -32,7 +32,22 @@ spec:
     ingress_type: none
     # Fix git "dubious ownership" on project sync (emptyDir /var/lib/awx/projects)
     security_context_settings:
-      fsGroup: 996  # awx UID — makes project volume group-owned by awx
+      fsGroup: 996  # awx UID — group ownership on project volume
+    # fsGroup alone is insufficient: AWX clones as root, awx user runs git later
+    task_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"
+    ee_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"
 
   eda:
     disabled: false

--- a/config/crs/aap-minimal-noingress.yaml
+++ b/config/crs/aap-minimal-noingress.yaml
@@ -30,22 +30,9 @@ spec:
   controller:
     disabled: false
     ingress_type: none
-    # Fix git "dubious ownership" error on vanilla k8s
-    # Project directories may have different ownership than the running process
-    task_extra_env: |
-      - name: GIT_CONFIG_COUNT
-        value: "1"
-      - name: GIT_CONFIG_KEY_0
-        value: safe.directory
-      - name: GIT_CONFIG_VALUE_0
-        value: "*"
-    ee_extra_env: |
-      - name: GIT_CONFIG_COUNT
-        value: "1"
-      - name: GIT_CONFIG_KEY_0
-        value: safe.directory
-      - name: GIT_CONFIG_VALUE_0
-        value: "*"
+    # Fix git "dubious ownership" on project sync (emptyDir /var/lib/awx/projects)
+    security_context_settings:
+      fsGroup: 996  # awx UID — makes project volume group-owned by awx
 
   eda:
     disabled: false

--- a/config/crs/aap-minimal.yaml
+++ b/config/crs/aap-minimal.yaml
@@ -8,6 +8,9 @@ spec:
 
   controller:
     disabled: false
+    # Fix git "dubious ownership" on project sync (emptyDir /var/lib/awx/projects)
+    security_context_settings:
+      fsGroup: 996  # awx UID — makes project volume group-owned by awx
 
   eda:
     disabled: false

--- a/config/crs/aap-minimal.yaml
+++ b/config/crs/aap-minimal.yaml
@@ -10,7 +10,22 @@ spec:
     disabled: false
     # Fix git "dubious ownership" on project sync (emptyDir /var/lib/awx/projects)
     security_context_settings:
-      fsGroup: 996  # awx UID — makes project volume group-owned by awx
+      fsGroup: 996  # awx UID — group ownership on project volume
+    # fsGroup alone is insufficient: AWX clones as root, awx user runs git later
+    task_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"
+    ee_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"
 
   eda:
     disabled: false

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -8,7 +8,8 @@
 # Usage:
 #   kubectl patch ansibleautomationplatform aap -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
 #
-# Or integrate into aap-demo.sh deploy flow
+# New deployments: included in config/crs/aap-minimal.yaml
+# Existing deployments: apply this patch manually (see Usage above)
 
 spec:
   controller:

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -1,17 +1,25 @@
 ---
 # Patch to fix git "dubious ownership" errors in AWX projects
-# Apply after AAP deployment creates the AutomationController CR
+# Apply after AAP deployment creates the AnsibleAutomationPlatform CR
 #
 # Usage:
-#   kubectl patch automationcontroller aap-controller -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
+#   kubectl patch ansibleautomationplatform aap -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
 #
 # Or integrate into aap-demo.sh deploy flow
 
 spec:
-  task_extra_env: |
-    - name: GIT_CONFIG_COUNT
-      value: "1"
-    - name: GIT_CONFIG_KEY_0
-      value: "safe.directory"
-    - name: GIT_CONFIG_VALUE_0
-      value: "/var/lib/awx/projects"
+  controller:
+    task_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: "safe.directory"
+      - name: GIT_CONFIG_VALUE_0
+        value: "/var/lib/awx/projects"  # Scoped to specific path (more secure than wildcard "*")
+    ee_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: "safe.directory"
+      - name: GIT_CONFIG_VALUE_0
+        value: "/var/lib/awx/projects"  # Scoped to specific path (more secure than wildcard "*")

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -2,10 +2,8 @@
 # Patch to fix git "dubious ownership" errors in AWX projects
 # Apply after AAP deployment creates the AnsibleAutomationPlatform CR
 #
-# SECURITY NOTE: Uses wildcard (*) for safe.directory which reduces git CVE-2022-24765 protections.
-# AWX creates unpredictable subdirs like _7__pp under /var/lib/awx/projects. Scoped paths don't match.
-# Alternative mitigation: fix ownership (AWX should own /var/lib/awx/projects/* not root).
-# Wildcard acceptable in demo/dev contexts; production should fix ownership or use init containers.
+# Uses fsGroup to make awx (UID 996) own /var/lib/awx/projects emptyDir volume.
+# This is more secure than safe.directory wildcard (*) which disables CVE-2022-24765 protections.
 #
 # Usage:
 #   kubectl patch ansibleautomationplatform aap -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
@@ -14,17 +12,6 @@
 
 spec:
   controller:
-    task_extra_env: |
-      - name: GIT_CONFIG_COUNT
-        value: "1"
-      - name: GIT_CONFIG_KEY_0
-        value: "safe.directory"
-      - name: GIT_CONFIG_VALUE_0
-        value: "*"
-    ee_extra_env: |
-      - name: GIT_CONFIG_COUNT
-        value: "1"
-      - name: GIT_CONFIG_KEY_0
-        value: "safe.directory"
-      - name: GIT_CONFIG_VALUE_0
-        value: "*"
+    task_pod_spec:
+      securityContext:
+        fsGroup: 996  # awx UID - makes emptyDir volumes owned by awx group

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -14,4 +14,4 @@ spec:
     - name: GIT_CONFIG_KEY_0
       value: "safe.directory"
     - name: GIT_CONFIG_VALUE_0
-      value: "*"
+      value: "/var/lib/awx/projects"

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -12,6 +12,5 @@
 
 spec:
   controller:
-    task_pod_spec:
-      securityContext:
-        fsGroup: 996  # awx UID - makes emptyDir volumes owned by awx group
+    security_context_settings:
+      fsGroup: 996  # awx UID - makes emptyDir volumes owned by awx group

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -2,6 +2,11 @@
 # Patch to fix git "dubious ownership" errors in AWX projects
 # Apply after AAP deployment creates the AnsibleAutomationPlatform CR
 #
+# SECURITY NOTE: Uses wildcard (*) for safe.directory which reduces git CVE-2022-24765 protections.
+# AWX creates unpredictable subdirs like _7__pp under /var/lib/awx/projects. Scoped paths don't match.
+# Alternative mitigation: fix ownership (AWX should own /var/lib/awx/projects/* not root).
+# Wildcard acceptable in demo/dev contexts; production should fix ownership or use init containers.
+#
 # Usage:
 #   kubectl patch ansibleautomationplatform aap -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
 #

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -2,16 +2,30 @@
 # Patch to fix git "dubious ownership" errors in AWX projects
 # Apply after AAP deployment creates the AnsibleAutomationPlatform CR
 #
-# Uses fsGroup to make awx (UID 996) own /var/lib/awx/projects emptyDir volume.
-# This is more secure than safe.directory wildcard (*) which disables CVE-2022-24765 protections.
+# AWX project sync clones repos as root but subsequent git commands run as awx.
+# fsGroup fixes volume group ownership; safe.directory bypasses git's ownership check.
+# Wildcard (*) is acceptable for demo/dev; production should scope paths if possible.
 #
 # Usage:
 #   kubectl patch ansibleautomationplatform aap -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
 #
 # New deployments: included in config/crs/aap-minimal.yaml
-# Existing deployments: apply this patch manually (see Usage above)
 
 spec:
   controller:
     security_context_settings:
-      fsGroup: 996  # awx UID - makes emptyDir volumes owned by awx group
+      fsGroup: 996
+    task_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"
+    ee_extra_env: |
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: "*"

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -1,0 +1,17 @@
+---
+# Patch to fix git "dubious ownership" errors in AWX projects
+# Apply after AAP deployment creates the AutomationController CR
+#
+# Usage:
+#   kubectl patch automationcontroller aap-controller -n aap-operator --patch-file config/patches/controller-git-safe-directory.yaml --type=merge
+#
+# Or integrate into aap-demo.sh deploy flow
+
+spec:
+  task_extra_env: |
+    - name: GIT_CONFIG_COUNT
+      value: "1"
+    - name: GIT_CONFIG_KEY_0
+      value: "safe.directory"
+    - name: GIT_CONFIG_VALUE_0
+      value: "*"

--- a/config/patches/controller-git-safe-directory.yaml
+++ b/config/patches/controller-git-safe-directory.yaml
@@ -15,11 +15,11 @@ spec:
       - name: GIT_CONFIG_KEY_0
         value: "safe.directory"
       - name: GIT_CONFIG_VALUE_0
-        value: "/var/lib/awx/projects"  # Scoped to specific path (more secure than wildcard "*")
+        value: "*"
     ee_extra_env: |
       - name: GIT_CONFIG_COUNT
         value: "1"
       - name: GIT_CONFIG_KEY_0
         value: "safe.directory"
       - name: GIT_CONFIG_VALUE_0
-        value: "/var/lib/awx/projects"  # Scoped to specific path (more secure than wildcard "*")
+        value: "*"


### PR DESCRIPTION
## Summary
- Fixes git "dubious ownership" errors during AWX project sync on OpenShift Local
- Combines `fsGroup: 996` (volume group ownership) with `safe.directory=*` via `GIT_CONFIG` env vars
- Bakes the fix into default CR templates (`aap-minimal.yaml`, `aap-minimal-noingress.yaml`) and the manual patch file

## Root cause
AWX clones projects as **root** (`.git` owned `root:awx`) but later git commands run as **awx** (UID 996). Git 2.35.2+ rejects repos owned by a different user when the parent directory is world-writable.

`fsGroup` alone fixes volume permissions but does **not** resolve the ownership mismatch on cloned `.git` directories.

## Fix
- `security_context_settings.fsGroup: 996` — group ownership on `/var/lib/awx/projects` emptyDir
- `task_extra_env` / `ee_extra_env` — `GIT_CONFIG` vars setting `safe.directory=*`

## Test plan
- [x] Deploy AAP with updated CR on OpenShift Local
- [x] Create git project and trigger project sync
- [x] Verify project update completes without dubious ownership errors
- [x] Confirm `GIT_CONFIG_*` env vars present on task pod after operator reconciliation

**Tested and validated on Fedora 44.**

Fixes #19