### PR TITLE
fix: detect SSH key type for MicroShift compatibility

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -249,8 +249,15 @@ setup_kubeconfig() {
     fi
     # Test if kubeconfig works, refresh from VM if not
     if ! kubectl cluster-info &>/dev/null 2>&1; then
+      # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+      local _crc_ssh_key=""
       if [ -f "$HOME/.crc/machines/crc/id_ed25519" ]; then
-        if ssh -p 2222 -i "$HOME/.crc/machines/crc/id_ed25519" \
+        _crc_ssh_key="$HOME/.crc/machines/crc/id_ed25519"
+      elif [ -f "$HOME/.crc/machines/crc/id_ecdsa" ]; then
+        _crc_ssh_key="$HOME/.crc/machines/crc/id_ecdsa"
+      fi
+      if [ -n "$_crc_ssh_key" ]; then
+        if ssh -p 2222 -i "$_crc_ssh_key" \
           -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
           -o ConnectTimeout=2 -o BatchMode=yes \
           core@127.0.0.1 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' \
@@ -1429,8 +1436,17 @@ INVEOF
 }
 
 cmd_ssh() {
-  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
-  exec ssh -p 2222 -i "$CRC_SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@127.0.0.1
+  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+  local crc_ssh_key
+  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
+  else
+    _err "No CRC SSH key found. Is OpenShift Local running?"
+    return 1
+  fi
+  exec ssh -p 2222 -i "$crc_ssh_key" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@127.0.0.1
 }
 
 cmd_kubeconfig() {

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -249,15 +249,10 @@ setup_kubeconfig() {
     fi
     # Test if kubeconfig works, refresh from VM if not
     if ! kubectl cluster-info &>/dev/null 2>&1; then
-      # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-      local _crc_ssh_key=""
-      if [ -f "$HOME/.crc/machines/crc/id_ed25519" ]; then
-        _crc_ssh_key="$HOME/.crc/machines/crc/id_ed25519"
-      elif [ -f "$HOME/.crc/machines/crc/id_ecdsa" ]; then
-        _crc_ssh_key="$HOME/.crc/machines/crc/id_ecdsa"
-      fi
-      if [ -n "$_crc_ssh_key" ]; then
-        if ssh -p 2222 -i "$_crc_ssh_key" \
+      # Ensure infra backend is loaded to set CRC_SSH_KEY
+      _infra_ensure_backend 2>/dev/null || true
+      if [ -n "$CRC_SSH_KEY" ]; then
+        if ssh -p 2222 -i "$CRC_SSH_KEY" \
           -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
           -o ConnectTimeout=2 -o BatchMode=yes \
           core@127.0.0.1 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' \
@@ -1436,17 +1431,13 @@ INVEOF
 }
 
 cmd_ssh() {
-  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-  local crc_ssh_key
-  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
-  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
-  else
+  # Ensure infra backend is loaded to set CRC_SSH_KEY
+  _infra_ensure_backend 2>/dev/null || true
+  if [ -z "$CRC_SSH_KEY" ]; then
     _err "No CRC SSH key found. Is OpenShift Local running?"
     return 1
   fi
-  exec ssh -p 2222 -i "$crc_ssh_key" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@127.0.0.1
+  exec ssh -p 2222 -i "$CRC_SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@127.0.0.1
 }
 
 cmd_kubeconfig() {

--- a/addons/registry/deploy.sh
+++ b/addons/registry/deploy.sh
@@ -39,11 +39,17 @@ kubectl wait --for=condition=available deployment/registry -n aap-demo-registry 
 REGISTRY_SVC_IP=$(kubectl get svc registry -n aap-demo-registry -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
 
 if [ -n "$REGISTRY_SVC_IP" ]; then
-  # Detect SSH method for CRC
-  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
+    CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
+    CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ecdsa"
+  else
+    CRC_SSH_KEY=""
+  fi
   CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
-  if [ -f "$CRC_SSH_KEY" ]; then
+  if [ -n "$CRC_SSH_KEY" ]; then
     # Add registry mirror: route hostname -> ClusterIP (for CRI-O pulls)
     ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 "sudo tee /etc/containers/registries.conf.d/999-aap-demo-registry.conf > /dev/null <<REGEOF
 [[registry]]

--- a/addons/registry/deploy.sh
+++ b/addons/registry/deploy.sh
@@ -13,6 +13,10 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source CRC SSH helpers for registry mirror configuration
+# shellcheck source=../../includes/infra-crc.sh
+source "${SCRIPT_DIR}/../../includes/infra-crc.sh" 2>/dev/null || true
+
 ACTION="${1:-deploy}"
 
 if [ "$ACTION" = "--delete" ] || [ "$ACTION" = "delete" ]; then
@@ -39,16 +43,7 @@ kubectl wait --for=condition=available deployment/registry -n aap-demo-registry 
 REGISTRY_SVC_IP=$(kubectl get svc registry -n aap-demo-registry -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
 
 if [ -n "$REGISTRY_SVC_IP" ]; then
-  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
-    CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
-  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
-    CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ecdsa"
-  else
-    CRC_SSH_KEY=""
-  fi
-  CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-
+  # CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
   if [ -n "$CRC_SSH_KEY" ]; then
     # Add registry mirror: route hostname -> ClusterIP (for CRI-O pulls)
     ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 "sudo tee /etc/containers/registries.conf.d/999-aap-demo-registry.conf > /dev/null <<REGEOF

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -23,7 +23,14 @@ configure_coredns() {
   local current_preset route_domain current_domain escaped_domain current_corefile corefile
   local crc_ssh_key crc_ssh_opts
 
-  crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
+  else
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  fi
   crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
   current_preset="${CURRENT_PRESET:-}"
@@ -280,14 +287,21 @@ fi
 # ---------------------------------------------------------------------------
 # Configure nip.io baseDomain (MicroShift only)
 # ---------------------------------------------------------------------------
-CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+# Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
+  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
+  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ecdsa"
+else
+  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+fi
 CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 if [ "$CURRENT_PRESET" = "microshift" ]; then
   printf "${_GREEN}▸${_NC} Configuring nip.io baseDomain...\n"
 
   # Write config drop-in (overrides CRC's 00-microshift-dns.yaml)
-  ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 "sudo tee /etc/microshift/config.d/99-aap-demo-dns.yaml > /dev/null <<EOF
+  ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 "sudo mkdir -p /etc/microshift/config.d && sudo tee /etc/microshift/config.d/99-aap-demo-dns.yaml > /dev/null <<EOF
 dns:
   baseDomain: 127.0.0.1.nip.io
 EOF" 2>/dev/null

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -21,17 +21,13 @@ _NC='\033[0m'
 
 configure_coredns() {
   local current_preset route_domain current_domain escaped_domain current_corefile corefile
-  local crc_ssh_key crc_ssh_opts
-
-  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
-  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
-  else
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  # Use centralized SSH key detection from infra-crc.sh
+  # CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
+  if [ -z "$CRC_SSH_KEY" ]; then
+    echo "ERROR: No CRC SSH key found. Cannot configure CoreDNS." >&2
+    return 1
   fi
-  crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+  local crc_ssh_opts="$CRC_SSH_OPTS"
 
   current_preset="${CURRENT_PRESET:-}"
   if [ -z "$current_preset" ]; then
@@ -287,15 +283,11 @@ fi
 # ---------------------------------------------------------------------------
 # Configure nip.io baseDomain (MicroShift only)
 # ---------------------------------------------------------------------------
-# Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
-  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
-elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
-  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ecdsa"
-else
-  CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+# CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
+if [ -z "$CRC_SSH_KEY" ]; then
+  echo "ERROR: No CRC SSH key found. Cannot configure nip.io baseDomain." >&2
+  exit 1
 fi
-CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 if [ "$CURRENT_PRESET" = "microshift" ]; then
   printf "${_GREEN}▸${_NC} Configuring nip.io baseDomain...\n"

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -25,13 +25,15 @@ _NC='\033[0m'
 
 configure_coredns() {
   local current_preset route_domain current_domain escaped_domain current_corefile corefile
-  # Use centralized SSH key detection from infra-crc.sh
-  # CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
-  if [ -z "$CRC_SSH_KEY" ]; then
+  local crc_ssh_key crc_ssh_opts
+
+  # Re-detect SSH key now that cluster is running
+  if crc_ssh_key="$(_detect_crc_ssh_key 2>/dev/null)"; then
+    crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+  else
     echo "ERROR: No CRC SSH key found. Cannot configure CoreDNS." >&2
     return 1
   fi
-  local crc_ssh_opts="$CRC_SSH_OPTS"
 
   current_preset="${CURRENT_PRESET:-}"
   if [ -z "$current_preset" ]; then
@@ -287,8 +289,10 @@ fi
 # ---------------------------------------------------------------------------
 # Configure nip.io baseDomain (MicroShift only)
 # ---------------------------------------------------------------------------
-# CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
-if [ -z "$CRC_SSH_KEY" ]; then
+# Re-detect SSH key now that cluster is running (sourcing infra-crc.sh happened before crc start)
+if CRC_SSH_KEY="$(_detect_crc_ssh_key 2>/dev/null)"; then
+  CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+else
   echo "ERROR: No CRC SSH key found. Cannot configure nip.io baseDomain." >&2
   exit 1
 fi

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -12,6 +12,10 @@ set -eo pipefail
 
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
+# Source CRC infra backend (sets CRC_SSH_KEY, CRC_SSH_OPTS)
+# shellcheck source=includes/infra-crc.sh
+source "${SCRIPT_DIR}/includes/infra-crc.sh"
+
 # Colors
 _RED='\033[0;31m'
 _GREEN='\033[0;32m'

--- a/includes/infra-crc.sh
+++ b/includes/infra-crc.sh
@@ -27,14 +27,23 @@ _detect_crc_ssh_key() {
   fi
 }
 
-CRC_SSH_KEY="$(_detect_crc_ssh_key 2>/dev/null || echo "${HOME}/.crc/machines/crc/id_ed25519")"
-CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+# Initialize SSH key — callers should check CRC_SSH_KEY before use
+if CRC_SSH_KEY="$(_detect_crc_ssh_key 2>/dev/null)"; then
+  CRC_SSH_OPTS="-i \"${CRC_SSH_KEY}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+else
+  CRC_SSH_KEY=""
+  CRC_SSH_OPTS=""
+fi
 
 # ---------------------------------------------------------------------------
 # SSH helpers
 # ---------------------------------------------------------------------------
 
 _crc_exec() {
+  if [ -z "$CRC_SSH_KEY" ]; then
+    echo "ERROR: No CRC SSH key found" >&2
+    return 1
+  fi
   ssh -p "$CRC_SSH_PORT" $CRC_SSH_OPTS core@127.0.0.1 "$@"
 }
 

--- a/includes/infra-crc.sh
+++ b/includes/infra-crc.sh
@@ -12,9 +12,22 @@
 if [ -n "$_INFRA_CRC_LOADED" ]; then return 0; fi
 _INFRA_CRC_LOADED=1
 
-# CRC SSH key and port
-CRC_SSH_KEY="${HOME}/.crc/machines/crc/id_ed25519"
+# CRC SSH port
 CRC_SSH_PORT=2222
+
+# Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+_detect_crc_ssh_key() {
+  local base="${HOME}/.crc/machines/crc"
+  if [ -f "${base}/id_ed25519" ]; then
+    echo "${base}/id_ed25519"
+  elif [ -f "${base}/id_ecdsa" ]; then
+    echo "${base}/id_ecdsa"
+  else
+    return 1
+  fi
+}
+
+CRC_SSH_KEY="$(_detect_crc_ssh_key 2>/dev/null || echo "${HOME}/.crc/machines/crc/id_ed25519")"
 CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 # ---------------------------------------------------------------------------

--- a/includes/ingress-ca-trust.sh
+++ b/includes/ingress-ca-trust.sh
@@ -129,10 +129,16 @@ _ingress_ca_export_env() {
 
 _fetch_ingress_ca_from_cluster() {
   local dest="$1"
-  local crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
-  local crc_ssh_opts
+  local crc_ssh_key crc_ssh_opts
 
-  [ -f "$crc_ssh_key" ] || return 1
+  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
+  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
+  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
+    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
+  else
+    return 1
+  fi
 
   crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
   ssh -p 2222 $crc_ssh_opts core@127.0.0.1 \

--- a/includes/ingress-ca-trust.sh
+++ b/includes/ingress-ca-trust.sh
@@ -129,19 +129,13 @@ _ingress_ca_export_env() {
 
 _fetch_ingress_ca_from_cluster() {
   local dest="$1"
-  local crc_ssh_key crc_ssh_opts
 
-  # Detect SSH key — CRC creates id_ed25519 (OpenShift) or id_ecdsa (MicroShift)
-  if [ -f "${HOME}/.crc/machines/crc/id_ed25519" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ed25519"
-  elif [ -f "${HOME}/.crc/machines/crc/id_ecdsa" ]; then
-    crc_ssh_key="${HOME}/.crc/machines/crc/id_ecdsa"
-  else
+  # CRC_SSH_KEY and CRC_SSH_OPTS are set when infra-crc.sh is sourced
+  if [ -z "$CRC_SSH_KEY" ]; then
     return 1
   fi
 
-  crc_ssh_opts="-i ${crc_ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-  ssh -p 2222 $crc_ssh_opts core@127.0.0.1 \
+  ssh -p 2222 $CRC_SSH_OPTS core@127.0.0.1 \
     'sudo cat /var/lib/microshift/certs/ingress-ca/ca.crt' >"$dest" 2>/dev/null
 
   [ -s "$dest" ] && grep -q 'BEGIN CERTIFICATE' "$dest"


### PR DESCRIPTION
## Summary

- CRC creates `id_ed25519` for OpenShift preset but `id_ecdsa` for MicroShift preset
- Hardcoded `id_ed25519` path caused SSH commands to fail with password prompts on MicroShift
- Now detects which key exists at runtime with fallback chain

## Changes

- `includes/infra-crc.sh`: Added `_detect_crc_ssh_key()` helper function
- `aap-demo.sh`: Fixed `cmd_ssh()` and kubeconfig refresh to detect key
- `includes/crc-create.sh`: Fixed `configure_coredns()` key detection
- `includes/ingress-ca-trust.sh`: Fixed `_fetch_ingress_ca_from_cluster()` key detection

## Test plan

- [ ] `aap-demo ssh` works on MicroShift preset (id_ecdsa)
- [ ] `aap-demo ssh` works on OpenShift preset (id_ed25519)
- [ ] `aap-demo create` completes on MicroShift
- [ ] `aap-demo deploy` completes on MicroShift

Fixes #39

🤖 Generated with [Claude Code](https://claude.ai/code)