### PR TITLE
fix: import ingress CA on Linux for create, deploy, and status

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -162,6 +162,8 @@ fi
 
 # Load infrastructure abstraction layer
 source "${SCRIPT_DIR}/includes/infra-api.sh"
+# shellcheck source=includes/ingress-ca-trust.sh
+source "${SCRIPT_DIR}/includes/ingress-ca-trust.sh"
 
 # -----------------------------------------------------------------------------
 # Prerequisite Checks
@@ -1337,8 +1339,10 @@ _run_atf() {
   aap_version=$(kubectl get csv -n "$test_namespace" -o jsonpath='{.items[0].spec.version}' 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
   if [ -z "$aap_version" ]; then
     # Fallback: gateway API ping (may report base version, not dev version)
-    local _curl_tls="--cacert /tmp/crc-ingress-ca.crt"
-    [ ! -f /tmp/crc-ingress-ca.crt ] && _curl_tls="-k"
+    local _ca_cert
+    _ca_cert=$(get_ingress_ca_cert_path)
+    local _curl_tls="--cacert ${_ca_cert}"
+    [ ! -f "$_ca_cert" ] && _curl_tls="-k"
     aap_version=$(curl -s $_curl_tls "https://${gateway_host}/api/gateway/v1/ping/" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
   fi
   aap_version="${aap_version:-2.7}"
@@ -1590,6 +1594,8 @@ cmd_status() {
     echo "Start with: aap-demo create"
     return 0
   fi
+
+  install_ingress_ca_trust
 
   # Show kubeconfig
   echo "Kubeconfig:  $KUBECONFIG"
@@ -1872,6 +1878,8 @@ cmd_deploy() {
     echo "Cluster is stopped. Starting..."
     _start_crc_cluster
   fi
+
+  install_ingress_ca_trust
 
   # Install OLM if not present (OpenShift Local doesn't include it)
   KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}" bash "${SCRIPT_DIR}/addons/olm/deploy.sh"

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -325,31 +325,9 @@ fi
 # ---------------------------------------------------------------------------
 # Trust ingress CA
 # ---------------------------------------------------------------------------
-printf "${_GREEN}▸${_NC} Trusting ingress CA...\n"
-
-CA_CERT="/tmp/crc-ingress-ca.crt"
-ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 'sudo cat /var/lib/microshift/certs/ingress-ca/ca.crt' >"$CA_CERT" 2>/dev/null
-
-if [ -s "$CA_CERT" ]; then
-  if [[ "$(uname)" == "Darwin" ]]; then
-    # Remove any previous ingress-ca certs to avoid accumulation
-    while sudo security delete-certificate -c "ingress-ca" /Library/Keychains/System.keychain 2>/dev/null; do :; done
-    if sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CA_CERT" 2>/dev/null; then
-      echo "  ✓ Ingress CA trusted (macOS keychain)"
-    else
-      printf "${_YELLOW}▸${_NC} Could not add CA (may need admin password)\n"
-    fi
-  else
-    # Linux: copy to system trust store and update (replaces previous)
-    if sudo cp "$CA_CERT" /etc/pki/ca-trust/source/anchors/crc-ingress-ca.crt 2>/dev/null \
-      && sudo update-ca-trust 2>/dev/null; then
-      echo "  ✓ Ingress CA trusted (system ca-trust)"
-    else
-      printf "${_YELLOW}▸${_NC} Could not add CA to system trust store\n"
-    fi
-  fi
-  rm -f "$CA_CERT"
-fi
+# shellcheck source=includes/ingress-ca-trust.sh
+source "${SCRIPT_DIR}/includes/ingress-ca-trust.sh"
+install_ingress_ca_trust
 
 # ---------------------------------------------------------------------------
 # Set up kubeconfig

--- a/includes/ingress-ca-trust.sh
+++ b/includes/ingress-ca-trust.sh
@@ -19,6 +19,7 @@ if [ -n "${_INGRESS_CA_TRUST_LOADED:-}" ]; then return 0; fi
 _INGRESS_CA_TRUST_LOADED=1
 
 _INGRESS_CA_ANCHOR_NAME='crc-ingress-ca.crt'
+_INGRESS_CA_NSS_NICKNAME='crc-ingress-ca'
 _INGRESS_CA_RHEL_ANCHOR="/etc/pki/ca-trust/source/anchors/${_INGRESS_CA_ANCHOR_NAME}"
 _INGRESS_CA_DEBIAN_ANCHOR="/usr/local/share/ca-certificates/${_INGRESS_CA_ANCHOR_NAME}"
 
@@ -80,6 +81,46 @@ _ingress_ca_in_trust_store() {
   [ -n "$installed_fingerprint" ] && [ "$fingerprint" = "$installed_fingerprint" ]
 }
 
+_ingress_ca_nss_db_paths() {
+  # Chrome/Chromium use NSS, not system ca-trust. Chromium prefers ~/.pki/nssdb
+  # when it exists, otherwise ~/.local/share/pki/nssdb (since M146).
+  if [ -d "${HOME}/.pki/nssdb" ]; then
+    echo "sql:${HOME}/.pki/nssdb"
+  fi
+  if [ -d "${HOME}/.local/share/pki/nssdb" ]; then
+    echo "sql:${HOME}/.local/share/pki/nssdb"
+  fi
+}
+
+_ingress_ca_in_nss_store() {
+  local path="$1"
+  local db fingerprint
+
+  command -v certutil &>/dev/null || return 1
+
+  fingerprint=$(_ingress_ca_fingerprint "$path")
+  [ -n "$fingerprint" ] || return 1
+
+  while IFS= read -r db; do
+    [ -n "$db" ] || continue
+    certutil -d "$db" -L 2>/dev/null | grep -Fq "$_INGRESS_CA_NSS_NICKNAME" || return 1
+  done < <(_ingress_ca_nss_db_paths)
+
+  # No NSS DB yet — browser has not created one; import will initialize trust.
+  if [ -z "$(_ingress_ca_nss_db_paths)" ]; then
+    return 1
+  fi
+
+  return 0
+}
+
+_ingress_ca_fully_trusted() {
+  local path="$1"
+
+  _ingress_ca_in_trust_store "$path" || return 1
+  _ingress_ca_in_nss_store "$path" || return 1
+}
+
 _ingress_ca_export_env() {
   local ca_path="$1"
   export CURL_CA_BUNDLE="$ca_path"
@@ -122,6 +163,42 @@ _import_ingress_ca_linux() {
   return 1
 }
 
+_import_ingress_ca_nss() {
+  local path="$1"
+  local db imported=false
+
+  if ! command -v certutil &>/dev/null; then
+    echo "  Chrome/Firefox: install nss-tools for browser trust (sudo dnf install nss-tools)" >&2
+    return 1
+  fi
+
+  local dbs=()
+  while IFS= read -r db; do
+    [ -n "$db" ] && dbs+=("$db")
+  done < <(_ingress_ca_nss_db_paths)
+
+  if [ "${#dbs[@]}" -eq 0 ]; then
+    mkdir -p "${HOME}/.pki/nssdb"
+    dbs=("sql:${HOME}/.pki/nssdb")
+  fi
+
+  for db in "${dbs[@]}"; do
+    certutil -d "$db" -D -n "$_INGRESS_CA_NSS_NICKNAME" 2>/dev/null || true
+    if certutil -d "$db" -A -t "C,," -n "$_INGRESS_CA_NSS_NICKNAME" -i "$path" 2>/dev/null; then
+      imported=true
+    fi
+  done
+
+  if [ "$imported" = true ]; then
+    echo "  ✓ Ingress CA trusted (Chrome/Firefox NSS)"
+    echo "  Fully quit Chrome and reopen the AAP URL if it still shows untrusted"
+    return 0
+  fi
+
+  echo "  Could not import ingress CA to browser certificate store" >&2
+  return 1
+}
+
 _import_ingress_ca_macos() {
   local path="$1"
 
@@ -141,16 +218,19 @@ import_ingress_ca_certificate() {
   [ -f "$path" ] || return 1
   grep -q 'BEGIN CERTIFICATE' "$path" || return 1
 
-  if _ingress_ca_in_trust_store "$path"; then
+  if _ingress_ca_fully_trusted "$path"; then
     echo "  ✓ Ingress CA already trusted"
     return 0
   fi
 
+  local ok=true
   if [[ "$(uname)" == "Darwin" ]]; then
-    _import_ingress_ca_macos "$path"
+    _import_ingress_ca_macos "$path" || ok=false
   else
-    _import_ingress_ca_linux "$path"
+    _ingress_ca_in_trust_store "$path" || _import_ingress_ca_linux "$path" || ok=false
+    _ingress_ca_in_nss_store "$path" || _import_ingress_ca_nss "$path" || ok=false
   fi
+  [ "$ok" = true ]
 }
 
 install_ingress_ca_trust() {
@@ -162,7 +242,7 @@ install_ingress_ca_trust() {
   ca_path=$(get_ingress_ca_cert_path)
   mkdir -p "$(dirname "$ca_path")"
 
-  if [ -f "$ca_path" ] && _ingress_ca_in_trust_store "$ca_path"; then
+  if [ -f "$ca_path" ] && _ingress_ca_fully_trusted "$ca_path"; then
     _ingress_ca_export_env "$ca_path"
     return 0
   fi

--- a/includes/ingress-ca-trust.sh
+++ b/includes/ingress-ca-trust.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# =============================================================================
+# ingress-ca-trust.sh — Trust the MicroShift ingress CA on the local machine
+# =============================================================================
+#
+# Mirrors PowerShell Install-AapIngressCaTrust for bash/Linux/macOS.
+# Saves the CA to ~/.aap-demo/crc-ingress-ca.crt and exports CURL_CA_BUNDLE /
+# SSL_CERT_FILE for CLI tools.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/includes/ingress-ca-trust.sh"
+#   install_ingress_ca_trust
+#
+# Skip automatic import: AAP_DEMO_TRUST_CA=false
+#
+# =============================================================================
+
+if [ -n "${_INGRESS_CA_TRUST_LOADED:-}" ]; then return 0; fi
+_INGRESS_CA_TRUST_LOADED=1
+
+_INGRESS_CA_ANCHOR_NAME='crc-ingress-ca.crt'
+_INGRESS_CA_RHEL_ANCHOR="/etc/pki/ca-trust/source/anchors/${_INGRESS_CA_ANCHOR_NAME}"
+_INGRESS_CA_DEBIAN_ANCHOR="/usr/local/share/ca-certificates/${_INGRESS_CA_ANCHOR_NAME}"
+
+get_ingress_ca_cert_path() {
+  local ca_dir="${AAP_DEMO_CONFIG_DIR:-${HOME}/.aap-demo}"
+  echo "${ca_dir}/${_INGRESS_CA_ANCHOR_NAME}"
+}
+
+_ingress_ca_fingerprint() {
+  local path="$1"
+  openssl x509 -in "$path" -noout -fingerprint -sha256 2>/dev/null \
+    | sed -E 's/sha256 [Ff]ingerprint=//' | tr -d ':' | tr '[:lower:]' '[:upper:]'
+}
+
+_ingress_ca_trust_list_contains() {
+  local fingerprint="$1"
+  command -v trust &>/dev/null || return 1
+  trust list --filter=ca-anchors 2>/dev/null | tr -d ':' | grep -qi "$fingerprint"
+}
+
+_ingress_ca_installed_fingerprint_linux() {
+  if [ -f "$_INGRESS_CA_RHEL_ANCHOR" ]; then
+    _ingress_ca_fingerprint "$_INGRESS_CA_RHEL_ANCHOR"
+    return 0
+  fi
+  if [ -f "$_INGRESS_CA_DEBIAN_ANCHOR" ]; then
+    _ingress_ca_fingerprint "$_INGRESS_CA_DEBIAN_ANCHOR"
+    return 0
+  fi
+  return 1
+}
+
+_ingress_ca_installed_fingerprint_macos() {
+  security find-certificate -a -p -c "ingress-ca" /Library/Keychains/System.keychain 2>/dev/null \
+    | awk '/BEGIN CERTIFICATE/{p=1} p{print} /END CERTIFICATE/{exit}' \
+    | openssl x509 -noout -fingerprint -sha256 2>/dev/null \
+    | sed -E 's/sha256 [Ff]ingerprint=//' | tr -d ':' | tr '[:lower:]' '[:upper:]'
+}
+
+_ingress_ca_in_trust_store() {
+  local path="$1"
+  local fingerprint installed_fingerprint
+
+  [ -f "$path" ] || return 1
+  grep -q 'BEGIN CERTIFICATE' "$path" || return 1
+
+  fingerprint=$(_ingress_ca_fingerprint "$path")
+  [ -n "$fingerprint" ] || return 1
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    installed_fingerprint=$(_ingress_ca_installed_fingerprint_macos)
+  else
+    installed_fingerprint=$(_ingress_ca_installed_fingerprint_linux)
+    if [ -z "$installed_fingerprint" ] && _ingress_ca_trust_list_contains "$fingerprint"; then
+      return 0
+    fi
+  fi
+
+  [ -n "$installed_fingerprint" ] && [ "$fingerprint" = "$installed_fingerprint" ]
+}
+
+_ingress_ca_export_env() {
+  local ca_path="$1"
+  export CURL_CA_BUNDLE="$ca_path"
+  export SSL_CERT_FILE="$ca_path"
+}
+
+_fetch_ingress_ca_from_cluster() {
+  local dest="$1"
+  local crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  local crc_ssh_opts
+
+  [ -f "$crc_ssh_key" ] || return 1
+
+  crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+  ssh -p 2222 $crc_ssh_opts core@127.0.0.1 \
+    'sudo cat /var/lib/microshift/certs/ingress-ca/ca.crt' >"$dest" 2>/dev/null
+
+  [ -s "$dest" ] && grep -q 'BEGIN CERTIFICATE' "$dest"
+}
+
+_import_ingress_ca_linux() {
+  local path="$1"
+
+  if [ -d /etc/pki/ca-trust/source/anchors ]; then
+    if sudo cp "$path" "$_INGRESS_CA_RHEL_ANCHOR" 2>/dev/null \
+      && sudo update-ca-trust 2>/dev/null; then
+      echo "  ✓ Ingress CA trusted (system ca-trust)"
+      return 0
+    fi
+  elif [ -d /usr/local/share/ca-certificates ]; then
+    if sudo cp "$path" "$_INGRESS_CA_DEBIAN_ANCHOR" 2>/dev/null \
+      && sudo update-ca-certificates 2>/dev/null; then
+      echo "  ✓ Ingress CA trusted (system ca-certificates)"
+      return 0
+    fi
+  fi
+
+  echo "  Could not add CA to system trust store (sudo may be required)" >&2
+  echo "  Manual import: sudo cp ${path} ${_INGRESS_CA_RHEL_ANCHOR} && sudo update-ca-trust" >&2
+  return 1
+}
+
+_import_ingress_ca_macos() {
+  local path="$1"
+
+  while sudo security delete-certificate -c "ingress-ca" /Library/Keychains/System.keychain 2>/dev/null; do :; done
+  if sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$path" 2>/dev/null; then
+    echo "  ✓ Ingress CA trusted (macOS keychain)"
+    return 0
+  fi
+
+  echo "  Could not add CA to macOS keychain (may need admin password)" >&2
+  return 1
+}
+
+import_ingress_ca_certificate() {
+  local path="$1"
+
+  [ -f "$path" ] || return 1
+  grep -q 'BEGIN CERTIFICATE' "$path" || return 1
+
+  if _ingress_ca_in_trust_store "$path"; then
+    echo "  ✓ Ingress CA already trusted"
+    return 0
+  fi
+
+  if [[ "$(uname)" == "Darwin" ]]; then
+    _import_ingress_ca_macos "$path"
+  else
+    _import_ingress_ca_linux "$path"
+  fi
+}
+
+install_ingress_ca_trust() {
+  if [ "${AAP_DEMO_TRUST_CA:-true}" = "false" ]; then
+    return 0
+  fi
+
+  local ca_path
+  ca_path=$(get_ingress_ca_cert_path)
+  mkdir -p "$(dirname "$ca_path")"
+
+  if [ -f "$ca_path" ] && _ingress_ca_in_trust_store "$ca_path"; then
+    _ingress_ca_export_env "$ca_path"
+    return 0
+  fi
+
+  echo "Trusting ingress CA..."
+
+  local tmp
+  tmp=$(mktemp)
+  if _fetch_ingress_ca_from_cluster "$tmp"; then
+    mv "$tmp" "$ca_path"
+    chmod 644 "$ca_path"
+  else
+    rm -f "$tmp"
+    if [ ! -f "$ca_path" ] || ! grep -q 'BEGIN CERTIFICATE' "$ca_path"; then
+      echo "  Could not fetch ingress CA from cluster" >&2
+      return 0
+    fi
+  fi
+
+  import_ingress_ca_certificate "$ca_path" || true
+  _ingress_ca_export_env "$ca_path"
+  return 0
+}


### PR DESCRIPTION
## Summary

- Adds `includes/ingress-ca-trust.sh`, a shared bash helper that mirrors the Windows PowerShell `Install-AapIngressCaTrust` flow
- Saves the MicroShift ingress CA to `~/.aap-demo/crc-ingress-ca.crt` and exports `CURL_CA_BUNDLE` / `SSL_CERT_FILE`
- Imports into the system trust store on Fedora/RHEL (`update-ca-trust`) and Debian/Ubuntu (`update-ca-certificates`), with macOS keychain support retained
- Calls `install_ingress_ca_trust` from `create`, `deploy`, and `status` so SSL trust is refreshed after cluster recreate, not only at initial create
- Honors `AAP_DEMO_TRUST_CA=false` to skip automatic import

Fixes #30

## Test plan

- [ ] On Fedora, run `aap-demo status` with a running CRC cluster and confirm `✓ Ingress CA trusted (system ca-trust)`
- [ ] Verify `curl -I https://<aap-route>` succeeds without `-k`
- [ ] Recreate cluster and confirm `aap-demo status` re-imports the new CA
- [ ] Confirm `AAP_DEMO_TRUST_CA=false aap-demo status` skips import
- [ ] Confirm macOS create/status still trusts the ingress CA via keychain


Made with [Cursor](https://cursor.com)