### PR TITLE
fix: remove CA keychain import from status command

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -1595,7 +1595,12 @@ cmd_status() {
     return 0
   fi
 
-  install_ingress_ca_trust
+  # Export CA env vars if installed, don't prompt for sudo
+  local ca_path
+  ca_path=$(get_ingress_ca_cert_path)
+  if [ -f "$ca_path" ]; then
+    _ingress_ca_export_env "$ca_path"
+  fi
 
   # Show kubeconfig
   echo "Kubeconfig:  $KUBECONFIG"


### PR DESCRIPTION
## Summary
- `aap-demo status` was calling `install_ingress_ca_trust` on every run, which imports the ingress CA into the system trust store (macOS keychain / Linux ca-trust / NSS)
- Replaced with `_ingress_ca_export_env` which only sets `CURL_CA_BUNDLE` and `SSL_CERT_FILE` env vars — enough for TLS within the status function without modifying system state
- CA import remains in `cmd_deploy` where it belongs

Fixes #43

## Test plan
- [ ] Run `aap-demo status` — verify no sudo/keychain prompt appears
- [ ] Run `aap-demo deploy` — verify CA is still imported to trust store
- [ ] Run `aap-demo status` on a cluster with CA already trusted — verify routes/credentials display correctly

Signed off by @chadmf 
🤖 Generated with [Claude Code](https://claude.com/claude-code)