### PR TITLE
feat(powershell): native portal addon and Windows CLI hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,9 @@ aap-demo help                # Full command reference
 
 - **Networking:** SSH (2222), API (6443), HTTP/HTTPS (443) — all on localhost
 - **Routes:** `*.apps.127.0.0.1.nip.io` (nip.io DNS, no /etc/hosts needed)
-- **TLS:** MicroShift's ingress CA auto-trusted on macOS keychain / Linux ca-trust/
-  Windows via certutil
+- **TLS:** MicroShift's ingress CA auto-trusted on macOS keychain / Linux ca-trust;
+  on Windows, run `aap-demo deploy` from an elevated PowerShell (see
+  [powershell/README.md](powershell/README.md#ingress-ca-and-browser-tls))
 
 ## Environment Variables
 

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -1731,30 +1731,48 @@ cmd_status() {
     [ "$_cred_found" = "true" ] && echo ""
   fi
 
-  # Show enabled addons with URLs
+  # Show addons with URLs or enable instructions
   local saved_addons
   saved_addons=$(_addons_list)
-  if [ -n "$saved_addons" ]; then
-    echo "Enabled Addons:"
-    echo "---------------"
-    for a in $saved_addons; do
-      local url=""
-      case "$a" in
-        console) url="https://console.apps.127.0.0.1.nip.io" ;;
-        registry) url="https://registry.apps.127.0.0.1.nip.io" ;;
-        mcp-server) url="https://aap-mcp-${NAMESPACE:-aap-operator}.apps.127.0.0.1.nip.io/mcp" ;;
-        portal) url="https://$(kubectl get route redhat-rhaap-portal -n redhat-rhaap-portal -o jsonpath='{.spec.host}' 2>/dev/null || kubectl get route redhat-rhaap-portal -n ${NAMESPACE:-aap-operator} -o jsonpath='{.spec.host}' 2>/dev/null || echo 'not-deployed')" ;;
-        registry-ui) url="https://registry-ui.apps.127.0.0.1.nip.io" ;;
-        prometheus) url="https://prometheus.apps.127.0.0.1.nip.io" ;;
-      esac
-      if [ -n "$url" ]; then
-        printf "  %-15s %s\n" "$a" "$url"
-      else
-        printf "  %s\n" "$a"
-      fi
-    done
-    echo ""
-  fi
+  echo "Addons:"
+  echo "-------"
+  for a in $AVAILABLE_ADDONS; do
+    local url="" label="" enabled=false
+    if echo "$saved_addons" | grep -qw "$a"; then
+      enabled=true
+    fi
+    case "$a" in
+      mcp-server)
+        if [ "$enabled" = true ]; then
+          url="https://aap-mcp-${NAMESPACE:-aap-operator}.apps.127.0.0.1.nip.io/mcp"
+          if ! kubectl get ansiblemcpserver aap-mcp-server -n "${NAMESPACE:-aap-operator}" &>/dev/null; then
+            label="not-deployed"
+          fi
+        else
+          label="disabled"
+        fi
+        ;;
+      portal)
+        if [ "$enabled" = true ]; then
+          url="https://$(kubectl get route redhat-rhaap-portal -n redhat-rhaap-portal -o jsonpath='{.spec.host}' 2>/dev/null || kubectl get route redhat-rhaap-portal -n ${NAMESPACE:-aap-operator} -o jsonpath='{.spec.host}' 2>/dev/null || true)"
+          if [ -z "$url" ] || [ "$url" = "https://" ]; then
+            url=""
+            label="not-deployed"
+          fi
+        else
+          label="disabled"
+        fi
+        ;;
+    esac
+    if [ -n "$url" ] && [ -z "$label" ]; then
+      printf "  %-15s %s\n" "$a" "$url"
+    elif [ -n "$label" ]; then
+      printf "  %-15s %s  (aap-demo enable %s)\n" "$a" "$label" "$a"
+    else
+      printf "  %-15s (aap-demo enable %s)\n" "$a" "$a"
+    fi
+  done
+  echo ""
 }
 
 cmd_redeploy() {

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -676,6 +676,39 @@ cmd_config() {
   mkdir -p "$(dirname "$AAP_DEMO_CONFIG")"
 }
 
+cmd_update() {
+  echo ""
+  printf "\033[1maap-demo update\033[0m - Pulling latest code and reinstalling...\n"
+  echo ""
+
+  local repo_root="$SCRIPT_DIR"
+  if [ ! -f "${repo_root}/aap-demo.sh" ]; then
+    _err "aap-demo repo not found at ${repo_root}"
+    echo "  Run from the repo directory or reinstall with ./install.sh"
+    return 1
+  fi
+
+  if ! git -C "$repo_root" rev-parse --is-inside-work-tree &>/dev/null; then
+    _err "Not a git repository: ${repo_root}"
+    return 1
+  fi
+
+  echo "  Pulling latest code..."
+  if ! git -C "$repo_root" pull; then
+    _err "git pull failed"
+    return 1
+  fi
+
+  echo "  Reinstalling launcher..."
+  if ! bash "${repo_root}/install.sh"; then
+    _err "install.sh failed"
+    return 1
+  fi
+
+  echo ""
+  echo "  ✓ Update complete"
+}
+
 cmd_redhat_status() {
   echo ""
   printf "\033[1maap-demo redhat-status\033[0m - Checking Red Hat service status...\n"
@@ -1204,9 +1237,11 @@ cmd_test() {
   # Find all namespaces with AAP deployments
   local aap_namespaces=()
   # Operator deploys: namespaces with AAP CRDs
-  local ns_list
-  ns_list=$(kubectl get aap --all-namespaces --no-headers 2>/dev/null | awk '{print $1}' || true)
-  # Sort alphabetically by namespace name
+  local ns_list ns
+  ns_list=$(kubectl get aap --all-namespaces --no-headers 2>/dev/null | awk '{print $1}' | sort -u || true)
+  while IFS= read -r ns; do
+    [ -n "$ns" ] && aap_namespaces+=("$ns")
+  done <<<"$ns_list"
 
   if [ ${#aap_namespaces[@]} -eq 0 ]; then
     _err "No AAP deployments found on cluster"

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -56,15 +56,15 @@ aap-demo help
 ```powershell
 aap-demo create        # Create OpenShift Local cluster (~10–20 min first time)
 aap-demo deploy        # Deploy AAP 2.7 (~5–15 min)
-aap-demo status        # Routes, credentials, pod counts; trusts ingress CA if needed
+aap-demo status        # Routes, credentials, pod counts
 ```
 
 On first `create`, you are prompted to choose a CRC preset (MicroShift is
 recommended). The choice is saved to `%USERPROFILE%\.aap-demo\config`.
 
-After deploy, open the AAP route from `aap-demo status`. If your browser still
-shows a certificate warning, run `aap-demo status` again and accept the UAC
-prompt — see [Ingress CA and browser TLS](#ingress-ca-and-browser-tls) below.
+After deploy, open the AAP route from `aap-demo status`. If your browser shows a
+certificate warning, trust the ingress CA from an elevated PowerShell — see
+[Ingress CA and browser TLS](#ingress-ca-and-browser-tls) below.
 
 ## Commands
 
@@ -192,33 +192,33 @@ MicroShift routes (for example `https://aap-aap-operator.apps.127.0.0.1.nip.io`)
 use a cluster-local CA. Browsers and CLI tools will warn or fail until that CA
 is trusted on Windows.
 
-#### Automatic trust
+#### To trust the CA for Chrome/Edge
 
-`create`, `deploy`, and `status` call **Install-AapIngressCaTrust** automatically:
+1. Right-click PowerShell → **Run as administrator**
+2. Run `aap-demo deploy`
 
-1. Fetch the ingress CA from the CRC VM:
-  `/var/lib/microshift/certs/ingress-ca/ca.crt`
-2. Save a copy to `%USERPROFILE%\.aap-demo\crc-ingress-ca.crt`
-3. Import into **Current User → Trusted Root Certification Authorities**
-4. Import into **Local Machine → Trusted Root Certification Authorities**
-  (requires Administrator / UAC — needed for Chrome and Edge)
+`deploy` fetches the ingress CA from the CRC VM, saves a copy to
+`%USERPROFILE%\.aap-demo\crc-ingress-ca.crt`, and imports it into **Local
+Machine → Trusted Root Certification Authorities** (required for Chrome and
+Edge). When the CA is already trusted, `deploy` stays silent.
 
-When the CA is already trusted, these commands stay silent. Failures are
-warnings only; `status` never aborts because of certificate import.
+If you are not running as Administrator, `deploy` warns and skips the system
+store import. `status` does not import certificates — it only uses a previously
+saved CA for `CURL_CA_BUNDLE` / `SSL_CERT_FILE` when one exists.
 
 Skip automatic import:
 
 ```powershell
 $env:AAP_DEMO_TRUST_CA = 'false'
-aap-demo status
+aap-demo deploy
 ```
 
 #### Chrome or Edge still shows a red certificate banner
 
-1. Run `aap-demo status` and **accept the UAC prompt** when it appears.
-  You should see: `Ingress CA trusted (Windows system certificate store)`.
+1. Confirm you ran `aap-demo deploy` from an **elevated** PowerShell. You should
+   see: `Ingress CA trusted (Windows system certificate store)`.
 2. **Fully quit** the browser (taskbar icon → Exit, or close every window).
-  Reloading a tab is not enough — the trust store is read at startup.
+   Reloading a tab is not enough — the trust store is read at startup.
 3. Open the AAP URL from `aap-demo status` again.
 
 If you opened the route **before** the CA was trusted, clear cached security
@@ -246,26 +246,25 @@ Use `--ssl-no-revoke` for local CRC routes:
 curl.exe --ssl-no-revoke -I https://aap-aap-operator.apps.127.0.0.1.nip.io
 ```
 
-During `create` / `deploy` / `status`, the saved CA path is also exported as
-`CURL_CA_BUNDLE` and `SSL_CERT_FILE` for tools that read those variables.
+During `deploy`, the saved CA path is also exported as `CURL_CA_BUNDLE` and
+`SSL_CERT_FILE` for tools that read those variables.
 
 #### Manual import
 
-If UAC is blocked (corporate policy) or auto-trust fails:
+If automatic trust fails (for example corporate policy blocks store writes):
 
 ```powershell
-certutil -user -addstore Root "$env:USERPROFILE\.aap-demo\crc-ingress-ca.crt"
-# Chrome/Edge also need the system store (elevated PowerShell):
 certutil -addstore Root "$env:USERPROFILE\.aap-demo\crc-ingress-ca.crt"
 ```
 
-Or import via **certmgr.msc** → Trusted Root Certification Authorities.
+Run that from an elevated PowerShell. Or import via **certmgr.msc** → Trusted
+Root Certification Authorities.
 
 #### After cluster recreate
 
 Destroying and recreating the cluster issues a new ingress CA. Run
-`aap-demo status` (or `create` / `deploy`) again to replace the saved cert and
-refresh both certificate stores.
+`aap-demo deploy` from an elevated PowerShell again to replace the saved cert and
+refresh the system certificate store.
 
 ### PowerShell vs PowerShell 7
 

--- a/powershell/aap-demo.ps1
+++ b/powershell/aap-demo.ps1
@@ -10,7 +10,7 @@
 
 .DESCRIPTION
 
-  All commands run natively in PowerShell. Only diagnose --ai delegates to Git Bash.
+  All commands run natively in PowerShell.
 
 #>
 

--- a/powershell/install.ps1
+++ b/powershell/install.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
   Checks prerequisites, records repo location, installs aap-demo to
   %USERPROFILE%\.local\bin, adds that directory to the user PATH, and
-  installs optional dependencies (oc, Git for Windows) via winget when missing.
+  installs optional dependencies (oc) via winget when missing.
 
 .EXAMPLE
   .\powershell\install.ps1
@@ -38,15 +38,6 @@ function Write-Err([string]$Message) { Write-Host "  ERROR $Message" -Foreground
 function Test-CommandExists {
   param([string]$Name)
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
-}
-
-function Find-GitBash {
-  $paths = @(
-    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
-    (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
-    (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
-  ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
-  return $paths | Select-Object -First 1
 }
 
 function Install-Oc {
@@ -86,46 +77,6 @@ function Install-Oc {
     Write-Ok 'oc installed via winget'
   } else {
     Write-Warn 'OpenShift Client installed but oc is not on PATH yet — open a new PowerShell window'
-  }
-}
-
-function Install-GitBash {
-  if (Find-GitBash) {
-    Write-Ok 'Git Bash already installed'
-    return
-  }
-
-  if (-not (Test-CommandExists 'winget')) {
-    Write-Warn 'Git Bash not found and winget is unavailable'
-    return
-  }
-
-  Write-Info 'Installing Git for Windows via winget (Git.Git)...'
-  $wingetArgs = @(
-    'install', '--id', 'Git.Git', '-e', '--source', 'winget',
-    '--accept-package-agreements', '--accept-source-agreements'
-  )
-  if ($Quiet) { $wingetArgs += '--disable-interactivity' }
-
-  try {
-    & winget @wingetArgs
-    if ($LASTEXITCODE -ne 0) {
-      Write-Warn "winget install Git.Git failed (exit $LASTEXITCODE)"
-      return
-    }
-  } catch {
-    Write-Warn "Could not install Git for Windows via winget: $($_.Exception.Message)"
-    return
-  }
-
-  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
-  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-  $env:Path = @($machinePath, $userPath) -join ';'
-
-  if (Find-GitBash) {
-    Write-Ok 'Git Bash installed via winget'
-  } else {
-    Write-Warn 'Git for Windows installed but bash.exe not found yet — open a new PowerShell window'
   }
 }
 
@@ -169,10 +120,6 @@ function Remove-UserPathEntry {
 function Test-Prerequisites {
   $missing = [System.Collections.Generic.List[string]]::new()
   $warnings = [System.Collections.Generic.List[string]]::new()
-
-  if (-not (Find-GitBash)) {
-    $warnings.Add('Git for Windows — needed for diagnose --ai only')
-  }
 
   foreach ($tool in @('crc', 'oc')) {
     if (-not (Test-CommandExists $tool)) {
@@ -225,7 +172,6 @@ function Install-AapDemo {
   }
 
   Install-Oc
-  Install-GitBash
 
   $checks = Test-Prerequisites
   if ($checks.Missing.Count -gt 0) {
@@ -238,12 +184,6 @@ function Install-AapDemo {
   }
 
   Write-Ok 'Required tools: crc, oc'
-
-  if (Find-GitBash) {
-    Write-Ok 'Git Bash available (diagnose --ai only)'
-  } else {
-    Write-Warn 'Git Bash not found — all commands work except diagnose --ai'
-  }
 
   if ($checks.Warnings.Count -gt 0 -and -not $Quiet) {
     Write-Warn 'Optional tools not found (deploy may still work):'
@@ -288,7 +228,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "%USERPROFILE%\.local\bin\aa
   Write-Info '  aap-demo deploy'
   Write-Host ''
   Write-Info 'Notes:'
-  Write-Info '- All commands run in PowerShell; only diagnose --ai uses Git Bash.'
+  Write-Info '- All commands run in PowerShell.'
   Write-Info '- OpenShift Local on Windows needs Hyper-V enabled.'
   Write-Info '- Kubeconfig default: %USERPROFILE%\.crc\machines\crc\kubeconfig'
   Write-Host ''

--- a/powershell/native/AapDemo.psm1
+++ b/powershell/native/AapDemo.psm1
@@ -16,6 +16,8 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 
 . (Join-Path $PrivateDir 'Watch.ps1')
 
+. (Join-Path $PrivateDir 'Portal.ps1')
+
 . (Join-Path $PrivateDir 'Addons.ps1')
 
 . (Join-Path $PrivateDir 'Commands.ps1')
@@ -69,8 +71,6 @@ Export-ModuleMember -Function @(
   'Invoke-AapDemoRedeployAll'
 
   'Get-AapDemoHelp'
-
-  'Invoke-AapBashCli'
 
 )
 

--- a/powershell/native/Private/Addons.ps1
+++ b/powershell/native/Private/Addons.ps1
@@ -1,19 +1,8 @@
-$Script:AapAvailableAddons = @('mcp-server')
+$Script:AapAvailableAddons = @('mcp-server', 'portal')
 
 function Invoke-AapEnsureClusterReady {
-  $crc = Get-AapCrcStatus
-  if ([string]$crc.crcStatus -eq 'Stopped') {
-    Write-AapStep 'Cluster stopped - starting CRC...'
-    & crc start
-    if ($LASTEXITCODE -ne 0) { throw 'crc start failed' }
-  } elseif ([string]$crc.crcStatus -eq 'Unknown') {
-    throw 'No cluster found. Run: aap-demo create'
-  }
-
-  Initialize-AapKubeEnvironment
-  if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
-    throw 'Cluster is not accessible'
-  }
+  Invoke-AapEnsureCluster
+  Install-AapIngressCaTrust
 }
 
 function Invoke-AapDeployMcpServerAddon {
@@ -88,7 +77,47 @@ function Invoke-AapAddonEnable {
 
   switch ($Addon) {
     'mcp-server' { Invoke-AapDeployMcpServerAddon -Namespace $Namespace }
+    'portal' { Invoke-AapDeployPortalAddon -Namespace $Namespace }
     default { throw "Unknown addon: $Addon`nAvailable: $($Script:AapAvailableAddons -join ', ')" }
+  }
+}
+
+function Get-AapMcpServerRouteHost {
+  param([string]$Namespace = $Script:AapDemoDefaultNamespace)
+
+  $result = Invoke-AapOcCapture @(
+    'get', 'ansiblemcpserver', 'aap-mcp-server', '-n', $Namespace,
+    '-o', 'jsonpath={.spec.route_host}'
+  )
+  if ($result.ExitCode -ne 0) { return $null }
+  $routeHost = $result.Output.Trim()
+  if ($routeHost -and $routeHost -notmatch '\s' -and $routeHost -notmatch ':') {
+    return $routeHost
+  }
+  return $null
+}
+
+function Get-AapAddonStatusLabel {
+  param(
+    [Parameter(Mandatory)][string]$Addon,
+    [string]$Namespace = $Script:AapDemoDefaultNamespace,
+    [Parameter(Mandatory)][bool]$Enabled
+  )
+
+  if (-not $Enabled) { return 'disabled' }
+
+  switch ($Addon) {
+    'mcp-server' {
+      $mcpHost = Get-AapMcpServerRouteHost -Namespace $Namespace
+      if ($mcpHost) { return "https://$mcpHost/mcp" }
+      return 'not-deployed'
+    }
+    'portal' {
+      $portalHost = Get-AapPortalRouteHost -AapNamespace $Namespace
+      if ($portalHost) { return "https://$portalHost" }
+      return 'not-deployed'
+    }
+    default { return $null }
   }
 }
 
@@ -100,6 +129,7 @@ function Invoke-AapAddonDisable {
 
   switch ($Addon) {
     'mcp-server' { Invoke-AapRemoveMcpServerAddon -Namespace $Namespace }
+    'portal' { Invoke-AapRemovePortalAddon -Namespace $Namespace }
     default { throw "Unknown addon: $Addon" }
   }
 }

--- a/powershell/native/Private/Addons.ps1
+++ b/powershell/native/Private/Addons.ps1
@@ -2,7 +2,7 @@ $Script:AapAvailableAddons = @('mcp-server', 'portal')
 
 function Invoke-AapEnsureClusterReady {
   Invoke-AapEnsureCluster
-  Install-AapIngressCaTrust
+  Set-AapIngressCaEnvFromSaved
 }
 
 function Invoke-AapDeployMcpServerAddon {

--- a/powershell/native/Private/Addons.ps1
+++ b/powershell/native/Private/Addons.ps1
@@ -97,6 +97,11 @@ function Get-AapMcpServerRouteHost {
   return $null
 }
 
+function Get-AapAddonEnableCommand {
+  param([Parameter(Mandatory)][string]$Addon)
+  return "aap-demo enable $Addon"
+}
+
 function Get-AapAddonStatusLabel {
   param(
     [Parameter(Mandatory)][string]$Addon,

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -87,9 +87,10 @@ function Write-AapClusterSummary {
 function Invoke-AapDemoStop {
   Write-Host ''
   Write-Host 'aap-demo stop - Stopping CRC cluster...' -ForegroundColor Cyan
-  & crc stop
-  Write-AapStep 'CRC cluster stopped'
-  Write-Host 'To restart: crc start'
+  if (-not (Invoke-AapCrcStop)) {
+    throw 'crc stop failed'
+  }
+  Write-Host 'To restart: aap-demo deploy'
 }
 
 function Invoke-AapDemoDestroy {
@@ -108,27 +109,21 @@ function Invoke-AapDemoDestroy {
   Write-Host ''
   Wait-AapUserContinue
 
-  $deleted = $false
-  & crc delete -f 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    $deleted = $true
-  } else {
-    & crc delete
-    if ($LASTEXITCODE -eq 0) { $deleted = $true }
-  }
-
-  if ($deleted) {
-    & podman system connection remove aap-demo 2>$null
+  if (Invoke-AapCrcDelete -Force) {
     Write-AapStep 'CRC cluster deleted'
     if ($Reset) {
       $configPath = Get-AapConfigPath
       if (Test-Path -LiteralPath $configPath) {
         Remove-Item -LiteralPath $configPath -Force
       }
-      Write-AapStep "Config reset - next 'aap-demo create' will re-prompt for preset"
+      Write-AapStep "Config reset - next deploy will re-prompt for preset"
     }
   } else {
     Write-AapErr 'CRC delete failed - config preserved'
+    Write-Host ''
+    Write-Host 'Try manually:'
+    Write-Host '  crc stop'
+    Write-Host '  crc delete -f'
     exit 1
   }
 }
@@ -614,7 +609,7 @@ function Write-AapClusterSummary {
 
   $crc = Get-AapCrcStatus
   if ([string]$crc.crcStatus -eq 'Stopped') {
-    & crc start | Out-Null
+    Invoke-AapCrcStart
   } elseif ([string]$crc.crcStatus -eq 'Unknown') {
     throw 'No cluster found. Run: aap-demo create'
   }

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -198,7 +198,17 @@ function Invoke-AapDemoClean {
 }
 
 function Invoke-AapDemoRepair {
-  Write-Host 'CRC repair: run crc stop; then crc start'
+  Write-Host ''
+  Write-Host 'aap-demo repair - Refreshing cluster access and TLS trust...' -ForegroundColor Cyan
+  Write-Host ''
+  Sync-AapKubeconfig -Quiet
+  Install-AapIngressCaTrust
+  Write-Host ''
+  Write-Host 'If Chrome/Edge still shows a certificate warning:'
+  Write-Host '  1. Run this command from an elevated PowerShell'
+  Write-Host '  2. Fully quit the browser (all windows), then reopen the AAP URL'
+  Write-Host '  3. Clear HSTS for 127.0.0.1.nip.io at chrome://net-internals/#hsts'
+  Write-Host ''
 }
 
 function Invoke-AapDemoSetup {
@@ -220,143 +230,11 @@ function Invoke-AapDemoKubeconfig {
   Write-Host 'aap-demo kubeconfig - Syncing local aap-demo kubeconfig...' -ForegroundColor Cyan
   Write-Host ''
 
-  $crc = Get-AapCrcStatus
-  if ([string]$crc.crcStatus -ne 'Running') {
-    throw 'Cluster not running. Run: aap-demo create'
-  }
+  Sync-AapKubeconfig
 
-  $crcKube = Join-Path $env:USERPROFILE '.crc\machines\crc\kubeconfig'
-  if (-not (Test-Path -LiteralPath $crcKube)) {
-    throw 'CRC kubeconfig not found. OpenShift Local may still be initializing.'
-  }
-
-  $ctxName = 'aap-demo'
-  $tempKube = [System.IO.Path]::GetTempFileName()
-  Copy-Item -LiteralPath $crcKube -Destination $tempKube -Force
-
-  try {
-    $config = Get-AapOcConfigJson -KubeConfig $tempKube
-    $contextNames = @($config.contexts | ForEach-Object { [string]$_.name })
-    $sourceCtx = if ($contextNames -contains 'microshift') {
-      'microshift'
-    } elseif ($contextNames -contains $ctxName) {
-      $ctxName
-    } elseif ($contextNames.Count -eq 1) {
-      $contextNames[0]
-    } else {
-      [string]$config.'current-context'
-    }
-
-    if ($sourceCtx -and $sourceCtx -ne $ctxName) {
-      $rename = Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-        'config', 'rename-context', $sourceCtx, $ctxName
-      )
-      if ($rename.ExitCode -ne 0) {
-        throw "Failed to rename context $sourceCtx to $ctxName"
-      }
-      $config = Get-AapOcConfigJson -KubeConfig $tempKube
-    }
-
-    $ctx = $config.contexts | Where-Object { $_.name -eq $ctxName } | Select-Object -First 1
-    $sourceCluster = if ($ctx) { [string]$ctx.context.cluster } else { 'microshift' }
-    $cluster = $config.clusters | Where-Object { $_.name -eq $sourceCluster } | Select-Object -First 1
-    $server = if ($cluster) { [string]$cluster.cluster.server } else { 'https://localhost:6443' }
-
-    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-      'config', 'set-cluster', $ctxName, "--server=$server", '--insecure-skip-tls-verify=true'
-    ) | Out-Null
-    if ($sourceCluster -ne $ctxName) {
-      Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-        'config', 'unset', "clusters.$sourceCluster"
-      ) | Out-Null
-    }
-
-    $sourceUser = $config.users | Where-Object {
-      $null -ne $_.user -and $_.user.'client-certificate-data' -and $_.user.'client-key-data'
-    } | Select-Object -First 1
-
-    if ($sourceUser -and [string]$sourceUser.name -ne $ctxName) {
-      $certBytes = ConvertFrom-AapKubeBase64 ([string]$sourceUser.user.'client-certificate-data')
-      $keyBytes = ConvertFrom-AapKubeBase64 ([string]$sourceUser.user.'client-key-data')
-      if ($certBytes -and $keyBytes) {
-        $certFile = [System.IO.Path]::GetTempFileName()
-        $keyFile = [System.IO.Path]::GetTempFileName()
-        try {
-          [IO.File]::WriteAllBytes($certFile, $certBytes)
-          [IO.File]::WriteAllBytes($keyFile, $keyBytes)
-          Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-            'config', 'set-credentials', $ctxName,
-            "--client-certificate=$certFile",
-            "--client-key=$keyFile",
-            '--embed-certs=true'
-          ) | Out-Null
-        } finally {
-          Remove-Item -LiteralPath $certFile, $keyFile -Force -ErrorAction SilentlyContinue
-        }
-        Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-          'config', 'unset', "users.$($sourceUser.name)"
-        ) | Out-Null
-      } else {
-        Write-AapWarn 'Could not decode kubeconfig credentials - keeping existing user entry'
-      }
-    }
-
-    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-      'config', 'set-context', $ctxName, "--cluster=$ctxName", "--user=$ctxName"
-    ) | Out-Null
-    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
-      'config', 'use-context', $ctxName
-    ) | Out-Null
-
-    $crcDir = Split-Path -Parent $crcKube
-    New-Item -ItemType Directory -Force -Path $crcDir | Out-Null
-    Move-Item -LiteralPath $tempKube -Destination $crcKube -Force
-    Write-AapStep 'Saved to ~/.crc/machines/crc/kubeconfig'
-    $tempKube = $null
-  } finally {
-    if ($tempKube -and (Test-Path -LiteralPath $tempKube)) {
-      Remove-Item -LiteralPath $tempKube -Force -ErrorAction SilentlyContinue
-    }
-  }
-
-  $userKubeDir = Join-Path $env:USERPROFILE '.kube'
-  $userKube = Join-Path $userKubeDir 'config'
-  New-Item -ItemType Directory -Force -Path $userKubeDir | Out-Null
-
-  if (Test-Path -LiteralPath $userKube) {
-    Write-Host '  Removing old aap-demo entries...'
-    foreach ($name in @($ctxName, 'microshift')) {
-      Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'delete-context', $name) | Out-Null
-      Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'delete-cluster', $name) | Out-Null
-      Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'delete-user', $name) | Out-Null
-    }
-
-    Write-Host '  Merging into existing ~/.kube/config...'
-    $merged = [System.IO.Path]::GetTempFileName()
-    $prev = $env:KUBECONFIG
-    try {
-      $env:KUBECONFIG = "$userKube;$crcKube"
-      $flat = Invoke-AapExternal oc @('config', 'view', '--flatten')
-      if ($flat.ExitCode -ne 0) { throw 'Failed to merge kubeconfigs' }
-      Set-Content -LiteralPath $merged -Value $flat.Output -Encoding ascii
-      Move-Item -LiteralPath $merged -Destination $userKube -Force
-      Write-AapStep 'Merged context into ~/.kube/config'
-    } finally {
-      $env:KUBECONFIG = $prev
-      if (Test-Path -LiteralPath $merged) {
-        Remove-Item -LiteralPath $merged -Force -ErrorAction SilentlyContinue
-      }
-    }
-  } else {
-    Copy-Item -LiteralPath $crcKube -Destination $userKube -Force
-    Write-AapStep 'Created ~/.kube/config'
-  }
-
-  Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'use-context', $ctxName) | Out-Null
-  Write-AapStep "Current context set to $ctxName"
   Write-Host ''
   Write-Host '  oc now connects to OpenShift Local cluster.'
-  Write-Host "  Context: $ctxName"
+  Write-Host '  Context: aap-demo'
 }
 
 function Invoke-AapDemoIdle {

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -647,7 +647,7 @@ function Invoke-AapDemoDeployAap {
   )
 
   Initialize-AapKubeEnvironment
-  Install-AapIngressCaTrust
+  Set-AapIngressCaEnvFromSaved
   Invoke-AapApplyAapCr -Namespace $Namespace -CrName $CrName -PublicUrl $PublicUrl
   Invoke-AapDemoWatch -Namespace $Namespace
 }

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -119,7 +119,6 @@ function Invoke-AapDemoCreate {
   }
 
   Install-AapOlm
-  Install-AapIngressCaTrust
 
   $kubeConfig = Get-AapKubeconfigPath
   Write-Host ''

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -120,6 +120,12 @@ function Invoke-AapDemoCreate {
 
   Install-AapOlm
 
+  try {
+    Sync-AapKubeconfig -Quiet
+  } catch {
+    Write-AapWarn "Kubeconfig sync skipped: $($_.Exception.Message)"
+  }
+
   $kubeConfig = Get-AapKubeconfigPath
   Write-Host ''
   Write-AapStep 'CRC cluster ready'

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -1,8 +1,12 @@
 function Invoke-AapDemoCreate {
   [CmdletBinding()]
-  param()
+  param(
+    [switch]$Embedded
+  )
 
-  Write-AapHeader 'aap-demo create'
+  if (-not $Embedded) {
+    Write-AapHeader 'aap-demo create'
+  }
 
   Assert-AapCommand crc 'Install OpenShift Local: https://console.redhat.com/openshift/create/local'
 
@@ -51,11 +55,7 @@ function Invoke-AapDemoCreate {
   Write-AapStep "Pull secret: $pullSecret"
 
   Write-AapStep 'Starting CRC (this may take several minutes)...'
-  & crc start -p $pullSecret
-  if ($LASTEXITCODE -ne 0) {
-    Get-Content -LiteralPath $pullSecret -Raw | & crc start --pull-secret-file -
-    if ($LASTEXITCODE -ne 0) { throw 'crc start failed' }
-  }
+  Invoke-AapCrcStart -PullSecretPath $pullSecret
 
   Initialize-AapKubeEnvironment
 
@@ -103,13 +103,10 @@ function Invoke-AapDemoCreate {
     if ((Invoke-AapOcQuiet @('get', 'sc', 'nfs-local-rwx')) -ne 0) {
       Write-AapStep 'Setting up nfs-local-rwx storage...'
       Invoke-AapOc @('adm', 'policy', 'add-scc-to-group', 'privileged', 'system:serviceaccounts:nfs-storage') | Out-Null
-      $defaultSc = (Invoke-AapOcCapture @(
-        'get', 'sc', '-o', 'jsonpath={.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
-      )).Output
-      if (-not $defaultSc) { $defaultSc = 'topolvm-provisioner' }
+      $defaultSc = Get-AapDefaultStorageClass
       Apply-AapManifestTemplate 'config/manifests/nfs-server.yaml' @{ '__DEFAULT_SC__' = $defaultSc }
       Invoke-AapOc @('wait', '--for=condition=Available', 'deployment/nfs-server', '-n', 'nfs-storage', '--timeout=120s') | Out-Null
-      $nfsIp = (Invoke-AapOcCapture @('get', 'svc', 'nfs-server', '-n', 'nfs-storage', '-o', 'jsonpath={.spec.clusterIP}')).Output
+      $nfsIp = Get-AapServiceClusterIp -Name 'nfs-server' -Namespace 'nfs-storage'
       Apply-AapManifestTemplate 'config/manifests/nfs-provisioner.yaml' @{ '__NFS_SERVER_IP__' = $nfsIp }
       Invoke-AapOc @('wait', '--for=condition=Available', 'deployment/nfs-provisioner', '-n', 'nfs-storage', '--timeout=120s') | Out-Null
     }
@@ -128,8 +125,35 @@ function Invoke-AapDemoCreate {
   Write-Host ''
   Write-AapStep 'CRC cluster ready'
   Write-Host "  Kubeconfig: $kubeConfig"
-  Write-Host '  Next: aap-demo deploy'
-  Write-Host ''
+  if (-not $Embedded) {
+    Write-Host '  Next: aap-demo deploy'
+    Write-Host ''
+  }
+}
+
+function Invoke-AapEnsureCluster {
+  param(
+    [switch]$CreateIfMissing
+  )
+
+  $crc = Get-AapCrcStatus
+  if ([string]$crc.crcStatus -eq 'Stopped') {
+    Write-AapStep 'Cluster stopped - starting CRC...'
+    Invoke-AapCrcStart
+  } elseif ([string]$crc.crcStatus -eq 'Unknown') {
+    if ($CreateIfMissing) {
+      Write-AapStep 'No cluster found - creating OpenShift Local cluster...'
+      Write-Host ''
+      Invoke-AapDemoCreate -Embedded
+    } else {
+      throw 'No cluster found. Run: aap-demo create'
+    }
+  }
+
+  Initialize-AapKubeEnvironment
+  if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
+    throw 'oc cannot connect to cluster'
+  }
 }
 
 function Set-AapCoreDns {

--- a/powershell/native/Private/Deploy.ps1
+++ b/powershell/native/Private/Deploy.ps1
@@ -74,19 +74,7 @@ function Invoke-AapDemoDeploy {
 
   Write-AapHeader 'aap-demo deploy'
 
-  $crc = Get-AapCrcStatus
-  if ([string]$crc.crcStatus -eq 'Stopped') {
-    Write-AapStep 'Cluster stopped - starting CRC...'
-    & crc start
-    if ($LASTEXITCODE -ne 0) { throw 'crc start failed' }
-  } elseif ([string]$crc.crcStatus -eq 'Unknown') {
-    throw 'No cluster found. Run: aap-demo create'
-  }
-
-  Initialize-AapKubeEnvironment
-  if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
-    throw 'oc cannot connect to cluster'
-  }
+  Invoke-AapEnsureCluster -CreateIfMissing
 
   Install-AapIngressCaTrust
 

--- a/powershell/native/Private/Deploy.ps1
+++ b/powershell/native/Private/Deploy.ps1
@@ -144,7 +144,6 @@ function Invoke-AapDemoDeploy {
 function Initialize-AapNamespace {
   param([Parameter(Mandatory)][string]$Namespace)
 
-  Write-AapStep "Setting up namespace $Namespace"
   Invoke-AapOcQuiet @('create', 'namespace', $Namespace) | Out-Null
   Grant-AapNamespaceSccs -Namespace $Namespace
   Invoke-AapOc @(

--- a/powershell/native/Private/Diagnose.ps1
+++ b/powershell/native/Private/Diagnose.ps1
@@ -6,8 +6,7 @@ function Invoke-AapDemoDiagnose {
   )
 
   if ($Ai) {
-    Invoke-AapBashCli @('diagnose', '--ai')
-    return
+    throw 'diagnose --ai is not available in the native PowerShell CLI. Use aap-demo diagnose without --ai.'
   }
 
   $counts = @{ Issues = 0; Warnings = 0 }

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -41,6 +41,112 @@ function Test-AapCommand {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Update-AapSessionPath {
+  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $env:Path = @($machinePath, $userPath) -join ';'
+}
+
+function Install-AapHelm {
+  if (Test-AapCommand 'helm') {
+    return $true
+  }
+
+  if (-not (Test-AapCommand 'winget')) {
+    Write-AapWarn 'helm not found and winget is unavailable'
+    return $false
+  }
+
+  Write-Host 'Installing Helm via winget (Helm.Helm)...'
+  $wingetArgs = @(
+    'install', '--id', 'Helm.Helm', '-e', '--source', 'winget',
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--disable-interactivity'
+  )
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    & winget @wingetArgs
+    if ($LASTEXITCODE -ne 0) {
+      Write-AapWarn "winget install Helm.Helm failed (exit $LASTEXITCODE)"
+      return $false
+    }
+  } catch {
+    Write-AapWarn "Could not install Helm via winget: $($_.Exception.Message)"
+    return $false
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+
+  Update-AapSessionPath
+  return (Test-AapCommand 'helm')
+}
+
+function Ensure-AapHelm {
+  if (Test-AapCommand 'helm') { return }
+
+  Write-Host 'Helm not found — installing via winget...'
+  if (-not (Install-AapHelm)) {
+    throw @"
+helm not found.
+
+Install Helm 3.10+: winget install --id Helm.Helm -e --source winget
+"@
+  }
+  Write-AapStep 'Helm installed via winget'
+}
+
+function Install-AapJq {
+  if (Test-AapCommand 'jq') {
+    return $true
+  }
+
+  if (-not (Test-AapCommand 'winget')) {
+    Write-AapWarn 'jq not found and winget is unavailable'
+    return $false
+  }
+
+  Write-Host 'Installing jq via winget (jqlang.jq)...'
+  $wingetArgs = @(
+    'install', '--id', 'jqlang.jq', '-e', '--source', 'winget',
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--disable-interactivity'
+  )
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    & winget @wingetArgs
+    if ($LASTEXITCODE -ne 0) {
+      Write-AapWarn "winget install jqlang.jq failed (exit $LASTEXITCODE)"
+      return $false
+    }
+  } catch {
+    Write-AapWarn "Could not install jq via winget: $($_.Exception.Message)"
+    return $false
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+
+  Update-AapSessionPath
+  return (Test-AapCommand 'jq')
+}
+
+function Ensure-AapJq {
+  if (Test-AapCommand 'jq') { return }
+
+  Write-Host 'jq not found — installing via winget...'
+  if (-not (Install-AapJq)) {
+    throw @"
+jq not found.
+
+Install jq: winget install --id jqlang.jq -e --source winget
+"@
+  }
+  Write-AapStep 'jq installed via winget'
+}
+
 function Assert-AapCommand {
   param(
     [Parameter(Mandatory)][string]$Name,
@@ -94,8 +200,8 @@ function Set-AapConfigValue {
 function Get-AapPullSecretPath {
   $candidates = @(
     $env:PULL_SECRET_PATH,
-    (Join-Path $Script:AapDemoConfigDir 'pull-secret.json'),
     (Join-Path $Script:AapDemoConfigDir 'pull-secret.txt'),
+    (Join-Path $Script:AapDemoConfigDir 'pull-secret.json'),
     (Join-Path $Script:AapDemoConfigDir 'pull-secret')
   ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
   return $candidates | Select-Object -First 1
@@ -220,6 +326,118 @@ function Get-AapCrcStatusJson {
   }
 }
 
+function Write-AapCrcStartOutput {
+  param([string[]]$Lines)
+
+  $skipOcEnvBlock = $false
+  foreach ($line in $Lines) {
+    if ($line -match "Use the 'oc' command line interface") {
+      $skipOcEnvBlock = $true
+      continue
+    }
+    if ($skipOcEnvBlock) { continue }
+    if ($line -match '@FOR /f|^\s*>\s*oc COMMAND|^\s*>\s*@') { continue }
+    if ($line.Trim()) { Write-Host $line }
+  }
+}
+
+function Invoke-AapCrcStart {
+  param(
+    [string]$PullSecretPath = $null
+  )
+
+  Assert-AapCommand crc 'Install OpenShift Local: https://console.redhat.com/openshift/create/local'
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    if ($PullSecretPath) {
+      $output = @(& crc start -p $PullSecretPath 2>&1 | ForEach-Object { "$_" })
+      if ($LASTEXITCODE -ne 0) {
+        $output = @(Get-Content -LiteralPath $PullSecretPath -Raw |
+          & crc start --pull-secret-file - 2>&1 | ForEach-Object { "$_" })
+      }
+    } else {
+      $output = @(& crc start 2>&1 | ForEach-Object { "$_" })
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+      $output | ForEach-Object { Write-Host $_ }
+      throw 'crc start failed'
+    }
+
+    Write-AapCrcStartOutput -Lines $output
+    Initialize-AapKubeEnvironment
+    $kube = Get-AapKubeconfigPath
+    if ($kube) {
+      Write-Host "  Kubeconfig: $kube"
+    }
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+}
+
+function Invoke-AapCrcDelete {
+  param(
+    [switch]$Force
+  )
+
+  Assert-AapCommand crc 'Install OpenShift Local: https://console.redhat.com/openshift/create/local'
+
+  $crc = Get-AapCrcStatus
+  $state = [string]$crc.crcStatus
+
+  if ($state -eq 'Running') {
+    Write-AapStep 'Stopping cluster before delete...'
+    Invoke-AapCrcStop -Quiet
+    Start-Sleep -Seconds 3
+  }
+
+  $deleteArgs = @('delete')
+  if ($Force) { $deleteArgs += '-f' }
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $output = @(& crc @deleteArgs 2>&1 | ForEach-Object { "$_" })
+    if ($LASTEXITCODE -eq 0) { return $true }
+
+    $combined = ($output -join "`n")
+    if ($combined -match 'invalid state') {
+      Write-AapStep 'Cluster not fully stopped — retrying after crc stop...'
+      Invoke-AapCrcStop -Quiet
+      Start-Sleep -Seconds 5
+      $output = @(& crc delete -f 2>&1 | ForEach-Object { "$_" })
+      if ($LASTEXITCODE -eq 0) { return $true }
+    }
+
+    $output | ForEach-Object { if ($_.Trim()) { Write-Host $_ } }
+    return $false
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+}
+
+function Invoke-AapCrcStop {
+  param([switch]$Quiet)
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $output = @(& crc stop 2>&1 | ForEach-Object { "$_" })
+    if ($LASTEXITCODE -ne 0) {
+      if (-not $Quiet) { $output | ForEach-Object { Write-Host $_ } }
+      return $false
+    }
+    if (-not $Quiet) {
+      Write-AapStep 'CRC cluster stopped'
+    }
+    return $true
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+}
+
 function Get-AapCrcDiskUsagePercent {
   $parsed = Get-AapCrcStatusJson
   if (-not $parsed) { return 0 }
@@ -305,6 +523,45 @@ function Read-AapManifest {
   return ($raw -replace "`r`n", "`n" -replace "`r", "`n")
 }
 
+function Get-AapDefaultStorageClass {
+  $fallback = 'topolvm-provisioner'
+  $result = Invoke-AapOcCapture @(
+    'get', 'sc', '-o', 'jsonpath={.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
+  )
+  if ($result.ExitCode -ne 0) { return $fallback }
+  $name = ($result.Output -split '\s+')[0].Trim()
+  if ($name -match '^[A-Za-z0-9][A-Za-z0-9._-]*$') { return $name }
+  return $fallback
+}
+
+function Get-AapServiceClusterIp {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string]$Namespace
+  )
+  $result = Invoke-AapOcCapture @(
+    'get', 'svc', $Name, '-n', $Namespace, '-o', 'jsonpath={.spec.clusterIP}'
+  )
+  if ($result.ExitCode -ne 0) {
+    throw "Could not resolve ClusterIP for service/$Name in $Namespace`: $($result.Output)"
+  }
+  $ip = ($result.Output -split '\s+')[0].Trim()
+  if (-not $ip) {
+    throw "Could not resolve ClusterIP for service/$Name in $Namespace"
+  }
+  return $ip
+}
+
+function Format-AapYamlReplacementValue {
+  param([AllowNull()][string]$Value)
+  if (-not $Value) { return '' }
+  $scalar = ($Value -split '[\r\n]', 2)[0].Trim()
+  if ($scalar -match '[:#@`'']|\s') {
+    return '"' + ($scalar -replace '\\', '\\' -replace '"', '\"') + '"'
+  }
+  return $scalar
+}
+
 function Apply-AapManifestTemplate {
   param(
     [Parameter(Mandatory)][string]$RelativePath,
@@ -314,11 +571,16 @@ function Apply-AapManifestTemplate {
   if (-not (Test-Path -LiteralPath $path)) {
     throw "Manifest not found: $path"
   }
-  $content = Get-Content -LiteralPath $path -Raw
+  $content = Read-AapManifest $RelativePath
   foreach ($key in $Replacements.Keys) {
-    $content = $content -replace [regex]::Escape($key), [string]$Replacements[$key]
+    $value = Format-AapYamlReplacementValue -Value ([string]$Replacements[$key])
+    $content = [regex]::Replace(
+      $content,
+      [regex]::Escape($key),
+      [System.Text.RegularExpressions.MatchEvaluator]{ $value }
+    )
   }
-  $temp = [System.IO.Path]::GetTempFileName()
+  $temp = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
   try {
     Set-AapUtf8Content -Path $temp -Value $content
     Invoke-AapOc @('apply', '-f', $temp) | Out-Null
@@ -497,6 +759,44 @@ function Add-AapCertToRootStoreViaCertutil {
   return $result.ExitCode -eq 0
 }
 
+function Set-AapIngressCaEnv {
+  param([Parameter(Mandatory)][string]$Path)
+  $env:CURL_CA_BUNDLE = $Path
+  $env:SSL_CERT_FILE = $Path
+}
+
+function Update-AapIngressCaFromCluster {
+  param([Parameter(Mandatory)][string]$CaPath)
+
+  $caPem = Invoke-AapCrcSsh 'sudo cat /var/lib/microshift/certs/ingress-ca/ca.crt' -AllowFailure
+  if (-not $caPem -or $caPem -notmatch 'BEGIN CERTIFICATE') {
+    return $false
+  }
+
+  $newContent = $caPem.Trim()
+  $rotated = $true
+  if (Test-Path -LiteralPath $CaPath) {
+    try {
+      $existing = (Get-Content -LiteralPath $CaPath -Raw).Trim()
+      if ($existing -eq $newContent) {
+        $rotated = $false
+      }
+    } catch {
+      $rotated = $true
+    }
+  }
+
+  New-Item -ItemType Directory -Force -Path $Script:AapDemoConfigDir | Out-Null
+  Set-AapUtf8Content -Path $CaPath -Value $newContent
+
+  if ($rotated) {
+    Remove-AapIngressCaCertificates -Location 'CurrentUser'
+    Remove-AapIngressCaCertificates -Location 'LocalMachine'
+  }
+
+  return $true
+}
+
 function Import-AapIngressCaCertificate {
   param([Parameter(Mandatory)][string]$Path)
 
@@ -532,6 +832,7 @@ function Import-AapIngressCaCertificate {
   if (Test-AapIsAdministrator) {
     if (Add-AapCertToRootStoreViaCertutil -Path $Path -Location 'LocalMachine') {
       Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
+      Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
     } else {
       Write-AapWarn 'Could not import ingress CA to system certificate store'
     }
@@ -540,6 +841,7 @@ function Import-AapIngressCaCertificate {
 
   if (Add-AapCertToRootStoreViaCertutil -Path $Path -Location 'LocalMachine' -Elevated) {
     Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
+    Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
     return
   }
 
@@ -550,44 +852,32 @@ function Install-AapIngressCaTrust {
   if ($env:AAP_DEMO_TRUST_CA -eq 'false') { return }
 
   $caPath = Get-AapIngressCaCertPath
-  if (Test-Path -LiteralPath $caPath) {
-    try {
-      $thumbprint = Get-AapX509Thumbprint -Path $caPath
-      if (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'LocalMachine') {
-        $env:CURL_CA_BUNDLE = $caPath
-        $env:SSL_CERT_FILE = $caPath
-        return
-      }
-      if (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'CurrentUser') {
-        Import-AapIngressCaCertificate -Path $caPath
-        $env:CURL_CA_BUNDLE = $caPath
-        $env:SSL_CERT_FILE = $caPath
-        return
-      }
-    } catch {
-      Write-AapWarn "Could not verify saved ingress CA: $($_.Exception.Message)"
-    }
-  }
-
-  Write-AapStep 'Trusting ingress CA...'
   try {
-    $caPem = Invoke-AapCrcSsh 'sudo cat /var/lib/microshift/certs/ingress-ca/ca.crt' -AllowFailure
-    if (-not $caPem -or $caPem -notmatch 'BEGIN CERTIFICATE') {
-      Write-AapWarn 'Could not fetch ingress CA from cluster'
-      if (Test-Path -LiteralPath $caPath) {
-        Import-AapIngressCaCertificate -Path $caPath
-      }
-      return
-    }
-
-    New-Item -ItemType Directory -Force -Path $Script:AapDemoConfigDir | Out-Null
-    Set-AapUtf8Content -Path $caPath -Value $caPem.Trim()
-    Import-AapIngressCaCertificate -Path $caPath
-    $env:CURL_CA_BUNDLE = $caPath
-    $env:SSL_CERT_FILE = $caPath
+    Update-AapIngressCaFromCluster -CaPath $caPath | Out-Null
   } catch {
-    Write-AapWarn "Could not trust ingress CA: $($_.Exception.Message)"
+    Write-AapWarn "Could not fetch ingress CA from cluster: $($_.Exception.Message)"
   }
+
+  if (-not (Test-Path -LiteralPath $caPath)) {
+    Write-AapWarn 'Could not fetch ingress CA from cluster and no saved copy exists'
+    return
+  }
+
+  try {
+    $thumbprint = Get-AapX509Thumbprint -Path $caPath
+  } catch {
+    Write-AapWarn "Could not read ingress CA: $($_.Exception.Message)"
+    return
+  }
+
+  if (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'LocalMachine') {
+    Set-AapIngressCaEnv -Path $caPath
+    return
+  }
+
+  Write-AapStep 'Trusting ingress CA for browser TLS...'
+  Import-AapIngressCaCertificate -Path $caPath
+  Set-AapIngressCaEnv -Path $caPath
 }
 
 function Get-AapExistingCrName {
@@ -802,24 +1092,6 @@ function Invoke-AapPruneCrcImages {
   }
 }
 
-function Find-AapGitBash {
-  $candidates = @(
-    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
-    (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
-    (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
-  ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
-
-  if (@($candidates).Count -eq 0) {
-    throw @"
-Git Bash not found.
-
-Install Git for Windows: https://git-scm.com/download/win
-Required for diagnose --ai only.
-"@
-  }
-  return @($candidates)[0]
-}
-
 function Get-AapInstalledRepoRoot {
   $repoRoot = $Script:AapDemoRepoRoot
   $marker = Join-Path $Script:AapDemoConfigDir 'repo-path'
@@ -835,32 +1107,4 @@ Run from the repo directory or install with:
 "@
   }
   return $repoRoot
-}
-
-function Invoke-AapBashCli {
-  param(
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$Arguments
-  )
-
-  $Arguments = @($Arguments)
-  $repoRoot = Get-AapInstalledRepoRoot
-  $bashExe = Find-AapGitBash
-
-  $env:HOME = $env:USERPROFILE
-
-  if ((Test-Path -LiteralPath $Script:AapDemoUserBin) -and ($env:Path -notlike "*$Script:AapDemoUserBin*")) {
-    $env:Path = "$Script:AapDemoUserBin;$env:Path"
-  }
-
-  if (-not $env:KUBECONFIG) {
-    $defaultKube = Join-Path $env:USERPROFILE '.crc\machines\crc\kubeconfig'
-    if (Test-Path -LiteralPath $defaultKube) {
-      $env:KUBECONFIG = $defaultKube
-    }
-  }
-
-  $scriptWin = Join-Path $repoRoot 'aap-demo.sh'
-  & $bashExe $scriptWin @Arguments
-  exit $LASTEXITCODE
 }

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -249,6 +249,23 @@ function Invoke-AapExternal {
   }
 }
 
+function Wait-AapOcRollout {
+  param(
+    [Parameter(Mandatory)][string]$Resource,
+    [Parameter(Mandatory)][string]$Namespace,
+    [int]$TimeoutSeconds = 600
+  )
+  Initialize-AapKubeEnvironment
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    & oc rollout status $Resource -n $Namespace --timeout="${TimeoutSeconds}s"
+    return $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+}
+
 function Invoke-AapOc {
   param([Parameter(Mandatory)][string[]]$Args)
   Assert-AapCommand oc 'Install oc: winget install --id RedHat.OpenShift-Client -e --source winget'
@@ -367,6 +384,11 @@ function Invoke-AapCrcStart {
     }
 
     Write-AapCrcStartOutput -Lines $output
+    try {
+      Sync-AapKubeconfig -Quiet
+    } catch {
+      Write-AapWarn "Kubeconfig sync skipped: $($_.Exception.Message)"
+    }
     Initialize-AapKubeEnvironment
     $kube = Get-AapKubeconfigPath
     if ($kube) {
@@ -768,85 +790,152 @@ function Update-AapIngressCaFromCluster {
   }
 
   $newContent = $caPem.Trim()
-  $rotated = $true
   if (Test-Path -LiteralPath $CaPath) {
     try {
       $existing = (Get-Content -LiteralPath $CaPath -Raw).Trim()
       if ($existing -eq $newContent) {
-        $rotated = $false
+        return $true
       }
     } catch {
-      $rotated = $true
+      # Overwrite unreadable saved copy.
     }
   }
 
   New-Item -ItemType Directory -Force -Path $Script:AapDemoConfigDir | Out-Null
   Set-AapUtf8Content -Path $CaPath -Value $newContent
 
-  if ($rotated) {
-    Remove-AapIngressCaCertificates -Location 'CurrentUser'
-    Remove-AapIngressCaCertificates -Location 'LocalMachine'
-  }
-
   return $true
 }
 
-function Import-AapIngressCaCertificate {
+function Test-AapIngressCaTrusted {
   param([Parameter(Mandatory)][string]$Path)
+  $thumbprint = Get-AapX509Thumbprint -Path $Path
+  return (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'LocalMachine') -or
+    (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'CurrentUser')
+}
 
+function Test-AapIngressCaBrowserTrusted {
+  param([Parameter(Mandatory)][string]$Path)
   $thumbprint = Get-AapX509Thumbprint -Path $Path
   if (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'LocalMachine') {
-    Write-AapStep 'Ingress CA already trusted (Windows system certificate store)'
-    return
+    return $true
+  }
+  try {
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', 'LocalMachine')
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
+    $stale = @($store.Certificates | Where-Object {
+        $_.Subject -match 'CN=ingress-ca' -and $_.Thumbprint.ToUpperInvariant() -ne $thumbprint
+      })
+    $store.Close()
+    if ($stale.Count -gt 0) { return $false }
+  } catch {
+    # Cannot read LocalMachine store — fall back to CurrentUser trust.
+  }
+  return (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'CurrentUser')
+}
+
+function Import-AapIngressCaToUserStore {
+  param([Parameter(Mandatory)][string]$Path)
+  if (Add-AapCertToRootStore -Path $Path -Location 'CurrentUser') {
+    return $true
+  }
+  if (-not (Get-Command certutil -ErrorAction SilentlyContinue)) {
+    return $false
+  }
+  $result = Invoke-AapExternal certutil @('-user', '-addstore', 'Root', $Path)
+  return $result.ExitCode -eq 0
+}
+
+function Import-AapIngressCaCertificate {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [switch]$Quiet
+  )
+
+  $thumbprint = Get-AapX509Thumbprint -Path $Path
+  if (Test-AapIngressCaBrowserTrusted -Path $Path) {
+    if (-not $Quiet) {
+      Write-AapStep 'Ingress CA already trusted (Windows certificate store)'
+    }
+    return $true
   }
 
   Remove-AapIngressCaCertificates -Location 'CurrentUser'
   Remove-AapIngressCaCertificates -Location 'LocalMachine'
 
-  if (Add-AapCertToRootStore -Path $Path -Location 'LocalMachine') {
-    Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
-    Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
-  } else {
-    Write-AapWarn 'Could not import ingress CA to system certificate store'
+  if (Test-AapIsAdministrator) {
+    if (Add-AapCertToRootStore -Path $Path -Location 'LocalMachine') {
+      if (-not $Quiet) {
+        Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
+        Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
+      }
+      return $true
+    }
   }
+
+  if (Import-AapIngressCaToUserStore -Path $Path) {
+    if (-not $Quiet) {
+      Write-AapStep 'Ingress CA trusted (Current User certificate store)'
+      if (-not (Test-AapIsAdministrator)) {
+        Write-AapWarn 'Chrome/Edge may still warn until you import from an elevated PowerShell:'
+        Write-Host "  certutil -delstore Root `"ingress-ca`""
+        Write-Host "  certutil -addstore Root `"$Path`""
+      }
+    }
+    return $true
+  }
+
+  if (-not $Quiet) {
+    Write-AapWarn 'Could not import ingress CA to Windows certificate store'
+  }
+  return $false
 }
 
 function Install-AapIngressCaTrust {
+  [CmdletBinding()]
+  param([switch]$Quiet)
+
   if ($env:AAP_DEMO_TRUST_CA -eq 'false') { return }
 
   $caPath = Get-AapIngressCaCertPath
   try {
     Update-AapIngressCaFromCluster -CaPath $caPath | Out-Null
   } catch {
-    Write-AapWarn "Could not fetch ingress CA from cluster: $($_.Exception.Message)"
+    if (-not $Quiet) {
+      Write-AapWarn "Could not fetch ingress CA from cluster: $($_.Exception.Message)"
+    }
   }
 
   if (-not (Test-Path -LiteralPath $caPath)) {
-    Write-AapWarn 'Could not fetch ingress CA from cluster and no saved copy exists'
+    if (-not $Quiet) {
+      Write-AapWarn 'Could not fetch ingress CA from cluster and no saved copy exists'
+    }
     return
   }
 
   try {
-    $thumbprint = Get-AapX509Thumbprint -Path $caPath
+    $null = Get-AapX509Thumbprint -Path $caPath
   } catch {
-    Write-AapWarn "Could not read ingress CA: $($_.Exception.Message)"
+    if (-not $Quiet) {
+      Write-AapWarn "Could not read ingress CA: $($_.Exception.Message)"
+    }
     return
   }
 
-  if (Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'LocalMachine') {
+  if (Test-AapIngressCaBrowserTrusted -Path $caPath) {
     Set-AapIngressCaEnv -Path $caPath
     return
   }
 
-  Write-AapStep 'Trusting ingress CA for browser TLS...'
-  if (-not (Test-AapIsAdministrator)) {
-    Write-AapWarn 'Ingress CA not trusted for browsers (Chrome/Edge require an elevated PowerShell).'
-    Write-Host '  Open PowerShell as Administrator and run: aap-demo deploy'
-    Set-AapIngressCaEnv -Path $caPath
-    return
+  if (-not $Quiet) {
+    Write-AapStep 'Trusting ingress CA for browser TLS...'
   }
-
-  Import-AapIngressCaCertificate -Path $caPath
+  $imported = Import-AapIngressCaCertificate -Path $caPath -Quiet:$Quiet
+  if (-not $imported -and -not (Test-AapIngressCaBrowserTrusted -Path $caPath) -and -not $Quiet) {
+    Write-AapWarn 'Chrome/Edge need the ingress CA in the Local Machine trust store (elevated PowerShell):'
+    Write-Host "  certutil -delstore Root `"ingress-ca`""
+    Write-Host "  certutil -addstore Root `"$caPath`""
+  }
   Set-AapIngressCaEnv -Path $caPath
 }
 
@@ -1044,6 +1133,184 @@ function Invoke-AapOcConfig {
     return $result
   } finally {
     $env:KUBECONFIG = $prev
+  }
+}
+
+function Remove-AapStaleCrcKubeEntries {
+  param([Parameter(Mandatory)][string]$KubeConfig)
+  if (-not (Test-Path -LiteralPath $KubeConfig)) { return }
+
+  foreach ($name in @('aap-demo', 'microshift', 'user/api-crc-testing:6443', 'user')) {
+    Invoke-AapOcConfig -KubeConfig $KubeConfig -Arguments @('config', 'delete-context', $name) | Out-Null
+    Invoke-AapOcConfig -KubeConfig $KubeConfig -Arguments @('config', 'delete-cluster', $name) | Out-Null
+    Invoke-AapOcConfig -KubeConfig $KubeConfig -Arguments @('config', 'delete-user', $name) | Out-Null
+  }
+
+  try {
+    $config = Get-AapOcConfigJson -KubeConfig $KubeConfig
+    foreach ($cluster in @($config.clusters)) {
+      $server = [string]$cluster.cluster.server
+      if ($server -match 'api\.crc\.testing') {
+        $clusterName = [string]$cluster.name
+        Invoke-AapOcConfig -KubeConfig $KubeConfig -Arguments @('config', 'delete-context', $clusterName) | Out-Null
+        Invoke-AapOcConfig -KubeConfig $KubeConfig -Arguments @('config', 'delete-cluster', $clusterName) | Out-Null
+      }
+    }
+  } catch {
+    # Ignore invalid kubeconfig during cleanup.
+  }
+}
+
+function Sync-AapKubeconfig {
+  [CmdletBinding()]
+  param(
+    [switch]$Quiet
+  )
+
+  $crc = Get-AapCrcStatus
+  if ([string]$crc.crcStatus -ne 'Running') {
+    throw 'Cluster not running. Run: aap-demo create'
+  }
+
+  $crcKube = Join-Path $env:USERPROFILE '.crc\machines\crc\kubeconfig'
+  if (-not (Test-Path -LiteralPath $crcKube)) {
+    throw 'CRC kubeconfig not found. OpenShift Local may still be initializing.'
+  }
+
+  $ctxName = 'aap-demo'
+  $tempKube = [System.IO.Path]::GetTempFileName()
+  Copy-Item -LiteralPath $crcKube -Destination $tempKube -Force
+
+  try {
+    $config = Get-AapOcConfigJson -KubeConfig $tempKube
+    $contextNames = @($config.contexts | ForEach-Object { [string]$_.name })
+    $sourceCtx = if ($contextNames -contains 'microshift') {
+      'microshift'
+    } elseif ($contextNames -contains $ctxName) {
+      $ctxName
+    } elseif ($contextNames.Count -eq 1) {
+      $contextNames[0]
+    } else {
+      [string]$config.'current-context'
+    }
+
+    if ($sourceCtx -and $sourceCtx -ne $ctxName) {
+      $rename = Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+        'config', 'rename-context', $sourceCtx, $ctxName
+      )
+      if ($rename.ExitCode -ne 0) {
+        throw "Failed to rename context $sourceCtx to $ctxName"
+      }
+      $config = Get-AapOcConfigJson -KubeConfig $tempKube
+    }
+
+    $ctx = $config.contexts | Where-Object { $_.name -eq $ctxName } | Select-Object -First 1
+    $sourceCluster = if ($ctx) { [string]$ctx.context.cluster } else { 'microshift' }
+    $cluster = $config.clusters | Where-Object { $_.name -eq $sourceCluster } | Select-Object -First 1
+    $server = if ($cluster) { [string]$cluster.cluster.server } else { 'https://localhost:6443' }
+    if ($server -match 'api\.crc\.testing') {
+      $server = 'https://localhost:6443'
+    }
+
+    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+      'config', 'set-cluster', $ctxName, "--server=$server", '--insecure-skip-tls-verify=true'
+    ) | Out-Null
+    if ($sourceCluster -ne $ctxName) {
+      Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+        'config', 'unset', "clusters.$sourceCluster"
+      ) | Out-Null
+    }
+
+    $sourceUser = $config.users | Where-Object {
+      $null -ne $_.user -and $_.user.'client-certificate-data' -and $_.user.'client-key-data'
+    } | Select-Object -First 1
+
+    if ($sourceUser -and [string]$sourceUser.name -ne $ctxName) {
+      $certBytes = ConvertFrom-AapKubeBase64 ([string]$sourceUser.user.'client-certificate-data')
+      $keyBytes = ConvertFrom-AapKubeBase64 ([string]$sourceUser.user.'client-key-data')
+      if ($certBytes -and $keyBytes) {
+        $certFile = [System.IO.Path]::GetTempFileName()
+        $keyFile = [System.IO.Path]::GetTempFileName()
+        try {
+          [IO.File]::WriteAllBytes($certFile, $certBytes)
+          [IO.File]::WriteAllBytes($keyFile, $keyBytes)
+          Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+            'config', 'set-credentials', $ctxName,
+            "--client-certificate=$certFile",
+            "--client-key=$keyFile",
+            '--embed-certs=true'
+          ) | Out-Null
+        } finally {
+          Remove-Item -LiteralPath $certFile, $keyFile -Force -ErrorAction SilentlyContinue
+        }
+        Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+          'config', 'unset', "users.$($sourceUser.name)"
+        ) | Out-Null
+      } elseif (-not $Quiet) {
+        Write-AapWarn 'Could not decode kubeconfig credentials - keeping existing user entry'
+      }
+    }
+
+    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+      'config', 'set-context', $ctxName, "--cluster=$ctxName", "--user=$ctxName"
+    ) | Out-Null
+    Invoke-AapOcConfig -KubeConfig $tempKube -Arguments @(
+      'config', 'use-context', $ctxName
+    ) | Out-Null
+
+    $crcDir = Split-Path -Parent $crcKube
+    New-Item -ItemType Directory -Force -Path $crcDir | Out-Null
+    Move-Item -LiteralPath $tempKube -Destination $crcKube -Force
+    if (-not $Quiet) {
+      Write-AapStep 'Saved to ~/.crc/machines/crc/kubeconfig'
+    }
+    $tempKube = $null
+  } finally {
+    if ($tempKube -and (Test-Path -LiteralPath $tempKube)) {
+      Remove-Item -LiteralPath $tempKube -Force -ErrorAction SilentlyContinue
+    }
+  }
+
+  $userKubeDir = Join-Path $env:USERPROFILE '.kube'
+  $userKube = Join-Path $userKubeDir 'config'
+  New-Item -ItemType Directory -Force -Path $userKubeDir | Out-Null
+
+  if (Test-Path -LiteralPath $userKube) {
+    if (-not $Quiet) {
+      Write-Host '  Removing stale OpenShift Local kubeconfig entries...'
+    }
+    Remove-AapStaleCrcKubeEntries -KubeConfig $userKube
+
+    if (-not $Quiet) {
+      Write-Host '  Merging into existing ~/.kube/config...'
+    }
+    $merged = [System.IO.Path]::GetTempFileName()
+    $prev = $env:KUBECONFIG
+    try {
+      $env:KUBECONFIG = "$userKube;$crcKube"
+      $flat = Invoke-AapExternal oc @('config', 'view', '--flatten')
+      if ($flat.ExitCode -ne 0) { throw 'Failed to merge kubeconfigs' }
+      Set-Content -LiteralPath $merged -Value $flat.Output -Encoding ascii
+      Move-Item -LiteralPath $merged -Destination $userKube -Force
+      if (-not $Quiet) {
+        Write-AapStep 'Merged context into ~/.kube/config'
+      }
+    } finally {
+      $env:KUBECONFIG = $prev
+      if (Test-Path -LiteralPath $merged) {
+        Remove-Item -LiteralPath $merged -Force -ErrorAction SilentlyContinue
+      }
+    }
+  } else {
+    Copy-Item -LiteralPath $crcKube -Destination $userKube -Force
+    if (-not $Quiet) {
+      Write-AapStep 'Created ~/.kube/config'
+    }
+  }
+
+  Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'use-context', $ctxName) | Out-Null
+  if (-not $Quiet) {
+    Write-AapStep "Current context set to $ctxName"
   }
 }
 

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -629,7 +629,6 @@ function Wait-AapCatalogSourceReady {
     [Parameter(Mandatory)][string]$Namespace,
     [int]$Attempts = 60
   )
-  Write-Host '  Waiting for CatalogSource...'
   for ($i = 1; $i -le $Attempts; $i++) {
     $result = Invoke-AapOcCapture @(
       'get', 'catalogsource', 'redhat-operators', '-n', $Namespace,
@@ -640,7 +639,6 @@ function Wait-AapCatalogSourceReady {
       Write-AapStep 'CatalogSource ready'
       return
     }
-    Write-Host "    attempt $i/$Attempts ($state)"
     Start-Sleep -Seconds 5
   }
   Write-AapWarn 'CatalogSource not READY after timeout — continuing'
@@ -651,7 +649,6 @@ function Wait-AapCsv {
     [Parameter(Mandatory)][string]$Namespace,
     [int]$Attempts = 60
   )
-  Write-Host '  Waiting for operator CSV...'
   $csv = $null
   for ($i = 1; $i -le $Attempts; $i++) {
     $result = Invoke-AapOcCapture @('get', 'csv', '-n', $Namespace, '--no-headers')
@@ -665,14 +662,12 @@ function Wait-AapCsv {
         break
       }
     }
-    Write-Host "    attempt $i/$Attempts"
     Start-Sleep -Seconds 10
   }
   if (-not $csv) {
     throw 'CSV not found after timeout'
   }
 
-  Write-Host '  Waiting for CSV to reach Succeeded phase...'
   if ((Invoke-AapOcQuiet @('wait', "--for=jsonpath={.status.phase}=Succeeded", "csv/$csv", '-n', $Namespace, '--timeout=600s')) -ne 0) {
     $phaseResult = Invoke-AapOcCapture @('get', 'csv', $csv, '-n', $Namespace, '-o', 'jsonpath={.status.phase}')
     $phase = if ($phaseResult.ExitCode -eq 0) { $phaseResult.Output.Trim() } else { 'unknown' }
@@ -733,36 +728,35 @@ function Remove-AapIngressCaCertificates {
   }
 }
 
-function Add-AapCertToRootStoreViaCertutil {
+function Add-AapCertToRootStore {
   param(
     [Parameter(Mandatory)][string]$Path,
     [ValidateSet('CurrentUser', 'LocalMachine')]
-    [string]$Location = 'CurrentUser',
-    [switch]$Elevated
+    [string]$Location = 'CurrentUser'
   )
-  $certutilArgs = if ($Location -eq 'CurrentUser') {
-    @('-user', '-addstore', 'Root', $Path)
-  } else {
-    @('-addstore', 'Root', $Path)
+  try {
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', $Location)
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($Path)
+    $store.Add($cert)
+    $store.Close()
+    return $true
+  } catch {
+    return $false
   }
-
-  if ($Elevated -and $Location -eq 'LocalMachine') {
-    try {
-      $proc = Start-Process -FilePath 'certutil.exe' -ArgumentList $certutilArgs -Verb RunAs -Wait -PassThru -WindowStyle Hidden
-      return $proc.ExitCode -eq 0
-    } catch {
-      return $false
-    }
-  }
-
-  $result = Invoke-AapExternal certutil.exe $certutilArgs
-  return $result.ExitCode -eq 0
 }
 
 function Set-AapIngressCaEnv {
   param([Parameter(Mandatory)][string]$Path)
   $env:CURL_CA_BUNDLE = $Path
   $env:SSL_CERT_FILE = $Path
+}
+
+function Set-AapIngressCaEnvFromSaved {
+  $caPath = Get-AapIngressCaCertPath
+  if (Test-Path -LiteralPath $caPath) {
+    Set-AapIngressCaEnv -Path $caPath
+  }
 }
 
 function Update-AapIngressCaFromCluster {
@@ -809,43 +803,12 @@ function Import-AapIngressCaCertificate {
   Remove-AapIngressCaCertificates -Location 'CurrentUser'
   Remove-AapIngressCaCertificates -Location 'LocalMachine'
 
-  $userTrusted = Test-AapCertInRootStore -Thumbprint $thumbprint -Location 'CurrentUser'
-  if (-not $userTrusted) {
-    $userOk = $false
-    try {
-      $store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', 'CurrentUser')
-      $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-      $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($Path)
-      $store.Add($cert)
-      $store.Close()
-      $userOk = $true
-    } catch {
-      $userOk = Add-AapCertToRootStoreViaCertutil -Path $Path -Location 'CurrentUser'
-    }
-    if ($userOk) {
-      Write-AapStep 'Ingress CA trusted (Windows user certificate store)'
-    } else {
-      Write-AapWarn 'Could not import ingress CA to user certificate store'
-    }
-  }
-
-  if (Test-AapIsAdministrator) {
-    if (Add-AapCertToRootStoreViaCertutil -Path $Path -Location 'LocalMachine') {
-      Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
-      Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
-    } else {
-      Write-AapWarn 'Could not import ingress CA to system certificate store'
-    }
-    return
-  }
-
-  if (Add-AapCertToRootStoreViaCertutil -Path $Path -Location 'LocalMachine' -Elevated) {
+  if (Add-AapCertToRootStore -Path $Path -Location 'LocalMachine') {
     Write-AapStep 'Ingress CA trusted (Windows system certificate store)'
     Write-Host '  Fully quit Chrome or Edge (all windows), then reopen the route URL.'
-    return
+  } else {
+    Write-AapWarn 'Could not import ingress CA to system certificate store'
   }
-
-  Write-AapWarn 'System trust skipped (UAC declined or unavailable). Fully quit Chrome/Edge and retry, or run aap-demo status from an elevated PowerShell.'
 }
 
 function Install-AapIngressCaTrust {
@@ -876,6 +839,13 @@ function Install-AapIngressCaTrust {
   }
 
   Write-AapStep 'Trusting ingress CA for browser TLS...'
+  if (-not (Test-AapIsAdministrator)) {
+    Write-AapWarn 'Ingress CA not trusted for browsers (Chrome/Edge require an elevated PowerShell).'
+    Write-Host '  Open PowerShell as Administrator and run: aap-demo deploy'
+    Set-AapIngressCaEnv -Path $caPath
+    return
+  }
+
   Import-AapIngressCaCertificate -Path $caPath
   Set-AapIngressCaEnv -Path $caPath
 }

--- a/powershell/native/Private/Portal.ps1
+++ b/powershell/native/Private/Portal.ps1
@@ -1,0 +1,1322 @@
+# Native PowerShell implementation of the portal Helm addon.
+
+$Script:AapPortalState = @{
+  AapNamespace         = $null
+  PortalNamespace      = 'redhat-rhaap-portal'
+  PortalDir            = (Join-Path $env:USERPROFILE '.aap-demo\portal')
+  ReleaseName          = 'redhat-rhaap-portal'
+  ChartRepo            = 'openshift-helm-charts/redhat-rhaap-portal'
+  DefaultPluginVersion = '2.2'
+  OAuthAppName         = 'ansible-automation-portal'
+  IsArmCluster         = $false
+  IsMicroshift         = $false
+  HelmWasUpgrade         = $false
+  AapRoute             = $null
+  AdminPass            = $null
+  OrgId                = $null
+  OrgName              = $null
+  OAuthAppId           = $null
+  ClientId             = $null
+  ClientSecret         = $null
+  ApiToken             = $null
+  ClusterBaseUrl       = $null
+  AapHostUrl           = $null
+  PortalRoute          = $null
+}
+
+function Get-AapPortalHelmExe {
+  if (Get-Command helm.exe -ErrorAction SilentlyContinue) { return 'helm.exe' }
+  if (Get-Command helm -ErrorAction SilentlyContinue) { return 'helm' }
+  throw 'helm not found'
+}
+
+function Get-AapPortalJqExe {
+  if (Get-Command jq.exe -ErrorAction SilentlyContinue) { return 'jq.exe' }
+  if (Get-Command jq -ErrorAction SilentlyContinue) { return 'jq' }
+  throw 'jq not found'
+}
+
+function Invoke-AapPortalHelm {
+  param([Parameter(Mandatory)][string[]]$ArgumentList)
+  return Invoke-AapExternal (Get-AapPortalHelmExe) $ArgumentList
+}
+
+function Invoke-AapPortalJq {
+  param(
+    [Parameter(Mandatory)][string]$Filter,
+    [string]$InputJson = $null,
+    [hashtable]$Args = @{}
+  )
+  $jq = Get-AapPortalJqExe
+  $jqArgs = if ($null -ne $InputJson) { @('-r', $Filter) } else { @($Filter) }
+  foreach ($key in $Args.Keys) {
+    $jqArgs += @('--arg', $key, [string]$Args[$key])
+  }
+  if ($null -ne $InputJson) {
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+      $output = $InputJson | & $jq @jqArgs 2>&1
+      $code = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $prev
+    }
+    return [PSCustomObject]@{
+      ExitCode = $code
+      Output   = ($output | Out-String).TrimEnd()
+    }
+  }
+  return Invoke-AapExternal $jq $jqArgs
+}
+
+function Invoke-AapPortalCurl {
+  param(
+    [string]$Method = 'GET',
+    [Parameter(Mandatory)][string]$Url,
+    [string]$User = $null,
+    [string]$Body = $null,
+    [int]$MaxTime = 0
+  )
+  $bodyFile = $null
+  $args = @('-k', '-s', '-S')
+  if ($User) { $args += @('-u', $User) }
+  if ($Method -ne 'GET') { $args += @('-X', $Method) }
+  if ($MaxTime -gt 0) { $args += @('--max-time', [string]$MaxTime) }
+  if ($Body) {
+    $bodyFile = [System.IO.Path]::GetTempFileName()
+    Set-AapUtf8Content -Path $bodyFile -Value $Body
+    $args += @('--data-binary', "@$bodyFile")
+  }
+  $args += @('-H', 'Content-Type: application/json', $Url, '-w', "`nHTTP_CODE:%{http_code}")
+  try {
+    $result = Invoke-AapExternal curl.exe $args
+    $output = $result.Output
+    $httpCode = $null
+    if ($output -match '(?s)(.*)\r?\nHTTP_CODE:(\d+)\s*$') {
+      $output = $Matches[1].TrimEnd()
+      $httpCode = $Matches[2]
+    }
+    return [PSCustomObject]@{
+      ExitCode = $result.ExitCode
+      Output   = $output
+      HttpCode = $httpCode
+      Lines    = $result.Lines
+    }
+  } finally {
+    if ($bodyFile) {
+      Remove-Item -LiteralPath $bodyFile -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+function Test-AapPortalCurlSuccess {
+  param(
+    [Parameter(Mandatory)]$Result,
+    [string[]]$AllowedHttpCodes = @()
+  )
+  if ($Result.ExitCode -ne 0) { return $false }
+  if (-not $Result.HttpCode) { return $true }
+  if ($AllowedHttpCodes.Count -gt 0) {
+    return $Result.HttpCode -in $AllowedHttpCodes
+  }
+  return $Result.HttpCode -match '^2'
+}
+
+function Get-AapPortalOAuthAppByName {
+  param(
+    [Parameter(Mandatory)][string]$Route,
+    [Parameter(Mandatory)][string]$User,
+    [Parameter(Mandatory)][string]$AppName
+  )
+  $encodedName = [uri]::EscapeDataString($AppName)
+  $result = Invoke-AapPortalCurl -Url "https://$Route/api/gateway/v1/applications/?name=$encodedName" -User $User
+  if (-not (Test-AapPortalCurlSuccess -Result $result)) { return $null }
+  $count = [int](Invoke-AapPortalJq -Filter '.count // 0' -InputJson $result.Output).Output
+  if ($count -le 0) { return $null }
+  return @{
+    Id       = (Invoke-AapPortalJq -Filter '.results[0].id' -InputJson $result.Output).Output.Trim()
+    ClientId = (Invoke-AapPortalJq -Filter '.results[0].client_id' -InputJson $result.Output).Output.Trim()
+  }
+}
+
+function Remove-AapPortalOAuthAppFromAap {
+  param(
+    [Parameter(Mandatory)][string]$Route,
+    [Parameter(Mandatory)][string]$User,
+    [Parameter(Mandatory)][string]$AppId
+  )
+  $deleteResult = Invoke-AapPortalCurl -Method DELETE `
+    -Url "https://$Route/api/gateway/v1/applications/$AppId/" -User $User
+  if (-not (Test-AapPortalCurlSuccess -Result $deleteResult -AllowedHttpCodes @('200', '202', '204'))) {
+    throw "Failed to delete OAuth application (ID: $AppId, HTTP $($deleteResult.HttpCode)): $($deleteResult.Output)"
+  }
+  $remaining = Get-AapPortalOAuthAppByName -Route $Route -User $User -AppName $Script:AapPortalState.OAuthAppName
+  if ($remaining -and [string]$remaining.Id -eq [string]$AppId) {
+    throw "OAuth application (ID: $AppId) still exists after delete"
+  }
+}
+
+function New-AapPortalOAuthAppBody {
+  param(
+    [Parameter(Mandatory)][string]$AppName,
+    [Parameter(Mandatory)][string]$OrgId
+  )
+  $org = [int]$OrgId
+  $nameJson = ConvertTo-Json -InputObject $AppName -Compress
+  return (
+    '{"name":' + $nameJson +
+    ',"organization":' + $org +
+    ',"authorization_grant_type":"authorization-code"' +
+    ',"client_type":"confidential"' +
+    ',"redirect_uris":"https://example.com"}'
+  )
+}
+
+function Invoke-AapPortalOAuthAppCreate {
+  param(
+    [Parameter(Mandatory)][string]$Route,
+    [Parameter(Mandatory)][string]$User,
+    [Parameter(Mandatory)][string]$AppName,
+    [Parameter(Mandatory)][string]$OrgId
+  )
+  $body = New-AapPortalOAuthAppBody -AppName $AppName -OrgId $OrgId
+  $oauthResult = Invoke-AapPortalCurl -Method POST -Url "https://$Route/api/gateway/v1/applications/" `
+    -User $User -Body $body
+  if (Test-AapPortalCurlSuccess -Result $oauthResult) {
+    return $oauthResult
+  }
+  if ($oauthResult.Output -match 'unique set') {
+    $existing = Get-AapPortalOAuthAppByName -Route $Route -User $User -AppName $AppName
+    if ($existing) {
+      Write-Host 'OAuth app already exists - removing and retrying...'
+      Remove-AapPortalOAuthAppFromAap -Route $Route -User $User -AppId $existing.Id
+      $oauthResult = Invoke-AapPortalCurl -Method POST -Url "https://$Route/api/gateway/v1/applications/" `
+        -User $User -Body $body
+    }
+  }
+  if (-not (Test-AapPortalCurlSuccess -Result $oauthResult)) {
+    $detail = if ($oauthResult.Output) { $oauthResult.Output } else { '(no response body)' }
+    throw "Failed to create OAuth application (HTTP $($oauthResult.HttpCode)): $detail"
+  }
+  return $oauthResult
+}
+
+function Initialize-AapPortalDir {
+  $dir = $Script:AapPortalState.PortalDir
+  New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+function Get-AapPortalRouteHost {
+  param([string]$AapNamespace = $Script:AapDemoDefaultNamespace)
+
+  $portalNs = $Script:AapPortalState.PortalNamespace
+  foreach ($ns in @($portalNs, $AapNamespace)) {
+    $result = Invoke-AapOcCapture @(
+      'get', 'route', 'redhat-rhaap-portal', '-n', $ns, '-o', 'jsonpath={.spec.host}'
+    )
+    if ($result.ExitCode -ne 0) { continue }
+    $routeHost = $result.Output.Trim()
+    if ($routeHost -and $routeHost -notmatch '\s' -and $routeHost -notmatch ':') {
+      return $routeHost
+    }
+  }
+  return $null
+}
+
+function Test-AapPortalHelmRelease {
+  param([Parameter(Mandatory)][string]$Namespace)
+  $result = Invoke-AapPortalHelm @('list', '-n', $Namespace)
+  if ($result.ExitCode -ne 0) { return $false }
+  $name = [regex]::Escape($Script:AapPortalState.ReleaseName)
+  return $result.Output -match "(?m)^$name\s"
+}
+
+function Clear-AapPortalNamespace {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  $release = $Script:AapPortalState.ReleaseName
+  if (Test-AapPortalHelmRelease -Namespace $Namespace) {
+    Write-Host "Uninstalling Helm release: $release (namespace: $Namespace)"
+    Invoke-AapPortalHelm @('uninstall', $release, '-n', $Namespace) | Out-Null
+  }
+
+  Invoke-AapOcQuiet @('delete', 'secret', "$release-dynamic-plugins-registry-auth", '-n', $Namespace) | Out-Null
+  Invoke-AapOcQuiet @('delete', 'secret', 'secrets-rhaap-portal', '-n', $Namespace) | Out-Null
+}
+
+function Test-AapPortalPrerequisites {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  Write-Host 'Checking prerequisites...'
+
+  if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
+    throw @"
+Cannot connect to Kubernetes cluster.
+Ensure oc is configured and cluster is accessible.
+"@
+  }
+
+  Resolve-AapPortalProfile
+  Test-AapPortalLocalArchitecture
+
+  if ((Invoke-AapOcQuiet @('get', 'route', 'aap', '-n', $Namespace)) -ne 0) {
+    throw @"
+AAP not deployed in namespace: $Namespace
+Run 'aap-demo deploy' first.
+"@
+  }
+
+  Ensure-AapHelm
+  $verResult = Invoke-AapPortalHelm @('version', '--short')
+  if ($verResult.ExitCode -ne 0) {
+    throw 'Could not determine Helm version'
+  }
+  if ($verResult.Output -match 'v(\d+)\.(\d+)') {
+    $major = [int]$Matches[1]
+    $minor = [int]$Matches[2]
+    if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 10)) {
+      throw "Helm version 3.10+ required (found: $($Matches[0]))"
+    }
+  }
+
+  Ensure-AapJq
+  Write-AapStep 'Prerequisites met'
+}
+
+function Resolve-AapPortalProfile {
+  $portalArch = $env:PORTAL_ARCH
+  $clusterArch = $null
+
+  if ($portalArch) {
+    switch -Regex ($portalArch) {
+      '^(arm|arm64|aarch64)$' { $clusterArch = 'arm64' }
+      '^(x86|amd64|x86_64)$' { $clusterArch = 'amd64' }
+      default { throw "Unknown PORTAL_ARCH: $portalArch (use arm or x86)" }
+    }
+  } else {
+    $archResult = Invoke-AapOcCapture @(
+      'get', 'nodes', '-o', 'jsonpath={.items[0].status.nodeInfo.architecture}'
+    )
+    if ($archResult.ExitCode -eq 0 -and $archResult.Output.Trim()) {
+      $clusterArch = $archResult.Output.Trim()
+    }
+  }
+
+  if (-not $clusterArch) {
+    Write-AapWarn 'Could not detect cluster architecture; defaulting to x86 profile'
+    $Script:AapPortalState.IsArmCluster = $false
+    return
+  }
+
+  Write-AapStep "Cluster architecture: $clusterArch"
+  if ($clusterArch -in @('arm64', 'aarch64')) {
+    $Script:AapPortalState.IsArmCluster = $true
+    Write-AapStep 'Using ARM profile (upstream community RHDH images)'
+  } else {
+    $Script:AapPortalState.IsArmCluster = $false
+    Write-AapStep 'Using x86 profile (Red Hat RHDH images)'
+  }
+}
+
+function Test-AapPortalLocalArchitecture {
+  $localArch = $env:PROCESSOR_ARCHITECTURE
+  $isLocalArm = $localArch -match 'ARM|AARCH64'
+
+  if ($Script:AapPortalState.IsArmCluster) {
+    if ($isLocalArm) {
+      Write-AapStep 'Local machine is ARM — matches cluster'
+    } else {
+      Write-Host '  Local machine is x86 — deploying to ARM cluster via KUBECONFIG'
+    }
+    return
+  }
+
+  if ($isLocalArm) {
+    Write-Host '  Local machine is ARM (Apple Silicon) — cluster is x86_64'
+    Write-Host '  Deploy to an ARM cluster (e.g. CRC on Apple Silicon) with: aap-demo enable portal'
+    Write-Host ''
+  }
+}
+
+function Clear-AapPortalLegacyInstall {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  $portalNs = $Script:AapPortalState.PortalNamespace
+  if ($Namespace -eq $portalNs) { return }
+
+  if (Test-AapPortalHelmRelease -Namespace $Namespace) {
+    Write-Host "Migrating portal from $Namespace to $portalNs..."
+    Clear-AapPortalNamespace -Namespace $Namespace
+  }
+}
+
+function Copy-AapPortalPullSecret {
+  param(
+    [Parameter(Mandatory)][string]$AapNamespace,
+    [Parameter(Mandatory)][string]$PortalNamespace
+  )
+
+  if ((Invoke-AapOcQuiet @('get', 'secret', 'redhat-operators-pull-secret', '-n', $AapNamespace)) -ne 0) {
+    return
+  }
+
+  Initialize-AapPortalDir
+  $pullSecretPath = Join-Path $Script:AapPortalState.PortalDir 'pull-secret.json'
+  $b64Result = Invoke-AapOcCapture @(
+    'get', 'secret', 'redhat-operators-pull-secret', '-n', $AapNamespace,
+    '-o', 'jsonpath={.data.\.dockerconfigjson}'
+  )
+  if ($b64Result.ExitCode -ne 0 -or -not $b64Result.Output.Trim()) { return }
+
+  $decoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64Result.Output.Trim()))
+  Set-AapUtf8Content -Path $pullSecretPath -Value $decoded
+
+  Invoke-AapOcQuiet @('delete', 'secret', 'redhat-operators-pull-secret', '-n', $PortalNamespace) | Out-Null
+  Invoke-AapOc @(
+    'create', 'secret', 'generic', 'redhat-operators-pull-secret',
+    "--from-file=.dockerconfigjson=$pullSecretPath",
+    '--type=kubernetes.io/dockerconfigjson',
+    '-n', $PortalNamespace
+  ) | Out-Null
+
+  $saResult = Invoke-AapOcCapture @(
+    'get', 'serviceaccount', 'default', '-n', $PortalNamespace,
+    '-o', 'jsonpath={.imagePullSecrets[*].name}'
+  )
+  $existing = if ($saResult.ExitCode -eq 0) { $saResult.Output.Trim() -split '\s+' } else { @() }
+  if ($existing -contains 'redhat-operators-pull-secret') { return }
+
+  $names = @($existing + 'redhat-operators-pull-secret' | Where-Object { $_ } | Sort-Object -Unique)
+  $patch = (@{ imagePullSecrets = @($names | ForEach-Object { @{ name = $_ } }) } | ConvertTo-Json -Compress)
+  Invoke-AapOcPatch @('patch', 'serviceaccount', 'default', '-n', $PortalNamespace) -Patch $patch | Out-Null
+}
+
+function Initialize-AapPortalNamespace {
+  param(
+    [Parameter(Mandatory)][string]$AapNamespace,
+    [Parameter(Mandatory)][string]$PortalNamespace
+  )
+
+  Write-Host "Setting up portal namespace: $PortalNamespace"
+  Invoke-AapOcQuiet @('create', 'namespace', $PortalNamespace) | Out-Null
+  Invoke-AapOc @(
+    'label', 'namespace', $PortalNamespace,
+    'pod-security.kubernetes.io/enforce=privileged',
+    'pod-security.kubernetes.io/audit=privileged',
+    'pod-security.kubernetes.io/warn=privileged',
+    '--overwrite'
+  ) | Out-Null
+
+  Grant-AapNamespaceSccs -Namespace $PortalNamespace
+  Copy-AapPortalPullSecret -AapNamespace $AapNamespace -PortalNamespace $PortalNamespace
+  Write-AapStep 'Portal namespace ready'
+}
+
+function Get-AapPortalAapCredentials {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  Write-Host 'Fetching AAP credentials...'
+
+  $routeResult = Invoke-AapOcCapture @('get', 'route', 'aap', '-n', $Namespace, '-o', 'jsonpath={.spec.host}')
+  if ($routeResult.ExitCode -ne 0 -or -not $routeResult.Output.Trim()) {
+    throw 'Failed to get AAP route'
+  }
+  $Script:AapPortalState.AapRoute = $routeResult.Output.Trim()
+
+  $adminPass = Get-AapAdminPassword -Namespace $Namespace
+  if (-not $adminPass) {
+    throw 'Failed to get AAP admin password'
+  }
+  $Script:AapPortalState.AdminPass = $adminPass
+
+  $ping = Invoke-AapPortalCurl -Url "https://$($Script:AapPortalState.AapRoute)/api/gateway/v1/ping/" `
+    -User "admin:$adminPass" -MaxTime 10
+  if ($ping.ExitCode -ne 0) {
+    throw "Cannot reach AAP at https://$($Script:AapPortalState.AapRoute)"
+  }
+
+  Write-AapStep "AAP accessible at: $($Script:AapPortalState.AapRoute)"
+}
+
+function Select-AapPortalOrganization {
+  Write-Host 'Selecting AAP organization...'
+
+  $route = $Script:AapPortalState.AapRoute
+  $user = "admin:$($Script:AapPortalState.AdminPass)"
+  $orgsResult = Invoke-AapPortalCurl -Url "https://$route/api/gateway/v1/organizations/" -User $user
+  if ($orgsResult.ExitCode -ne 0) {
+    throw 'Failed to list AAP organizations'
+  }
+
+  $countResult = Invoke-AapPortalJq -Filter '.count // 0' -InputJson $orgsResult.Output
+  $orgCount = [int]$countResult.Output
+
+  if ($orgCount -eq 0) {
+    Write-Host 'Creating default organization...'
+    $body = '{"name": "Default", "description": "Default organization for portal"}'
+    $createResult = Invoke-AapPortalCurl -Method POST -Url "https://$route/api/gateway/v1/organizations/" `
+      -User $user -Body $body
+    if ($createResult.ExitCode -ne 0) {
+      throw 'Failed to create default organization'
+    }
+    $Script:AapPortalState.OrgId = (Invoke-AapPortalJq -Filter '.id' -InputJson $createResult.Output).Output.Trim()
+    $Script:AapPortalState.OrgName = 'Default'
+  } else {
+    $Script:AapPortalState.OrgId = (Invoke-AapPortalJq -Filter '.results[0].id' -InputJson $orgsResult.Output).Output.Trim()
+    $Script:AapPortalState.OrgName = (Invoke-AapPortalJq -Filter '.results[0].name' -InputJson $orgsResult.Output).Output.Trim()
+  }
+
+  if (-not $Script:AapPortalState.OrgId -or $Script:AapPortalState.OrgId -eq 'null') {
+    throw 'Failed to get/create organization'
+  }
+
+  Write-AapStep "Using organization: $($Script:AapPortalState.OrgName) (ID: $($Script:AapPortalState.OrgId))"
+}
+
+function New-AapPortalOAuthApp {
+  Write-Host 'Creating OAuth application in AAP...'
+
+  Initialize-AapPortalDir
+  $oauthFile = Join-Path $Script:AapPortalState.PortalDir 'oauth_credentials.json'
+  $route = $Script:AapPortalState.AapRoute
+  $user = "admin:$($Script:AapPortalState.AdminPass)"
+  $appName = $Script:AapPortalState.OAuthAppName
+
+  $existing = Get-AapPortalOAuthAppByName -Route $route -User $user -AppName $appName
+  if ($existing) {
+    $Script:AapPortalState.OAuthAppId = $existing.Id
+    $Script:AapPortalState.ClientId = $existing.ClientId
+    $Script:AapPortalState.ClientSecret = ''
+
+    if (Test-Path -LiteralPath $oauthFile) {
+      $saved = Get-Content -LiteralPath $oauthFile -Raw | ConvertFrom-Json
+      if ($saved.oauth_app_id -eq $Script:AapPortalState.OAuthAppId -and $saved.client_secret) {
+        $Script:AapPortalState.ClientSecret = [string]$saved.client_secret
+        Write-Host 'Using saved OAuth client secret for existing app...'
+      }
+    }
+
+    if (-not $Script:AapPortalState.ClientSecret) {
+      Write-Host 'OAuth app exists but client secret unavailable - recreating...'
+      Remove-AapPortalOAuthAppFromAap -Route $route -User $user -AppId $Script:AapPortalState.OAuthAppId
+      $existing = $null
+    } else {
+      Write-Host 'OAuth app already exists, using existing...'
+    }
+  }
+
+  if (-not $existing) {
+    $oauthResult = Invoke-AapPortalOAuthAppCreate -Route $route -User $user -AppName $appName `
+      -OrgId $Script:AapPortalState.OrgId
+    $Script:AapPortalState.OAuthAppId = (Invoke-AapPortalJq -Filter '.id' -InputJson $oauthResult.Output).Output.Trim()
+    $Script:AapPortalState.ClientId = (Invoke-AapPortalJq -Filter '.client_id' -InputJson $oauthResult.Output).Output.Trim()
+    $Script:AapPortalState.ClientSecret = (Invoke-AapPortalJq -Filter '.client_secret' -InputJson $oauthResult.Output).Output.Trim()
+  }
+
+  if (-not $Script:AapPortalState.ClientId -or $Script:AapPortalState.ClientId -eq 'null') {
+    throw 'Failed to create OAuth application: missing client_id in AAP response'
+  }
+  if (-not $Script:AapPortalState.ClientSecret -or $Script:AapPortalState.ClientSecret -eq 'null') {
+    throw 'Failed to obtain OAuth client secret'
+  }
+
+  $credJson = (@{
+    oauth_app_id  = $Script:AapPortalState.OAuthAppId
+    client_id     = $Script:AapPortalState.ClientId
+    client_secret = $Script:AapPortalState.ClientSecret
+  } | ConvertTo-Json -Compress)
+  Set-AapUtf8Content -Path $oauthFile -Value $credJson
+  Set-AapUtf8Content -Path (Join-Path $Script:AapPortalState.PortalDir 'oauth_app_id') -Value $Script:AapPortalState.OAuthAppId
+
+  Write-AapStep "OAuth app ready (ID: $($Script:AapPortalState.OAuthAppId))"
+}
+
+function Enable-AapPortalOAuthTokens {
+  Write-Host 'Enabling OAuth token creation for external users...'
+
+  $route = $Script:AapPortalState.AapRoute
+  $user = "admin:$($Script:AapPortalState.AdminPass)"
+  $settingsResult = Invoke-AapPortalCurl -Url "https://$route/api/gateway/v1/settings/" -User $user
+  if ($settingsResult.ExitCode -ne 0) {
+    throw 'Failed to read AAP settings'
+  }
+
+  $current = (Invoke-AapPortalJq -Filter '.ALLOW_OAUTH2_FOR_EXTERNAL_USERS // false' -InputJson $settingsResult.Output).Output.Trim()
+  if ($current -eq 'true') {
+    Write-AapStep 'OAuth tokens already enabled'
+    return
+  }
+
+  Invoke-AapPortalCurl -Method PATCH -Url "https://$route/api/gateway/v1/settings/" `
+    -User $user -Body '{"ALLOW_OAUTH2_FOR_EXTERNAL_USERS": true}' | Out-Null
+  Write-AapStep 'OAuth tokens enabled'
+}
+
+function New-AapPortalApiToken {
+  Write-Host 'Generating AAP API token...'
+
+  $route = $Script:AapPortalState.AapRoute
+  $user = "admin:$($Script:AapPortalState.AdminPass)"
+  $body = (@{
+    description = 'Portal backend catalog access'
+    scope       = 'read'
+    application = [int]$Script:AapPortalState.OAuthAppId
+  } | ConvertTo-Json -Compress)
+
+  $tokenResult = Invoke-AapPortalCurl -Method POST -Url "https://$route/api/gateway/v1/tokens/" `
+    -User $user -Body $body
+  if ($tokenResult.ExitCode -ne 0) {
+    throw 'Failed to generate API token'
+  }
+
+  $Script:AapPortalState.ApiToken = (Invoke-AapPortalJq -Filter '.token' -InputJson $tokenResult.Output).Output.Trim()
+  if (-not $Script:AapPortalState.ApiToken -or $Script:AapPortalState.ApiToken -eq 'null') {
+    throw 'Failed to generate API token'
+  }
+
+  Write-AapStep 'API token generated'
+}
+
+function Set-AapPortalRegistryAuthFile {
+  param(
+    [Parameter(Mandatory)][string]$SourceJson,
+    [Parameter(Mandatory)][string]$AuthPath
+  )
+
+  $raw = $SourceJson.TrimStart([char]0xFEFF).Trim()
+  if (-not $raw) { return $false }
+
+  try {
+    $config = $raw | ConvertFrom-Json
+  } catch {
+    return $false
+  }
+
+  if (-not $config.auths) { return $false }
+
+  $entry = $config.auths.'registry.redhat.io'
+  if (-not $entry) {
+    $connect = $config.auths.'registry.connect.redhat.com'
+    if ($connect) {
+      $config.auths | Add-Member -NotePropertyName 'registry.redhat.io' -NotePropertyValue $connect -Force
+      $entry = $connect
+    }
+  }
+
+  if (-not $entry) { return $false }
+
+  if (-not $entry.auth) {
+    if ($entry.username -and $null -ne $entry.password) {
+      $token = [Convert]::ToBase64String(
+        [Text.Encoding]::UTF8.GetBytes("$($entry.username):$($entry.password)")
+      )
+      $entry | Add-Member -NotePropertyName 'auth' -NotePropertyValue $token -Force
+    }
+  }
+
+  if (-not $entry.auth) { return $false }
+
+  Set-AapUtf8Content -Path $AuthPath -Value ($config | ConvertTo-Json -Compress -Depth 10)
+  return $true
+}
+
+function Import-AapPortalRegistryAuthFromFile {
+  param(
+    [Parameter(Mandatory)][string]$SourcePath,
+    [Parameter(Mandatory)][string]$AuthPath
+  )
+  if (-not (Test-Path -LiteralPath $SourcePath)) { return $false }
+  try {
+    $raw = Get-Content -LiteralPath $SourcePath -Raw
+    return (Set-AapPortalRegistryAuthFile -SourceJson $raw -AuthPath $AuthPath)
+  } catch {
+    return $false
+  }
+}
+
+function Import-AapPortalRegistryAuthFromSecret {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string]$Namespace,
+    [Parameter(Mandatory)][string]$AuthPath
+  )
+  if ((Invoke-AapOcQuiet @('get', 'secret', $Name, '-n', $Namespace)) -ne 0) { return $false }
+  $b64Result = Invoke-AapOcCapture @(
+    'get', 'secret', $Name, '-n', $Namespace,
+    '-o', 'jsonpath={.data.\.dockerconfigjson}'
+  )
+  if ($b64Result.ExitCode -ne 0 -or -not $b64Result.Output.Trim()) { return $false }
+  try {
+    $decoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64Result.Output.Trim()))
+    return (Set-AapPortalRegistryAuthFile -SourceJson $decoded -AuthPath $AuthPath)
+  } catch {
+    return $false
+  }
+}
+
+function Get-AapPortalRegistryCredentials {
+  Write-Host 'Configuring registry credentials...'
+  Initialize-AapPortalDir
+  $authPath = Join-Path $Script:AapPortalState.PortalDir 'auth.json'
+  $portalNs = $Script:AapPortalState.PortalNamespace
+  $aapNs = $Script:AapPortalState.AapNamespace
+
+  $fileSources = @(
+    @{ Label = 'local pull secret'; Path = (Get-AapPullSecretPath) },
+    @{ Label = 'portal pull secret cache'; Path = (Join-Path $Script:AapPortalState.PortalDir 'pull-secret.json') }
+  )
+  foreach ($src in $fileSources) {
+    if (-not $src.Path) { continue }
+    if (Import-AapPortalRegistryAuthFromFile -SourcePath $src.Path -AuthPath $authPath) {
+      Write-AapStep "Using registry.redhat.io credentials from $($src.Label)"
+      return
+    }
+  }
+
+  $secretSources = @(
+    @{ Label = 'cluster pull secret'; Name = 'pull-secret'; Namespace = 'openshift-config' },
+    @{ Label = 'AAP namespace pull secret'; Name = 'redhat-operators-pull-secret'; Namespace = $aapNs },
+    @{ Label = 'portal namespace pull secret'; Name = 'redhat-operators-pull-secret'; Namespace = $portalNs }
+  )
+  foreach ($src in $secretSources) {
+    if (Import-AapPortalRegistryAuthFromSecret -Name $src.Name -Namespace $src.Namespace -AuthPath $authPath) {
+      Write-AapStep "Using registry.redhat.io credentials from $($src.Label)"
+      return
+    }
+  }
+
+  if ($env:REGISTRY_USERNAME -and $env:REGISTRY_PASSWORD) {
+    $authString = [Convert]::ToBase64String(
+      [Text.Encoding]::UTF8.GetBytes("$($env:REGISTRY_USERNAME):$($env:REGISTRY_PASSWORD)")
+    )
+    $authJson = (@{
+      auths = @{
+        'registry.redhat.io' = @{ auth = $authString }
+      }
+    } | ConvertTo-Json -Compress)
+    Set-AapUtf8Content -Path $authPath -Value $authJson
+    Write-AapStep 'Using registry credentials from environment'
+    return
+  }
+
+  throw @"
+Registry credentials not found in pull secret.
+Save your Red Hat pull secret to $($Script:AapDemoConfigDir)\pull-secret.txt and run 'aap-demo deploy' before 'aap-demo enable portal'.
+"@
+}
+
+function New-AapPortalRegistrySecret {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Creating registry secret in OpenShift...'
+  $release = $Script:AapPortalState.ReleaseName
+  $authPath = Join-Path $Script:AapPortalState.PortalDir 'auth.json'
+
+  Invoke-AapOcQuiet @('delete', 'secret', "$release-dynamic-plugins-registry-auth", '-n', $PortalNamespace) | Out-Null
+  Invoke-AapOc @(
+    'create', 'secret', 'generic', "$release-dynamic-plugins-registry-auth",
+    "--from-file=auth.json=$authPath",
+    '-n', $PortalNamespace
+  ) | Out-Null
+
+  Write-AapStep 'Registry secret created'
+}
+
+function Get-AapPortalClusterInfo {
+  Write-Host 'Getting cluster information...'
+
+  $domainResult = Invoke-AapOcCapture @(
+    'get', 'ingresses.config/cluster', '-o', 'jsonpath={.spec.domain}', '--request-timeout=5s'
+  )
+  $clusterBase = if ($domainResult.ExitCode -eq 0) { $domainResult.Output.Trim() } else { '' }
+
+  if (-not $clusterBase) {
+    $Script:AapPortalState.IsMicroshift = $true
+    $aapRoute = $Script:AapPortalState.AapRoute
+    $aapNs = $Script:AapPortalState.AapNamespace
+    if ($aapRoute -match "^aap-${aapNs}\.(.+)$") {
+      $clusterBase = $Matches[1]
+    }
+  } else {
+    $Script:AapPortalState.IsMicroshift = $false
+  }
+
+  if (-not $clusterBase) {
+    throw 'Failed to get cluster base URL'
+  }
+
+  $Script:AapPortalState.ClusterBaseUrl = $clusterBase
+  Write-AapStep "Cluster base URL: $clusterBase"
+}
+
+function Get-AapPortalAapHostUrl {
+  if ($Script:AapPortalState.IsMicroshift) {
+    return "http://$($Script:AapPortalState.AapRoute)"
+  }
+  return "https://$($Script:AapPortalState.AapRoute)"
+}
+
+function New-AapPortalAapSecrets {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Creating AAP credentials secret...'
+  $Script:AapPortalState.AapHostUrl = Get-AapPortalAapHostUrl
+
+  Invoke-AapOcQuiet @('delete', 'secret', 'secrets-rhaap-portal', '-n', $PortalNamespace) | Out-Null
+  Invoke-AapOc @(
+    'create', 'secret', 'generic', 'secrets-rhaap-portal',
+    '-n', $PortalNamespace,
+    "--from-literal=aap-host-url=$($Script:AapPortalState.AapHostUrl)",
+    "--from-literal=oauth-client-id=$($Script:AapPortalState.ClientId)",
+    "--from-literal=oauth-client-secret=$($Script:AapPortalState.ClientSecret)",
+    "--from-literal=aap-token=$($Script:AapPortalState.ApiToken)"
+  ) | Out-Null
+
+  Write-AapStep 'AAP credentials secret created'
+  Write-AapStep "AAP host URL: $($Script:AapPortalState.AapHostUrl)"
+}
+
+function Get-AapPortalSslValuesYaml {
+  if (-not $Script:AapPortalState.IsMicroshift) { return '' }
+
+  if ($Script:AapPortalState.IsArmCluster) {
+    return @"
+        ansible:
+          rhaap:
+            checkSSL: false
+        auth:
+          providers:
+            rhaap:
+              'production':
+                checkSSL: false
+"@
+  }
+
+  return @"
+      ansible:
+        rhaap:
+          checkSSL: false
+      auth:
+        providers:
+          rhaap:
+            'production':
+              checkSSL: false
+"@
+}
+
+function Write-AapPortalHelmValuesFile {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$Content
+  )
+  $normalized = ($Content -replace "`r`n", "`n" -replace "`r", "`n").TrimEnd() + "`n"
+  Set-AapUtf8Content -Path $Path -Value $normalized
+}
+
+function New-AapPortalHelmValues {
+  $valuesPath = Join-Path $Script:AapPortalState.PortalDir 'values.yaml'
+  $sslValues = Get-AapPortalSslValuesYaml
+  $clusterBase = $Script:AapPortalState.ClusterBaseUrl
+  $pluginVersion = $Script:AapPortalState.DefaultPluginVersion
+
+  if ($Script:AapPortalState.IsArmCluster) {
+    $values = @"
+redhat-developer-hub:
+  global:
+    clusterRouterBase: $clusterBase
+    pluginMode: oci
+    imageTagInfo: "$pluginVersion"
+  upstream:
+    backstage:
+      image:
+        registry: quay.io
+        repository: rhdh-community/rhdh
+        tag: "1.10"
+      appConfig:
+$sslValues
+        dynamicPlugins:
+          frontend:
+            default.main-menu-items:
+              menuItems:
+                default.home:
+                  title: Home
+    postgresql:
+      image:
+        registry: registry.redhat.io
+        repository: rhel9/postgresql-15
+        tag: "9.8-1782419742"
+"@
+    Write-AapPortalHelmValuesFile -Path $valuesPath -Content $values
+    Write-AapStep 'Helm values created (ARM profile)'
+    Write-Host '  RHDH hub: quay.io/rhdh-community/rhdh:1.10'
+    Write-Host '  PostgreSQL: registry.redhat.io/rhel9/postgresql-15:9.8-1782419742'
+    return
+  }
+
+  $values = @"
+global:
+  clusterRouterBase: $clusterBase
+  pluginMode: oci
+  imageTagInfo: "$pluginVersion"
+
+upstream:
+  backstage:
+    appConfig:
+$sslValues
+    dynamicPlugins:
+      frontend:
+        default.main-menu-items:
+          menuItems:
+            default.home:
+              title: Home
+            default.catalog:
+              title: Catalog
+            default.create:
+              title: Create
+            default.apis:
+              title: APIs
+            default.learning-path:
+              title: Learning Paths
+            default.my-group:
+              title: My Group
+"@
+  Write-AapPortalHelmValuesFile -Path $valuesPath -Content $values
+  Write-AapStep 'Helm values created (x86 profile)'
+}
+
+function Install-AapPortalHelmChart {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Installing Helm chart...'
+  $Script:AapPortalState.HelmWasUpgrade = $false
+  $release = $Script:AapPortalState.ReleaseName
+  $valuesPath = Join-Path $Script:AapPortalState.PortalDir 'values.yaml'
+
+  $repoList = Invoke-AapPortalHelm @('repo', 'list')
+  if ($repoList.ExitCode -eq 0 -and $repoList.Output -notmatch 'openshift-helm-charts') {
+    Write-Host 'Adding OpenShift Helm Charts repository...'
+    Invoke-AapPortalHelm @('repo', 'add', 'openshift-helm-charts', 'https://charts.openshift.io/') | Out-Null
+  } elseif ($repoList.ExitCode -ne 0) {
+    Write-Host 'Adding OpenShift Helm Charts repository...'
+    Invoke-AapPortalHelm @('repo', 'add', 'openshift-helm-charts', 'https://charts.openshift.io/') | Out-Null
+  }
+
+  Invoke-AapPortalHelm @('repo', 'update') | Out-Null
+
+  if ($Script:AapPortalState.IsArmCluster) {
+    Invoke-AapOcQuiet @(
+      'delete', 'configmap', "$release-dynamic-plugins", '-n', $PortalNamespace, '--ignore-not-found'
+    ) | Out-Null
+  }
+
+  if (Test-AapPortalHelmRelease -Namespace $PortalNamespace) {
+    Write-Host 'Upgrading existing Helm release...'
+    $Script:AapPortalState.HelmWasUpgrade = $true
+    $result = Invoke-AapPortalHelm @(
+      'upgrade', $release, $Script:AapPortalState.ChartRepo,
+      '-n', $PortalNamespace, '-f', $valuesPath, '--hide-notes'
+    )
+  } else {
+    Write-Host 'Installing Helm release...'
+    $result = Invoke-AapPortalHelm @(
+      'install', $release, $Script:AapPortalState.ChartRepo,
+      '-n', $PortalNamespace, '-f', $valuesPath, '--hide-notes'
+    )
+  }
+
+  if ($result.ExitCode -ne 0) {
+    throw "Helm install failed: $($result.Output)"
+  }
+
+  Write-AapStep 'Helm chart installed'
+}
+
+function Update-AapPortalQuayPluginPatch {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Patching dynamic-plugins configmap...'
+  $release = $Script:AapPortalState.ReleaseName
+  $cm = "$release-dynamic-plugins"
+
+  $cmResult = Invoke-AapOcCapture @(
+    'get', 'cm', $cm, '-n', $PortalNamespace, '-o', 'jsonpath={.data.dynamic-plugins\.yaml}'
+  )
+  $pluginsYaml = if ($cmResult.ExitCode -eq 0) { $cmResult.Output } else { '' }
+
+  if (-not $pluginsYaml) {
+    Write-AapWarn 'dynamic-plugins configmap not found or empty'
+    return
+  }
+
+  if ($pluginsYaml -notmatch 'ansible-automation-platform') {
+    Write-AapWarn 'AAP OCI plugins missing from dynamic-plugins configmap'
+    return
+  }
+
+  if ($pluginsYaml -match '(?ms)- disabled: true\r?\n\s+package: \./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-quay-dynamic') {
+    Write-AapStep 'Quay plugin override already present'
+    return
+  }
+
+  $lines = @($pluginsYaml -split "`r?`n")
+  $filtered = [System.Collections.Generic.List[string]]::new()
+  $skipNextDisabled = $false
+  foreach ($line in $lines) {
+    if ($line -match 'scaffolder-backend-module-quay-dynamic') {
+      $skipNextDisabled = $true
+      continue
+    }
+    if ($skipNextDisabled -and $line -match '^\s+- disabled: true$') {
+      $skipNextDisabled = $false
+      continue
+    }
+    $skipNextDisabled = $false
+    [void]$filtered.Add($line)
+  }
+  [void]$filtered.Add('- disabled: true')
+  [void]$filtered.Add('  package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-quay-dynamic')
+  $newYaml = ($filtered -join "`n")
+
+  $tempFile = [System.IO.Path]::GetTempFileName()
+  try {
+    Set-AapUtf8Content -Path $tempFile -Value $newYaml
+    $dryRun = Invoke-AapOcCapture @(
+      'create', 'configmap', $cm,
+      "--from-file=dynamic-plugins.yaml=$tempFile",
+      '-n', $PortalNamespace, '--dry-run=client', '-o', 'yaml'
+    )
+    if ($dryRun.ExitCode -ne 0) {
+      Write-AapWarn "Failed to render configmap patch: $($dryRun.Output)"
+      return
+    }
+    $applyTemp = [System.IO.Path]::GetTempFileName()
+    try {
+      Set-AapUtf8Content -Path $applyTemp -Value $dryRun.Output
+      Invoke-AapOc @('apply', '-f', $applyTemp) | Out-Null
+    } finally {
+      Remove-Item -LiteralPath $applyTemp -Force -ErrorAction SilentlyContinue
+    }
+  } finally {
+    Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+  }
+
+  Write-AapStep 'Disabled broken quay scaffolder plugin (preserving AAP OCI plugins)'
+}
+
+function Reset-AapPortalDynamicPluginsPvc {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Resetting dynamic-plugins PVC for clean plugin install...'
+  $pvcResult = Invoke-AapOcCapture @('get', 'pvc', '-n', $PortalNamespace, '-o', 'name')
+  if ($pvcResult.ExitCode -ne 0) { return }
+
+  foreach ($line in $pvcResult.Lines) {
+    $pvcName = $line.Trim()
+    if ($pvcName -match 'dynamic-plugins') {
+      Invoke-AapOcQuiet @('delete', $pvcName, '-n', $PortalNamespace, '--timeout=120s') | Out-Null
+    }
+  }
+}
+
+function Restart-AapPortalDeployment {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Restarting portal to apply credential updates...'
+  $release = $Script:AapPortalState.ReleaseName
+  if ((Invoke-AapOcQuiet @('rollout', 'restart', "deployment/$release", '-n', $PortalNamespace)) -ne 0) {
+    Write-AapWarn 'Failed to restart portal deployment'
+    return
+  }
+  Write-AapStep 'Portal deployment restarted'
+}
+
+function Wait-AapPortalDeployment {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Waiting for portal deployment to be ready...'
+  $release = $Script:AapPortalState.ReleaseName
+  $status = Invoke-AapOcCapture @(
+    'rollout', 'status', "deployment/$release", '-n', $PortalNamespace, '--timeout=600s'
+  )
+  if ($status.ExitCode -ne 0) {
+    Write-AapWarn 'Deployment taking longer than expected'
+    Write-Host "Check status with: oc get pods -n $PortalNamespace"
+    Write-Host 'Proceeding anyway...'
+  } else {
+    Write-AapStep 'Deployment ready'
+  }
+}
+
+function Update-AapPortalAapRouteHostAlias {
+  param(
+    [Parameter(Mandatory)][string]$AapNamespace,
+    [Parameter(Mandatory)][string]$PortalNamespace
+  )
+
+  if (-not $Script:AapPortalState.IsMicroshift) { return }
+
+  Write-Host 'Configuring AAP route host alias for in-pod OAuth token exchange...'
+  $release = $Script:AapPortalState.ReleaseName
+  $aapRoute = $Script:AapPortalState.AapRoute
+
+  $ipResult = Invoke-AapOcCapture @('get', 'svc', 'aap', '-n', $AapNamespace, '-o', 'jsonpath={.spec.clusterIP}')
+  $aapIp = if ($ipResult.ExitCode -eq 0) { $ipResult.Output.Trim() } else { '' }
+  if (-not $aapIp) {
+    Write-AapWarn 'Could not resolve AAP service ClusterIP; skipping host alias'
+    return
+  }
+
+  $currentResult = Invoke-AapOcCapture @(
+    'get', 'deployment', $release, '-n', $PortalNamespace,
+    '-o', "jsonpath={.spec.template.spec.hostAliases[?(@.hostnames[0]=='$aapRoute')].ip}"
+  )
+  $currentIp = if ($currentResult.ExitCode -eq 0) { $currentResult.Output.Trim() } else { '' }
+
+  if ($currentIp -eq $aapIp) {
+    Write-AapStep "AAP route host alias already configured ($aapRoute → $aapIp)"
+    return
+  }
+
+  $patch = (@{
+    spec = @{
+      template = @{
+        spec = @{
+          hostAliases = @(
+            @{ ip = $aapIp; hostnames = @($aapRoute) }
+          )
+        }
+      }
+    }
+  } | ConvertTo-Json -Depth 6 -Compress)
+  Invoke-AapOcPatch @('patch', 'deployment', $release, '-n', $PortalNamespace) -Patch $patch | Out-Null
+
+  $rollout = Invoke-AapOcCapture @(
+    'rollout', 'status', "deployment/$release", '-n', $PortalNamespace, '--timeout=600s'
+  )
+  if ($rollout.ExitCode -ne 0) {
+    Write-AapWarn 'Portal rollout after host alias patch is still in progress'
+  }
+
+  Write-AapStep "AAP route host alias: $aapRoute → $aapIp"
+}
+
+function Update-AapPortalOAuthRedirect {
+  Write-Host 'Updating OAuth redirect URI...'
+
+  $portalNs = $Script:AapPortalState.PortalNamespace
+  $release = $Script:AapPortalState.ReleaseName
+  $routeResult = Invoke-AapOcCapture @(
+    'get', 'route', $release, '-n', $portalNs, '-o', 'jsonpath={.spec.host}'
+  )
+  if ($routeResult.ExitCode -ne 0 -or -not $routeResult.Output.Trim()) {
+    Write-AapWarn 'Failed to get portal route'
+    Write-Host 'OAuth redirect URI not updated - may need manual fix'
+    return
+  }
+
+  $Script:AapPortalState.PortalRoute = $routeResult.Output.Trim()
+  $redirectUri = "https://$($Script:AapPortalState.PortalRoute)/api/auth/rhaap/handler/frame"
+  $route = $Script:AapPortalState.AapRoute
+  $user = "admin:$($Script:AapPortalState.AdminPass)"
+  $body = (@{ redirect_uris = $redirectUri } | ConvertTo-Json -Compress)
+
+  Invoke-AapPortalCurl -Method PATCH `
+    -Url "https://$route/api/gateway/v1/applications/$($Script:AapPortalState.OAuthAppId)/" `
+    -User $user -Body $body | Out-Null
+
+  Write-AapStep "OAuth redirect URI updated: $redirectUri"
+}
+
+function Test-AapPortalAapHostUrl {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Verifying AAP host URL in portal pod...'
+  $release = $Script:AapPortalState.ReleaseName
+  $result = Invoke-AapOcCapture @(
+    'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+    'printenv', 'AAP_HOST_URL'
+  )
+  $aapHostUrl = if ($result.ExitCode -eq 0) { $result.Output.Trim() } else { '' }
+
+  if (-not $aapHostUrl) {
+    Write-AapWarn 'Could not read AAP_HOST_URL from portal pod'
+    return $false
+  }
+
+  if ($aapHostUrl -match '\.svc') {
+    Write-Host "  ERROR Portal is configured with in-cluster AAP URL: $aapHostUrl" -ForegroundColor Red
+    Write-Host '  Browser OAuth redirects require the external AAP route hostname.'
+    Write-Host '  Re-run: aap-demo enable portal'
+    return $false
+  }
+
+  if ($Script:AapPortalState.IsMicroshift -and $aapHostUrl -match '^https://') {
+    Write-Host "  ERROR Portal AAP URL uses HTTPS on MicroShift: $aapHostUrl" -ForegroundColor Red
+    Write-Host '  In-cluster OAuth token exchange requires http://<aap-route> on CRC/MicroShift.'
+    Write-Host '  Re-run: aap-demo enable portal'
+    return $false
+  }
+
+  Write-AapStep "AAP host URL: $aapHostUrl"
+  return $true
+}
+
+function Test-AapPortalOAuthClient {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  Write-Host 'Verifying OAuth client credentials...'
+  $release = $Script:AapPortalState.ReleaseName
+  $aapHostUrl = $Script:AapPortalState.AapHostUrl
+  $portalRoute = $Script:AapPortalState.PortalRoute
+
+  $script = @"
+AUTH=`$(printf '%s:%s' "`$OAUTH_CLIENT_ID" "`$OAUTH_CLIENT_SECRET" | base64 -w0)
+curl -s -o /dev/null -w '%{http_code}' -X POST '${aapHostUrl}/o/token/' \
+  -H "Authorization: Basic `$AUTH" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=authorization_code&code=invalid&redirect_uri=https://${portalRoute}/api/auth/rhaap/handler/frame'
+"@
+
+  $result = Invoke-AapOcCapture @(
+    'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+    'sh', '-c', $script
+  )
+  $httpCode = if ($result.ExitCode -eq 0) { $result.Output.Trim() } else { '000' }
+
+  if ($httpCode -eq '000') {
+    Write-Host "  ERROR Portal pod cannot reach AAP token endpoint at ${aapHostUrl}/o/token/" -ForegroundColor Red
+    Write-Host '  On CRC/MicroShift, nip.io resolves to 127.0.0.1 inside pods.'
+    Write-Host '  Re-run: aap-demo enable portal'
+    return $false
+  }
+
+  if ($httpCode -eq '401') {
+    Write-Host '  ERROR OAuth client credentials rejected by AAP (invalid_client)' -ForegroundColor Red
+    Write-Host '  Re-run: aap-demo enable portal'
+    return $false
+  }
+
+  Write-AapStep "OAuth client credentials accepted by AAP (HTTP $httpCode)"
+  return $true
+}
+
+function Show-AapPortalSuccess {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  Write-Host ''
+  Write-Host ('=' * 60)
+  Write-AapStep 'Portal addon enabled successfully!'
+  Write-Host ('=' * 60)
+  Write-Host ''
+  Write-Host "Portal URL: https://$($Script:AapPortalState.PortalRoute)"
+  if ($Script:AapPortalState.IsArmCluster) {
+    Write-Host 'Profile: ARM (quay.io/rhdh-community/rhdh:1.10)'
+  } else {
+    Write-Host 'Profile: x86 (Red Hat RHDH hub image from chart)'
+  }
+  Write-Host ''
+  Write-Host 'Next steps:'
+  Write-Host '1. Open the portal URL in your browser'
+  Write-Host "2. Click 'Sign In'"
+  Write-Host '3. Authenticate with AAP credentials (admin / <aap-admin-password>)'
+  Write-Host '4. Browse AAP job templates in the catalog'
+  Write-Host ''
+  Write-Host 'Check status: aap-demo status portal'
+  Write-Host 'Disable: aap-demo disable portal'
+  Write-Host ''
+
+  $adminPassword = Get-AapAdminPassword -Namespace $Namespace
+  if ($adminPassword) {
+    Write-Host '  Credentials:'
+    Write-Host '    Username: admin'
+    Write-Host "    Password: $adminPassword"
+    Write-Host ''
+    Write-Host '  Sign in with these AAP credentials when the portal prompts you.'
+    Write-Host ''
+  }
+}
+
+function Invoke-AapDeployPortalAddon {
+  param(
+    [string]$Namespace = $Script:AapDemoDefaultNamespace
+  )
+
+  $Script:AapPortalState.AapNamespace = $Namespace
+  $portalNs = $Script:AapPortalState.PortalNamespace
+
+  Test-AapPortalPrerequisites -Namespace $Namespace
+  Clear-AapPortalLegacyInstall -Namespace $Namespace
+  Initialize-AapPortalNamespace -AapNamespace $Namespace -PortalNamespace $portalNs
+  Get-AapPortalAapCredentials -Namespace $Namespace
+  Select-AapPortalOrganization
+  New-AapPortalOAuthApp
+  Enable-AapPortalOAuthTokens
+  New-AapPortalApiToken
+  Get-AapPortalRegistryCredentials
+  New-AapPortalRegistrySecret -PortalNamespace $portalNs
+  Get-AapPortalClusterInfo
+  New-AapPortalAapSecrets -PortalNamespace $portalNs
+  New-AapPortalHelmValues
+  Install-AapPortalHelmChart -PortalNamespace $portalNs
+
+  if ($Script:AapPortalState.IsArmCluster) {
+    Update-AapPortalQuayPluginPatch -PortalNamespace $portalNs
+    Reset-AapPortalDynamicPluginsPvc -PortalNamespace $portalNs
+    Restart-AapPortalDeployment -PortalNamespace $portalNs
+  } elseif ($Script:AapPortalState.HelmWasUpgrade) {
+    Restart-AapPortalDeployment -PortalNamespace $portalNs
+  }
+
+  Wait-AapPortalDeployment -PortalNamespace $portalNs
+  Update-AapPortalAapRouteHostAlias -AapNamespace $Namespace -PortalNamespace $portalNs
+  Update-AapPortalOAuthRedirect
+
+  if (-not (Test-AapPortalAapHostUrl -PortalNamespace $portalNs)) {
+    Write-AapWarn 'AAP host URL verification failed (portal may still work)'
+  }
+  if (-not (Test-AapPortalOAuthClient -PortalNamespace $portalNs)) {
+    Write-AapWarn 'OAuth client verification failed (portal may still work)'
+  }
+
+  Show-AapPortalSuccess -Namespace $Namespace
+}
+
+function Invoke-AapRemovePortalAddon {
+  param(
+    [string]$Namespace = $Script:AapDemoDefaultNamespace
+  )
+
+  $portalNs = $Script:AapPortalState.PortalNamespace
+  $portalDir = $Script:AapPortalState.PortalDir
+  $release = $Script:AapPortalState.ReleaseName
+
+  Write-Host 'Disabling portal addon...'
+
+  Clear-AapPortalNamespace -Namespace $portalNs
+  if ($Namespace -ne $portalNs) {
+    Clear-AapPortalNamespace -Namespace $Namespace
+  }
+
+  $oauthAppIdPath = Join-Path $portalDir 'oauth_app_id'
+  if (Test-Path -LiteralPath $oauthAppIdPath) {
+    $appId = (Get-Content -LiteralPath $oauthAppIdPath -Raw).Trim()
+    $routeResult = Invoke-AapOcCapture @('get', 'route', 'aap', '-n', $Namespace, '-o', 'jsonpath={.spec.host}')
+    $aapRoute = if ($routeResult.ExitCode -eq 0) { $routeResult.Output.Trim() } else { '' }
+    $adminPass = Get-AapAdminPassword -Namespace $Namespace
+
+    if ($aapRoute -and $adminPass -and $appId) {
+      Write-Host "Deleting OAuth application (ID: $appId) from AAP"
+      Invoke-AapPortalCurl -Method DELETE `
+        -Url "https://$aapRoute/api/gateway/v1/applications/$appId/" `
+        -User "admin:$adminPass" | Out-Null
+    }
+  }
+
+  Invoke-AapOcQuiet @('delete', 'namespace', $portalNs, '--timeout=120s') | Out-Null
+
+  if (Test-Path -LiteralPath $portalDir) {
+    Remove-Item -LiteralPath $portalDir -Recurse -Force -ErrorAction SilentlyContinue
+  }
+
+  Write-AapStep 'Portal addon disabled'
+}

--- a/powershell/native/Private/Portal.ps1
+++ b/powershell/native/Private/Portal.ps1
@@ -1035,16 +1035,92 @@ function Wait-AapPortalDeployment {
 
   Write-Host 'Waiting for portal deployment to be ready...'
   $release = $Script:AapPortalState.ReleaseName
-  $status = Invoke-AapOcCapture @(
-    'rollout', 'status', "deployment/$release", '-n', $PortalNamespace, '--timeout=600s'
-  )
-  if ($status.ExitCode -ne 0) {
+  if ((Wait-AapOcRollout -Resource "deployment/$release" -Namespace $PortalNamespace -TimeoutSeconds 600) -ne 0) {
     Write-AapWarn 'Deployment taking longer than expected'
     Write-Host "Check status with: oc get pods -n $PortalNamespace"
     Write-Host 'Proceeding anyway...'
   } else {
     Write-AapStep 'Deployment ready'
   }
+}
+
+function Get-AapRouteServiceClusterIp {
+  param(
+    [Parameter(Mandatory)][string]$RouteName,
+    [Parameter(Mandatory)][string]$Namespace
+  )
+  $routeResult = Invoke-AapOcCapture @('get', 'route', $RouteName, '-n', $Namespace, '-o', 'json')
+  if ($routeResult.ExitCode -ne 0) { return '' }
+  try {
+    $route = $routeResult.Output | ConvertFrom-Json
+    $svcName = [string]$route.spec.to.name
+    if (-not $svcName) { return '' }
+    $ipResult = Invoke-AapOcCapture @(
+      'get', 'svc', $svcName, '-n', $Namespace, '-o', 'jsonpath={.spec.clusterIP}'
+    )
+    if ($ipResult.ExitCode -eq 0) { return $ipResult.Output.Trim() }
+  } catch {
+    return ''
+  }
+  return ''
+}
+
+function Test-AapPortalRouteHostResolution {
+  param(
+    [Parameter(Mandatory)][string]$PortalNamespace,
+    [Parameter(Mandatory)][string]$Hostname,
+    [string]$ExpectedIp = ''
+  )
+  $release = $Script:AapPortalState.ReleaseName
+  $result = Invoke-AapOcCapture @(
+    'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+    'getent', 'hosts', $Hostname
+  )
+  if ($result.ExitCode -ne 0 -or -not $result.Output.Trim()) { return $false }
+  $line = $result.Output.Trim()
+  if ($line -match '127\.0\.0\.1') { return $false }
+  if ($ExpectedIp -and $line -notmatch [regex]::Escape($ExpectedIp)) { return $false }
+  return $true
+}
+
+function Wait-AapPortalRouteHostAliasReady {
+  param(
+    [Parameter(Mandatory)][string]$PortalNamespace,
+    [Parameter(Mandatory)][string]$Hostname,
+    [Parameter(Mandatory)][string]$ExpectedIp,
+    [int]$Attempts = 30
+  )
+  for ($i = 1; $i -le $Attempts; $i++) {
+    if (Test-AapPortalRouteHostResolution -PortalNamespace $PortalNamespace `
+        -Hostname $Hostname -ExpectedIp $ExpectedIp) {
+      return $true
+    }
+    Start-Sleep -Seconds 5
+  }
+  return $false
+}
+
+function Get-AapPortalDeploymentHostAliasIp {
+  param(
+    [Parameter(Mandatory)][string]$Release,
+    [Parameter(Mandatory)][string]$PortalNamespace,
+    [Parameter(Mandatory)][string]$Hostname
+  )
+  $result = Invoke-AapOcCapture @('get', 'deployment', $Release, '-n', $PortalNamespace, '-o', 'json')
+  if ($result.ExitCode -ne 0) { return '' }
+  try {
+    $deployment = $result.Output | ConvertFrom-Json
+    $aliases = $deployment.spec.template.spec.hostAliases
+    if (-not $aliases) { return '' }
+    foreach ($alias in @($aliases)) {
+      if ($alias.hostnames -contains $Hostname) {
+        return [string]$alias.ip
+      }
+    }
+  } catch {
+    return ''
+  }
+  return ''
 }
 
 function Update-AapPortalAapRouteHostAlias {
@@ -1059,21 +1135,36 @@ function Update-AapPortalAapRouteHostAlias {
   $release = $Script:AapPortalState.ReleaseName
   $aapRoute = $Script:AapPortalState.AapRoute
 
-  $ipResult = Invoke-AapOcCapture @('get', 'svc', 'aap', '-n', $AapNamespace, '-o', 'jsonpath={.spec.clusterIP}')
-  $aapIp = if ($ipResult.ExitCode -eq 0) { $ipResult.Output.Trim() } else { '' }
+  $aapIp = Get-AapRouteServiceClusterIp -RouteName 'aap' -Namespace $AapNamespace
+  if (-not $aapIp) {
+    $ipResult = Invoke-AapOcCapture @('get', 'svc', 'aap', '-n', $AapNamespace, '-o', 'jsonpath={.spec.clusterIP}')
+    $aapIp = if ($ipResult.ExitCode -eq 0) { $ipResult.Output.Trim() } else { '' }
+  }
   if (-not $aapIp) {
     Write-AapWarn 'Could not resolve AAP service ClusterIP; skipping host alias'
     return
   }
 
-  $currentResult = Invoke-AapOcCapture @(
-    'get', 'deployment', $release, '-n', $PortalNamespace,
-    '-o', "jsonpath={.spec.template.spec.hostAliases[?(@.hostnames[0]=='$aapRoute')].ip}"
-  )
-  $currentIp = if ($currentResult.ExitCode -eq 0) { $currentResult.Output.Trim() } else { '' }
+  $currentIp = Get-AapPortalDeploymentHostAliasIp -Release $release -PortalNamespace $PortalNamespace -Hostname $aapRoute
+  $podResolves = Test-AapPortalRouteHostResolution -PortalNamespace $PortalNamespace `
+    -Hostname $aapRoute -ExpectedIp $aapIp
 
-  if ($currentIp -eq $aapIp) {
+  if ($currentIp -eq $aapIp -and $podResolves) {
     Write-AapStep "AAP route host alias already configured ($aapRoute → $aapIp)"
+    return
+  }
+
+  if ($currentIp -eq $aapIp -and -not $podResolves) {
+    Write-Host '  Deployment has host alias but portal pod still resolves nip.io to 127.0.0.1 — restarting...'
+    Invoke-AapOcQuiet @('rollout', 'restart', "deployment/$release", '-n', $PortalNamespace) | Out-Null
+    if ((Wait-AapOcRollout -Resource "deployment/$release" -Namespace $PortalNamespace -TimeoutSeconds 600) -ne 0) {
+      Write-AapWarn 'Portal rollout after restart is still in progress'
+    }
+    if (Wait-AapPortalRouteHostAliasReady -PortalNamespace $PortalNamespace -Hostname $aapRoute -ExpectedIp $aapIp) {
+      Write-AapStep "AAP route host alias active ($aapRoute → $aapIp)"
+      return
+    }
+    Write-AapWarn "Portal pod still cannot resolve $aapRoute to $aapIp"
     return
   }
 
@@ -1090,14 +1181,18 @@ function Update-AapPortalAapRouteHostAlias {
   } | ConvertTo-Json -Depth 6 -Compress)
   Invoke-AapOcPatch @('patch', 'deployment', $release, '-n', $PortalNamespace) -Patch $patch | Out-Null
 
-  $rollout = Invoke-AapOcCapture @(
-    'rollout', 'status', "deployment/$release", '-n', $PortalNamespace, '--timeout=600s'
-  )
-  if ($rollout.ExitCode -ne 0) {
+  Write-Host '  Restarting portal pod to apply host alias...'
+  if ((Wait-AapOcRollout -Resource "deployment/$release" -Namespace $PortalNamespace -TimeoutSeconds 600) -ne 0) {
     Write-AapWarn 'Portal rollout after host alias patch is still in progress'
   }
 
-  Write-AapStep "AAP route host alias: $aapRoute → $aapIp"
+  if (Wait-AapPortalRouteHostAliasReady -PortalNamespace $PortalNamespace -Hostname $aapRoute -ExpectedIp $aapIp) {
+    Write-AapStep "AAP route host alias: $aapRoute → $aapIp"
+    return
+  }
+
+  Write-AapWarn "Portal pod cannot resolve $aapRoute to AAP service IP $aapIp"
+  Write-Host '  Check: oc exec deploy/redhat-rhaap-portal -c backstage-backend -n redhat-rhaap-portal -- getent hosts $aapRoute'
 }
 
 function Update-AapPortalOAuthRedirect {
@@ -1120,7 +1215,7 @@ function Update-AapPortalOAuthRedirect {
   $user = "admin:$($Script:AapPortalState.AdminPass)"
   $body = (@{ redirect_uris = $redirectUri } | ConvertTo-Json -Compress)
 
-  Invoke-AapPortalCurl -Method PATCH `
+  Invoke-AapPortalCurl -Method PATCH -MaxTime 60 `
     -Url "https://$route/api/gateway/v1/applications/$($Script:AapPortalState.OAuthAppId)/" `
     -User $user -Body $body | Out-Null
 
@@ -1168,10 +1263,23 @@ function Test-AapPortalOAuthClient {
   $release = $Script:AapPortalState.ReleaseName
   $aapHostUrl = $Script:AapPortalState.AapHostUrl
   $portalRoute = $Script:AapPortalState.PortalRoute
+  if (-not $portalRoute) {
+    $routeResult = Invoke-AapOcCapture @(
+      'get', 'route', $release, '-n', $PortalNamespace, '-o', 'jsonpath={.spec.host}'
+    )
+    if ($routeResult.ExitCode -eq 0) {
+      $portalRoute = $routeResult.Output.Trim()
+      $Script:AapPortalState.PortalRoute = $portalRoute
+    }
+  }
+  if (-not $portalRoute) {
+    Write-AapWarn 'Portal route not found — skipping OAuth client verification'
+    return $false
+  }
 
   $script = @"
 AUTH=`$(printf '%s:%s' "`$OAUTH_CLIENT_ID" "`$OAUTH_CLIENT_SECRET" | base64 -w0)
-curl -s -o /dev/null -w '%{http_code}' -X POST '${aapHostUrl}/o/token/' \
+curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 -X POST '${aapHostUrl}/o/token/' \
   -H "Authorization: Basic `$AUTH" \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'grant_type=authorization_code&code=invalid&redirect_uri=https://${portalRoute}/api/auth/rhaap/handler/frame'
@@ -1186,6 +1294,14 @@ curl -s -o /dev/null -w '%{http_code}' -X POST '${aapHostUrl}/o/token/' \
   if ($httpCode -eq '000') {
     Write-Host "  ERROR Portal pod cannot reach AAP token endpoint at ${aapHostUrl}/o/token/" -ForegroundColor Red
     Write-Host '  On CRC/MicroShift, nip.io resolves to 127.0.0.1 inside pods.'
+    $aapRoute = $Script:AapPortalState.AapRoute
+    $resolveResult = Invoke-AapOcCapture @(
+      'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+      'getent', 'hosts', $aapRoute
+    )
+    if ($resolveResult.ExitCode -eq 0 -and $resolveResult.Output.Trim()) {
+      Write-Host "  Pod DNS for ${aapRoute}: $($resolveResult.Output.Trim())"
+    }
     Write-Host '  Re-run: aap-demo enable portal'
     return $false
   }

--- a/powershell/native/Private/Portal.ps1
+++ b/powershell/native/Private/Portal.ps1
@@ -813,13 +813,41 @@ function Write-AapPortalHelmValuesFile {
   Set-AapUtf8Content -Path $Path -Value $normalized
 }
 
+function Get-AapPortalHelmHostAliasesYaml {
+  param([string]$Indent = '    ')
+
+  if (-not $Script:AapPortalState.IsMicroshift) { return '' }
+
+  $aapRoute = $Script:AapPortalState.AapRoute
+  $aapNs = $Script:AapPortalState.AapNamespace
+  if (-not $aapRoute) { return '' }
+
+  $aapIp = Get-AapRouteServiceClusterIp -RouteName 'aap' -Namespace $aapNs
+  if (-not $aapIp) {
+    $ipResult = Invoke-AapOcCapture @(
+      'get', 'svc', 'aap', '-n', $aapNs, '-o', 'jsonpath={.spec.clusterIP}'
+    )
+    $aapIp = if ($ipResult.ExitCode -eq 0) { $ipResult.Output.Trim() } else { '' }
+  }
+  if (-not $aapIp) { return '' }
+
+  return @"
+${Indent}hostAliases:
+${Indent}  - ip: "$aapIp"
+${Indent}    hostnames:
+${Indent}      - "$aapRoute"
+"@
+}
+
 function New-AapPortalHelmValues {
   $valuesPath = Join-Path $Script:AapPortalState.PortalDir 'values.yaml'
   $sslValues = Get-AapPortalSslValuesYaml
   $clusterBase = $Script:AapPortalState.ClusterBaseUrl
   $pluginVersion = $Script:AapPortalState.DefaultPluginVersion
+  $hostAliases = Get-AapPortalHelmHostAliasesYaml -Indent '    '
 
   if ($Script:AapPortalState.IsArmCluster) {
+    $armHostAliases = Get-AapPortalHelmHostAliasesYaml -Indent '      '
     $values = @"
 redhat-developer-hub:
   global:
@@ -832,6 +860,7 @@ redhat-developer-hub:
         registry: quay.io
         repository: rhdh-community/rhdh
         tag: "1.10"
+$armHostAliases
       appConfig:
 $sslValues
         dynamicPlugins:
@@ -861,6 +890,7 @@ global:
 
 upstream:
   backstage:
+$hostAliases
     appConfig:
 $sslValues
     dynamicPlugins:
@@ -1256,12 +1286,63 @@ function Test-AapPortalAapHostUrl {
   return $true
 }
 
+function Get-AapPortalPodAapHostUrl {
+  param([Parameter(Mandatory)][string]$PortalNamespace)
+
+  $release = $Script:AapPortalState.ReleaseName
+  $result = Invoke-AapOcCapture @(
+    'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+    'printenv', 'AAP_HOST_URL'
+  )
+  if ($result.ExitCode -eq 0 -and $result.Output.Trim()) {
+    return $result.Output.Trim()
+  }
+  return [string]$Script:AapPortalState.AapHostUrl
+}
+
+function Get-AapPortalOAuthHttpCode {
+  param($Result)
+  $line = @($Result.Lines | Where-Object { $_ -match '^\d{3}$' } | Select-Object -Last 1)
+  if ($line) { return [string]$line }
+  if ($Result.Output -match '\b(\d{3})\b') { return $Matches[1] }
+  if ($Result.ExitCode -eq 0 -and $Result.Output.Trim() -match '^\d{3}$') {
+    return $Result.Output.Trim()
+  }
+  return '000'
+}
+
+function Invoke-AapPortalOAuthTokenProbe {
+  param(
+    [Parameter(Mandatory)][string]$PortalNamespace,
+    [Parameter(Mandatory)][string]$AapHostUrl,
+    [Parameter(Mandatory)][string]$PortalRoute,
+    [int]$Attempts = 12,
+    [int]$DelaySeconds = 5
+  )
+
+  $release = $Script:AapPortalState.ReleaseName
+  $script = @"
+AUTH=`$(printf '%s:%s' "`$OAUTH_CLIENT_ID" "`$OAUTH_CLIENT_SECRET" | base64 -w0); curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 -X POST '${AapHostUrl}/o/token/' -H "Authorization: Basic `$AUTH" -H 'Content-Type: application/x-www-form-urlencoded' -d 'grant_type=authorization_code&code=invalid&redirect_uri=https://${PortalRoute}/api/auth/rhaap/handler/frame'
+"@
+
+  for ($i = 1; $i -le $Attempts; $i++) {
+    $result = Invoke-AapOcCapture @(
+      'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
+      'sh', '-c', $script
+    )
+    $httpCode = Get-AapPortalOAuthHttpCode -Result $result
+    if ($httpCode -ne '000') { return $httpCode }
+    if ($i -lt $Attempts) { Start-Sleep -Seconds $DelaySeconds }
+  }
+  return '000'
+}
+
 function Test-AapPortalOAuthClient {
   param([Parameter(Mandatory)][string]$PortalNamespace)
 
   Write-Host 'Verifying OAuth client credentials...'
   $release = $Script:AapPortalState.ReleaseName
-  $aapHostUrl = $Script:AapPortalState.AapHostUrl
+  $aapHostUrl = Get-AapPortalPodAapHostUrl -PortalNamespace $PortalNamespace
   $portalRoute = $Script:AapPortalState.PortalRoute
   if (-not $portalRoute) {
     $routeResult = Invoke-AapOcCapture @(
@@ -1276,20 +1357,33 @@ function Test-AapPortalOAuthClient {
     Write-AapWarn 'Portal route not found — skipping OAuth client verification'
     return $false
   }
+  if (-not $aapHostUrl) {
+    Write-AapWarn 'AAP host URL not found in portal pod — skipping OAuth client verification'
+    return $false
+  }
 
-  $script = @"
-AUTH=`$(printf '%s:%s' "`$OAUTH_CLIENT_ID" "`$OAUTH_CLIENT_SECRET" | base64 -w0)
-curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 -X POST '${aapHostUrl}/o/token/' \
-  -H "Authorization: Basic `$AUTH" \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'grant_type=authorization_code&code=invalid&redirect_uri=https://${portalRoute}/api/auth/rhaap/handler/frame'
-"@
+  if ($Script:AapPortalState.IsMicroshift) {
+    $aapRoute = $Script:AapPortalState.AapRoute
+    if ($aapRoute -and -not (Test-AapPortalRouteHostResolution -PortalNamespace $PortalNamespace `
+          -Hostname $aapRoute -ExpectedIp '')) {
+      Write-Host '  Waiting for AAP route host alias in portal pod...'
+      $aapIp = Get-AapRouteServiceClusterIp -RouteName 'aap' -Namespace $Script:AapPortalState.AapNamespace
+      if (-not $aapIp) {
+        $ipResult = Invoke-AapOcCapture @(
+          'get', 'svc', 'aap', '-n', $Script:AapPortalState.AapNamespace,
+          '-o', 'jsonpath={.spec.clusterIP}'
+        )
+        $aapIp = if ($ipResult.ExitCode -eq 0) { $ipResult.Output.Trim() } else { '' }
+      }
+      if ($aapIp) {
+        Wait-AapPortalRouteHostAliasReady -PortalNamespace $PortalNamespace `
+          -Hostname $aapRoute -ExpectedIp $aapIp | Out-Null
+      }
+    }
+  }
 
-  $result = Invoke-AapOcCapture @(
-    'exec', "deployment/$release", '-c', 'backstage-backend', '-n', $PortalNamespace, '--',
-    'sh', '-c', $script
-  )
-  $httpCode = if ($result.ExitCode -eq 0) { $result.Output.Trim() } else { '000' }
+  $httpCode = Invoke-AapPortalOAuthTokenProbe -PortalNamespace $PortalNamespace `
+    -AapHostUrl $aapHostUrl -PortalRoute $portalRoute
 
   if ($httpCode -eq '000') {
     Write-Host "  ERROR Portal pod cannot reach AAP token endpoint at ${aapHostUrl}/o/token/" -ForegroundColor Red
@@ -1302,7 +1396,7 @@ curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 -X POST '${aapHostUr
     if ($resolveResult.ExitCode -eq 0 -and $resolveResult.Output.Trim()) {
       Write-Host "  Pod DNS for ${aapRoute}: $($resolveResult.Output.Trim())"
     }
-    Write-Host '  Re-run: aap-demo enable portal'
+    Write-Host '  Host alias may still be rolling out — re-run: aap-demo enable portal'
     return $false
   }
 

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -17,13 +17,13 @@ function Invoke-AapDemoStatus {
     'Stopped' {
       Write-Host 'Cluster:     stopped' -ForegroundColor Yellow
       Write-Host ''
-      Write-Host 'Start with: crc start  or  aap-demo create'
+      Write-Host 'Start with: aap-demo deploy'
       return
     }
     default {
       Write-Host 'Cluster:     not running' -ForegroundColor Red
       Write-Host ''
-      Write-Host 'Create with: aap-demo create'
+      Write-Host 'Run: aap-demo deploy'
       return
     }
   }
@@ -42,10 +42,21 @@ function Invoke-AapDemoStatus {
 
   Write-Host 'Namespaces:'
   Write-Host '-----------'
+  $hiddenNamespaces = @(
+    'default',
+    'kube-node-lease',
+    'kube-public',
+    'openshift-controller-manager',
+    'openshift-infra',
+    'openshift-kube-controller-manager',
+    'openshift-route-controller-manager',
+    'operators'
+  )
   $nsResult = Invoke-AapOcCapture @('get', 'ns', '--no-headers', '-o', 'custom-columns=:metadata.name')
   $namespaces = if ($nsResult.ExitCode -eq 0) { $nsResult.Lines } else { @() }
   foreach ($ns in $namespaces) {
     if ([string]::IsNullOrWhiteSpace($ns)) { continue }
+    if ($hiddenNamespaces -contains $ns.Trim()) { continue }
     $podsResult = Invoke-AapOcCapture @('get', 'pods', '-n', $ns, '--no-headers')
     $pods = if ($podsResult.ExitCode -eq 0) { $podsResult.Lines } else { @() }
     if (-not $pods) { continue }
@@ -105,6 +116,20 @@ function Invoke-AapDemoStatus {
     }
   }
   if (-not $foundCred) { Write-Host '  (no admin password secret found yet)' }
+
+  $savedAddons = @(Get-AapAddonsList)
+  Write-Host ''
+  Write-Host 'Addons:'
+  Write-Host '-------'
+  foreach ($a in $Script:AapAvailableAddons) {
+    $enabled = $savedAddons -contains $a
+    $label = Get-AapAddonStatusLabel -Addon $a -Namespace $Namespace -Enabled $enabled
+    if ($label) {
+      Write-Host ("  {0,-15} {1}" -f $a, $label)
+    } else {
+      Write-Host "  $a"
+    }
+  }
   Write-Host ''
 }
 
@@ -116,18 +141,14 @@ USAGE:
     aap-demo <command> [options]
 
 CLUSTER:
-    create          Create OpenShift Local (CRC) cluster
-    stop            Stop CRC cluster
-    destroy         Delete CRC cluster (--reset clears saved preset)
-    repair          Show CRC repair instructions
-    setup           CRC setup info (handled by create)
-    kubeconfig      Sync and merge kubeconfig (context: aap-demo)
-    ssh             SSH into CRC VM
+    stop            Stop cluster
+    start           Start stopped cluster
+    destroy         Deletes cluster (--reset clears saved preset)
+    repair          Show repair instructions
+    ssh             SSH into VM
 
 DEPLOY:
-    deploy          Deploy AAP 2.7 via OLM (alias: deploy-all)
-    deploy-operator Deploy operator only (no AAP CR)
-    deploy-aap      Apply AAP CR only (operator must exist)
+    deploy          Deploy AAP 2.7 via OLM (creates cluster if missing; alias: deploy-all)
     redeploy        Clean namespace and redeploy AAP
     redeploy-all    Destroy cluster and full redeploy
     clean           Remove AAP namespace and resources
@@ -141,36 +162,13 @@ STATUS:
     must-gather     Collect diagnostic bundle
 
 ADDONS:
-    enable <name>   Enable addon (PowerShell + oc)
-    disable <name>  Disable addon
-
-OTHER:
-    config [k] [v]  Show or set ~/.aap-demo/config values
-    update          git pull and reinstall launcher
-    help            Show this help
-
-OPTIONS:
-    -Force          Redeploy even if AAP CR exists
-    -Namespace=ns   Target namespace (default: aap-operator)
-    -Channel=ch     OLM channel (default: stable-2.7)
-    CR=name         AAP CR template (default: minimal)
-    PUBLIC_URL=url  Required for noingress CRs
-    --ai            AI-assisted diagnose (requires Git Bash + claude CLI)
-
-EXAMPLES:
-    aap-demo create
-    aap-demo deploy
-    aap-demo deploy -Force
-    aap-demo deploy-operator
-    aap-demo deploy-aap CR=minimal
-    aap-demo status
-    aap-demo diagnose
-    aap-demo watch
-    aap-demo idle true
+    enable portal   Enable Self-Service Portal (Helm; auto-detects arm64 vs amd64)
+                    Requires: AAP 2.6+, Helm 3.10+, Red Hat pull secret
+    enable mcp-server  Enable MCP server for AI assistants
+    disable <name>  Disable an addon (portal, mcp-server)
 
 NOTES:
     Requires oc and crc on PATH. OpenShift Local needs Hyper-V.
     Pull secret: %USERPROFILE%\.aap-demo\pull-secret.txt
-    Git Bash: only needed for diagnose --ai.
 '@
 }

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -38,7 +38,7 @@ function Invoke-AapDemoStatus {
     return
   }
 
-  Install-AapIngressCaTrust
+  Set-AapIngressCaEnvFromSaved
 
   Write-Host 'Namespaces:'
   Write-Host '-----------'

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -124,10 +124,13 @@ function Invoke-AapDemoStatus {
   foreach ($a in $Script:AapAvailableAddons) {
     $enabled = $savedAddons -contains $a
     $label = Get-AapAddonStatusLabel -Addon $a -Namespace $Namespace -Enabled $enabled
-    if ($label) {
+    $enableCmd = Get-AapAddonEnableCommand -Addon $a
+    if ($label -in @('disabled', 'not-deployed')) {
+      Write-Host ("  {0,-15} {1}  ({2})" -f $a, $label, $enableCmd)
+    } elseif ($label) {
       Write-Host ("  {0,-15} {1}" -f $a, $label)
     } else {
-      Write-Host "  $a"
+      Write-Host ("  {0,-15} ({1})" -f $a, $enableCmd)
     }
   }
   Write-Host ''


### PR DESCRIPTION
## Summary

- Adds a native PowerShell **portal addon** (ap-demo enable portal / disable portal) — no Git Bash required
- Completes the Windows-native CLI: deploy auto-creates the cluster, quieter deploy output, improved status/addon reporting
- Fixes Windows-specific issues (OAuth app creation, registry pull secrets, Helm values, NFS storage class, MCP/portal route detection)
- Ingress CA trust is **deploy-only** from an **elevated PowerShell** (no certutil/UAC popups during status)

## Looking for Windows testers

We need volunteers on **Windows 10/11** with **OpenShift Local (CRC)** to exercise the full flow and report issues. Please comment on this PR if you can help.

**Suggested test plan:**

[ ] Fresh install: aap-demo delete and then aap-demo deploy from an elevated PowerShell
[ ] Confirm ingress CA trust: Chrome/Edge opens the AAP route without certificate warnings after elevated deploy
[ ] aap-demo status — routes, credentials, addon state (should **not** prompt for cert import)
[ ] aap-demo enable portal — portal deploys, URL and admin credentials shown
[ ] aap-demo disable portal — clean teardown

**Environment notes:**

- Pull secret: %USERPROFILE%\.aap-demo\pull-secret.txt
- CA trust: right-click PowerShell -> **Run as administrator** -> ap-demo deploy
- Skip auto trust: $env:AAP_DEMO_TRUST_CA = 'false'

Please report: Windows version, CRC preset, PowerShell version (5.1 vs 7), and any errors or UX friction.

Made with [Cursor](https://cursor.com)