### PR TITLE
docs(adr): Add full architecture decision record set

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ aap-demo help                # Full command reference
 
 ## Architecture
 
+Architecture decisions are documented in [docs/adr/](docs/adr/README.md) (14 ADRs covering CLI
+design, storage, OLM, addons, and cross-platform support).
+
 ### macOS / Linux / Windows
 
 - **Networking:** SSH (2222), API (6443), HTTP/HTTPS (443) — all on localhost

--- a/docs/adr/001-project-cli-architecture.md
+++ b/docs/adr/001-project-cli-architecture.md
@@ -1,0 +1,103 @@
+# ADR-001: Project Purpose and CLI Architecture
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+Developers and testers need a reproducible local environment for Ansible Automation Platform
+(AAP) 2.7 on OpenShift-compatible infrastructure. Production OpenShift clusters are expensive,
+slow to provision, and unsuitable for day-to-day feature work.
+
+The project must:
+
+- Deploy AAP in minutes with a single entry point (`aap-demo`)
+- Work on macOS, Linux, and Windows
+- Support cluster lifecycle (create, deploy, idle, clean, destroy)
+- Offer optional components (portal, MCP server, registry) without complicating the default path
+- Remain maintainable as a shell-first tool with minimal dependencies
+
+## Decision
+
+Build **aap-demo** as a CLI wrapper around OpenShift Local (CRC/MicroShift) that orchestrates
+cluster provisioning, OLM installation, AAP operator deployment, and optional addons.
+
+### CLI structure
+
+| Layer | Path | Role |
+|-------|------|------|
+| Entry point (Unix) | `aap-demo.sh` | Bash dispatcher; symlinked to `~/.local/bin/aap-demo` by `install.sh` |
+| Entry point (Windows) | `powershell/aap-demo.ps1` | PowerShell launcher importing `powershell/native/AapDemo.psm1` |
+| Infrastructure | `includes/infra-api.sh`, `includes/infra-crc.sh` | Backend abstraction for SSH and kubeconfig |
+| Cluster create | `includes/crc-create.sh` | CRC VM setup, NFS, CoreDNS, OLM bootstrap |
+| Manifests | `config/manifests/`, `config/olm/`, `config/crs/` | Kubernetes/OpenShift resources applied at deploy time |
+| Addons | `addons/<name>/deploy.sh` | Pluggable optional components |
+| User state | `~/.aap-demo/` | Config, pull secrets, portal OAuth creds, ingress CA |
+
+### Command categories
+
+1. **Lifecycle** — `create`, `deploy`, `stop`, `start`, `destroy`, `clean`, `redeploy-all`
+2. **Observability** — `status`, `watch`, `diagnose`, `must-gather`
+3. **Operations** — `idle`, `ssh`, `repair`, `update`
+4. **Addons** — `enable <addon>`, `disable <addon>`, `status <addon>`
+5. **Testing** — `test` (delegates to AAP ATF via Ansible)
+
+### Configuration model
+
+- `~/.aap-demo/config` stores `INFRA`, `CRC_PRESET`, and user preferences
+- Environment variables override defaults: `NAMESPACE`, `CRC_CPUS`, `CRC_MEMORY`, `QUIET`, `AAP_OCP_VERSION`
+- `KUBECONFIG` defaults to CRC path when unset
+
+### Design principles
+
+- **Delegate, don't reimplement** — Cluster operations use `crc`, `kubectl`/`oc`, `helm`, and
+  `operator-sdk`; the CLI wires them together
+- **Idempotent commands** — Re-running `deploy` or `enable` updates state safely
+- **Fail with fixes** — `diagnose` outputs actionable remediation, not just errors
+- **Destructive guardrails** — `destroy`, `clean`, and `redeploy-all` require confirmation unless `QUIET=true`
+
+## Consequences
+
+### Positive
+
+- One command (`aap-demo deploy`) covers the full happy path
+- Clear separation between core CLI, infrastructure backends, and addons
+- User state isolated under `~/.aap-demo/` — repo stays read-only after install
+- Skill and docs can reference a stable command surface
+
+### Negative
+
+- `aap-demo.sh` is large (~2,500 lines) — high cognitive load for contributors
+- Bash and PowerShell implementations must stay in sync manually
+- Monolithic script resists unit testing without grep-based integration tests
+
+### Neutral
+
+- No long-running daemon; each invocation is a shell process
+- Ansible used only for ATF test execution, not core deploy flow
+
+## Alternatives Considered
+
+### Ansible playbook as primary interface
+
+Rejected: slower feedback loop, harder for Windows users, and obscures imperative cluster
+steps (CRC start, CoreDNS patch) that need explicit ordering.
+
+### Helm chart for entire aap-demo stack
+
+Rejected: AAP itself is operator-managed; wrapping CRC + OLM + operator in one chart adds
+indirection without simplifying user workflow.
+
+### Docker Compose / kind
+
+Rejected: lacks OpenShift Routes, SCCs, and OLM — required for faithful AAP operator testing.
+
+## References
+
+- [README.md](../../README.md) — user-facing overview
+- [ADR-003](003-infrastructure-backend-selection.md) — CRC backend selection
+- [ADR-008](008-addon-system.md) — addon plugin pattern
+- [ADR-010](010-cross-platform-cli.md) — PowerShell parity

--- a/docs/adr/001-project-cli-architecture.md
+++ b/docs/adr/001-project-cli-architecture.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/003-infrastructure-backend-selection.md
+++ b/docs/adr/003-infrastructure-backend-selection.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-15
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/003-infrastructure-backend-selection.md
+++ b/docs/adr/003-infrastructure-backend-selection.md
@@ -1,0 +1,119 @@
+# ADR-003: Infrastructure Backend Selection
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+AAP requires an OpenShift-compatible API surface: Routes, Security Context Constraints (SCCs),
+Operator Lifecycle Manager (OLM), and CRD-based operators. Developers run aap-demo on macOS,
+Linux, and Windows with varying resource budgets.
+
+Options evaluated:
+
+| Backend | Platform | VM overhead | OpenShift fidelity |
+|---------|----------|-------------|-------------------|
+| CRC MicroShift | macOS, Linux, Windows | Yes (~10 system pods) | API subset, fast |
+| CRC OpenShift | macOS, Linux, Windows | Yes (~96 system pods) | Full OCP |
+| MINC (Podman container) | Linux only | No | Same API subset as MicroShift |
+| External lab cluster | Any | None (remote) | Varies |
+
+## Decision
+
+**CRC MicroShift is the default and primary supported backend.** The infrastructure layer uses a
+dispatch pattern (`includes/infra-api.sh` → `includes/infra-crc.sh`) so additional backends can
+be added without rewriting the CLI.
+
+### CRC presets
+
+During `aap-demo create`, users choose:
+
+| Preset | Use when |
+|--------|----------|
+| **microshift** (default) | Day-to-day AAP dev; fastest startup; ~16 GB RAM |
+| **openshift** | DevSpaces, OperatorHub, full OCP operator ecosystem |
+
+Selection persists as `CRC_PRESET` in `~/.aap-demo/config`.
+
+### Resource defaults
+
+| Setting | Default | Env override |
+|---------|---------|--------------|
+| CPUs | 8 | `CRC_CPUS` |
+| Memory | 16 GiB | `CRC_MEMORY` |
+| Disk | 100 GiB | `CRC_DISK` |
+| LVMS PV reservation | 70 GiB | `CRC_PV_SIZE` |
+
+### Backend abstraction
+
+```text
+aap-demo command
+      │
+      ▼
+infra-api.sh  ──dispatch──▶  infra-crc.sh
+  infra_exec_cmd()            SSH to CRC VM (port 2222)
+  infra_get_kubeconfig()      ~/.crc/machines/crc/kubeconfig
+  infra_copy_to/from()        scp + sudo on VM
+```
+
+`INFRA_TYPE` defaults to `crc`. The abstraction was designed for `minc` and `lab` backends;
+only CRC is implemented in this repository today.
+
+### MINC status
+
+[environment-comparison.md](../environment-comparison.md) documents MINC (MicroShift in Podman,
+Linux-only) as a lightweight alternative. MINC is **not currently implemented** in `includes/` —
+documentation reflects a planned or legacy path. Linux users should use CRC MicroShift unless/until
+`infra-minc.sh` lands.
+
+### External / lab clusters
+
+Users with an existing OpenShift cluster can skip `create` and point `KUBECONFIG` at their
+cluster. Deploy logic (OLM, CatalogSource, Subscription, AAP CR) runs against any cluster
+meeting prerequisites. `config/manifests/aap-ingress.yaml` supports vanilla Kubernetes with a
+manual Ingress when Routes are unavailable.
+
+## Consequences
+
+### Positive
+
+- CRC is Red Hat-supported, cross-platform, and matches AAP certification targets
+- MicroShift preset minimizes resource use while preserving Routes + SCCs + OLM
+- Infra abstraction isolates SSH/kubeconfig details from deploy logic
+- OpenShift preset available without a separate tool
+
+### Negative
+
+- CRC requires Hyper-V (Windows) or virtualization (macOS/Linux) — not container-only
+- MINC documentation may confuse users until implementation catches up
+- Switching backends requires `destroy` + re-`create` — no in-place migration
+
+### Neutral
+
+- Laptop architecture (arm64 vs amd64) affects portal image profiles (ADR-002) but not backend choice
+- Remote x86 clusters work from ARM laptops via `KUBECONFIG`
+
+## Alternatives Considered
+
+### MINC as default on Linux
+
+Deferred: CRC provides a more consistent cross-platform experience; MINC backend not yet implemented.
+
+### kind / k3s only
+
+Rejected: no native Routes, SCCs, or OLM — insufficient for operator-based AAP.
+
+### Single OpenShift preset only
+
+Rejected: full OCP is overkill for most AAP component testing (~96 vs ~10 system pods).
+
+## References
+
+- [environment-comparison.md](../environment-comparison.md)
+- [includes/infra-api.sh](../../includes/infra-api.sh)
+- [includes/infra-crc.sh](../../includes/infra-crc.sh)
+- [includes/crc-create.sh](../../includes/crc-create.sh)
+- [ADR-001](001-project-cli-architecture.md)

--- a/docs/adr/004-portal-helm-addon.md
+++ b/docs/adr/004-portal-helm-addon.md
@@ -1,7 +1,7 @@
 # ADR-004: Portal Helm Addon Architecture
 
 **Status:** Accepted
-**Date:** 2026-06-25
+**Date:** 2026-06-26
 **Author:** DevOps Automator Agent
 
 ## Context

--- a/docs/adr/005-olm-on-microshift.md
+++ b/docs/adr/005-olm-on-microshift.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-16
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/005-olm-on-microshift.md
+++ b/docs/adr/005-olm-on-microshift.md
@@ -1,0 +1,116 @@
+# ADR-005: OLM Installation on MicroShift
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+AAP 2.7 ships as an **OLM-managed operator** installed via CatalogSource + Subscription + CSV.
+Full OpenShift includes OLM by default; **MicroShift does not**.
+
+Without OLM, aap-demo cannot:
+
+- Install `ansible-automation-platform-operator` from `registry.redhat.io`
+- Reconcile ClusterServiceVersions and operator pods
+- Use the standard Red Hat operator index
+
+MicroShift also lacks `openshift-marketplace` — CatalogSources must live in the AAP namespace.
+
+## Decision
+
+Install OLM during cluster creation using **`operator-sdk olm install`**, wrapped by `addons/olm/deploy.sh`.
+
+### Installation flow
+
+```text
+aap-demo create
+      │
+      ├─▶ crc start (MicroShift VM)
+      ├─▶ addons/olm/deploy.sh
+      │         ├─ ensure operator-sdk (auto-download v1.38.0 if missing)
+      │         ├─ operator-sdk olm install
+      │         └─ delete operatorhubio-catalog (MicroShift incompatible)
+      └─▶ continue NFS, CoreDNS, metrics-server setup
+```
+
+### operator-sdk bootstrap
+
+If `operator-sdk` is absent, `deploy.sh` downloads the matching OS/arch binary to `~/.local/bin/`
+(or `/usr/local/bin/` with sudo). This removes a manual prerequisite for most users.
+
+### operatorhubio-catalog removal
+
+The default `operatorhubio-catalog` CatalogSource causes pod scheduling issues on MicroShift. It
+is deleted immediately after OLM install:
+
+```bash
+kubectl delete catsrc operatorhubio-catalog -n olm
+```
+
+### Idempotency
+
+If `subscriptions.operators.coreos.com` CRD already exists, the script exits early with "OLM is already installed."
+
+### Timeout tolerance
+
+`operator-sdk olm install` may report timeout while CRDs are actually present. The script checks
+for CRD existence and treats that as success.
+
+### CatalogSource placement
+
+AAP's CatalogSource (`config/olm/catalogsource.yaml`) is created in the **target namespace**
+(`aap-operator` by default), not `openshift-marketplace`:
+
+```yaml
+metadata:
+  name: redhat-operators
+  namespace: aap-operator
+spec:
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.20
+```
+
+Version is overridable via `AAP_OCP_VERSION` to match the cluster's OpenShift version mapping.
+
+## Consequences
+
+### Positive
+
+- AAP operator installs the same way on MicroShift as on production OpenShift
+- OLM install is automated and idempotent
+- operator-sdk auto-install lowers onboarding friction
+
+### Negative
+
+- Adds ~1 minute to cluster create time
+- OLM pods consume cluster resources (~4 pods in `olm` namespace)
+- operator-sdk version pinned in deploy script — must be updated deliberately
+- Full CRC OpenShift preset includes OLM but aap-demo still documents the addon for consistency
+
+### Neutral
+
+- OLM uninstall on `destroy` relies on namespace deletion or `operator-sdk olm uninstall`
+- Bundle unpack jobs require `privileged` SCC (see ADR-012)
+
+## Alternatives Considered
+
+### Manual operator install without OLM
+
+Rejected: unsupported by Red Hat; bypasses CSV lifecycle and upgrade paths.
+
+### Embedded OLM manifests in repo
+
+Rejected: `operator-sdk olm install` is the maintained upstream path and handles version compatibility.
+
+### Keep operatorhubio-catalog
+
+Rejected: causes known pod failures on MicroShift; no AAP dependency on community catalog.
+
+## References
+
+- [addons/olm/deploy.sh](../../addons/olm/deploy.sh)
+- [config/olm/catalogsource.yaml](../../config/olm/catalogsource.yaml)
+- [config/olm/subscription.yaml](../../config/olm/subscription.yaml)
+- [ADR-009](009-aap-operator-olm-deployment.md)

--- a/docs/adr/006-storage-architecture.md
+++ b/docs/adr/006-storage-architecture.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/006-storage-architecture.md
+++ b/docs/adr/006-storage-architecture.md
@@ -1,0 +1,106 @@
+# ADR-006: Storage Architecture
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+AAP components have distinct storage needs:
+
+| Component | Access mode | Typical size |
+|-----------|-------------|--------------|
+| Controller (AWX) | RWO | 5–10 GiB |
+| Hub (file storage) | **RWX** required for multi-replica sync | 5+ GiB |
+| PostgreSQL | RWO | Operator-managed |
+| EDA | RWO | Operator-managed |
+
+MicroShift on CRC uses **LVMS** (`topolvm-provisioner`) for RWO volumes. Hub file storage
+requires **ReadWriteMany**, which LVMS does not provide.
+
+## Decision
+
+Deploy an **in-cluster NFS server** with the NFS Subdir External Provisioner to expose
+`nfs-local-rwx` StorageClass on CRC/MicroShift. Use **local-path provisioner** as the default
+RWO class where LVMS is unavailable (documented MINC path).
+
+### CRC/MicroShift stack
+
+```text
+nfs-storage namespace
+  ├── nfs-server pod (privileged SCC)
+  └── nfs-provisioner (external-provisioner)
+           │
+           ▼
+    StorageClass: nfs-local-rwx (Retain, RWX)
+```
+
+Manifests: `config/manifests/nfs-server.yaml`, `config/manifests/nfs-provisioner.yaml`
+
+NFS server IP uses `__NFS_SERVER_IP__` placeholder resolved at deploy time from the NFS Service ClusterIP.
+
+### AAP CR storage binding
+
+`config/crs/aap-minimal.yaml` configures Hub file storage explicitly:
+
+```yaml
+hub:
+  file_storage_storage_class: nfs-local-rwx
+  file_storage_access_mode: ReadWriteMany
+```
+
+Deploy logic falls back to RWO when `nfs-local-rwx` is absent (warns in output).
+
+### LVMS PV reservation
+
+`CRC_PV_SIZE` (default 70 GiB) reserves disk for LVMS-provisioned PVCs inside the CRC VM, separate from NFS-backed RWX volumes.
+
+### local-path (MINC / fallback)
+
+`config/manifests/local-path-provisioner.yaml` deploys Rancher local-path-provisioner for
+clusters without LVMS. Provides RWO only — Hub RWX requires NFS or an alternative RWX
+provisioner.
+
+## Consequences
+
+### Positive
+
+- Hub file storage works with RWX on single-node MicroShift
+- NFS is self-contained — no external NAS dependency
+- StorageClass name (`nfs-local-rwx`) is stable across docs and CRs
+- Deploy adapts when RWX is unavailable (degraded but functional)
+
+### Negative
+
+- NFS server requires `privileged` SCC — security tradeoff for local dev
+- In-cluster NFS is not HA — acceptable for demo, not production
+- NFS adds pods and memory overhead in `nfs-storage` namespace
+- `__NFS_SERVER_IP__` substitution adds deploy-time complexity
+
+### Neutral
+
+- Production OpenShift uses enterprise storage (ODF, NFS, cloud RWX); aap-demo pattern is dev-only
+- PVC binding checked by `aap-demo diagnose`
+
+## Alternatives Considered
+
+### Hub on RWO only
+
+Rejected: breaks multi-pod Hub scenarios and diverges from supported AAP configs.
+
+### HostPath RWX
+
+Rejected: not portable across CRC restarts; SCC and path management fragile.
+
+### External cloud RWX (EFS, Azure Files)
+
+Rejected: adds cloud dependency; unsuitable for offline local dev.
+
+## References
+
+- [config/manifests/nfs-provisioner.yaml](../../config/manifests/nfs-provisioner.yaml)
+- [config/manifests/nfs-server.yaml](../../config/manifests/nfs-server.yaml)
+- [config/crs/aap-minimal.yaml](../../config/crs/aap-minimal.yaml)
+- [ADR-012](012-scc-and-pod-security.md) — privileged SCC for NFS

--- a/docs/adr/007-coredns-route-resolution.md
+++ b/docs/adr/007-coredns-route-resolution.md
@@ -78,7 +78,7 @@ CoreDNS fixes general in-cluster DNS; OAuth-specific workarounds address TLS and
 ### Neutral
 
 - External (browser) traffic still uses nip.io → 127.0.0.1 — unchanged
-- Ingress CA trust is separate (see ADR-010 / `ingress-ca-trust.sh`)
+- Ingress CA trust is separate (see ADR-015 / `ingress-ca-trust.sh`)
 
 ## Alternatives Considered
 

--- a/docs/adr/007-coredns-route-resolution.md
+++ b/docs/adr/007-coredns-route-resolution.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-15
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/007-coredns-route-resolution.md
+++ b/docs/adr/007-coredns-route-resolution.md
@@ -1,0 +1,102 @@
+# ADR-007: CoreDNS Route Resolution for nip.io
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+OpenShift Routes expose services at hostnames like `aap-aap-operator.apps.127.0.0.1.nip.io`. On developer laptops:
+
+- **Browsers** resolve `*.nip.io` via public DNS to `127.0.0.1` — routes work without `/etc/hosts`
+- **Pods inside the cluster** also resolve `*.nip.io` via upstream DNS to `127.0.0.1` — wrong
+  inside the pod network
+
+Symptoms without a fix:
+
+- OAuth token exchange fails (portal, MCP)
+- Pod-to-AAP API calls timeout
+- Catalog sync and webhook callbacks break
+
+MicroShift lacks `ingresses.config.openshift.io`; route domains use `apps.<baseDomain>`
+(e.g., `apps.crc.testing` or custom `127.0.0.1.nip.io`).
+
+## Decision
+
+Patch the cluster CoreDNS ConfigMap (`dns-default` in `openshift-dns`) to **rewrite nip.io
+route hostnames to the ingress router Service** using the CoreDNS `rewrite` plugin.
+
+### Implementation
+
+`includes/crc-create.sh` → `configure_coredns()`:
+
+1. Wait for `router-internal-default` Service in `openshift-ingress`
+2. Detect route domain from MicroShift config (`apps.crc.testing` or custom)
+3. Patch CoreDNS Corefile with:
+
+```text
+rewrite stop {
+    name regex (.*)\.apps\.<domain> router-internal-default.openshift-ingress.svc.cluster.local
+    answer auto
+}
+```
+
+1. Re-apply on `aap-demo start` — router ClusterIP can change after CRC restarts
+
+### Why not static manifests?
+
+`config/manifests/coredns-config.yaml` is documentation only. The router ClusterIP is
+**dynamic** and unknown until the cluster runs; a runtime patch is required.
+
+### MicroShift OAuth companion fixes
+
+Some addons (portal, ADR-002) additionally use:
+
+- `hostAliases` mapping route hostname → AAP Service ClusterIP
+- `AAP_HOST_URL` as `http://` for in-cluster token exchange
+- `checkSSL: false` in Backstage auth providers
+
+CoreDNS fixes general in-cluster DNS; OAuth-specific workarounds address TLS and nip.io edge cases.
+
+## Consequences
+
+### Positive
+
+- Pods resolve route hostnames to the ingress router — standard OpenShift ingress path
+- No `/etc/hosts` editing on developer machines
+- `aap-demo start` re-applies config after stale router IP issues
+- `diagnose` can detect DNS misconfiguration
+
+### Negative
+
+- CoreDNS patch is fragile across OpenShift version upgrades (Corefile schema changes)
+- Must re-run after CRC stop/start if router IP changes
+- Custom route domains require matching regex in rewrite rule
+
+### Neutral
+
+- External (browser) traffic still uses nip.io → 127.0.0.1 — unchanged
+- Ingress CA trust is separate (see ADR-010 / `ingress-ca-trust.sh`)
+
+## Alternatives Considered
+
+### /etc/hosts in every pod
+
+Rejected: not maintainable; breaks on route changes.
+
+### Use in-cluster Service DNS only
+
+Rejected: OAuth redirects and external URLs require route hostnames reachable from browsers.
+
+### Disable nip.io; use crc.testing only
+
+Rejected: nip.io is widely documented in aap-demo; CRC testing domain varies by preset.
+
+## References
+
+- [includes/crc-create.sh](../../includes/crc-create.sh) — `configure_coredns()`
+- [config/manifests/coredns-config.yaml](../../config/manifests/coredns-config.yaml) — documentation placeholder
+- [ADR-002](002-portal-helm-deployment.md) — MicroShift OAuth host alias
+- Skill troubleshooting: DNS resolution failures → `aap-demo start`

--- a/docs/adr/008-addon-system.md
+++ b/docs/adr/008-addon-system.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/008-addon-system.md
+++ b/docs/adr/008-addon-system.md
@@ -1,0 +1,119 @@
+# ADR-008: Addon System Architecture
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+Core aap-demo delivers AAP on MicroShift. Optional capabilities — portal, MCP server,
+in-cluster registry, DevSpaces, console — should be:
+
+- Opt-in (not installed by default)
+- Independently deployable and removable
+- Discoverable via `aap-demo enable` without bloating the main script
+
+## Decision
+
+Implement addons as **self-contained directories** under `addons/<name>/` with a standard `deploy.sh` contract.
+
+### Directory contract
+
+```text
+addons/<addon>/
+├── deploy.sh          # Required: deploy and --delete
+├── *.yaml             # Optional: Kubernetes manifests
+├── values.yaml.template  # Optional: Helm values (portal)
+└── README.md          # Optional: operator documentation
+```
+
+### deploy.sh interface
+
+| Invocation | Behavior |
+|------------|----------|
+| `./deploy.sh` | Install or upgrade addon |
+| `./deploy.sh --delete` | Remove addon resources |
+
+Optional header comment for prerequisites:
+
+```bash
+# ADDON_REQUIRES_AAP=true
+```
+
+### CLI integration
+
+`aap-demo.sh` maintains `AVAILABLE_ADDONS` and dispatches:
+
+```text
+aap-demo enable <addon>  →  bash addons/<addon>/deploy.sh
+aap-demo disable <addon> →  bash addons/<addon>/deploy.sh --delete
+aap-demo status <addon>  →  built-in case per addon (routes, pods)
+```
+
+Current first-class addons in `AVAILABLE_ADDONS`:
+
+| Addon | Requires AAP | Mechanism |
+|-------|--------------|-----------|
+| `mcp-server` | Yes | AnsibleMCPServer CR |
+| `portal` | Yes | Helm chart |
+
+Additional addons invoked via `enable` but not in `AVAILABLE_ADDONS` list:
+
+| Addon | Mechanism |
+|-------|-----------|
+| `olm` | operator-sdk (called from create, not user-facing enable) |
+| `registry` | Namespace + Deployment |
+| `console` | OpenShift console (OpenShift preset or manifest) |
+| `devspaces` | CheCluster CR |
+| `prometheus` | Monitoring stack |
+
+### Design rules
+
+1. Addons **must not** modify core AAP CR unless documented
+2. Addons use `NAMESPACE` env var when AAP-scoped
+3. Addons check `kubectl cluster-info` before applying resources
+4. Idempotent: re-enable upgrades in place
+5. `--delete` cleans up cluster resources; user-local state (e.g., `~/.aap-demo/portal/`) documented per addon
+
+## Consequences
+
+### Positive
+
+- New addons added without restructuring `aap-demo.sh` — one line in `AVAILABLE_ADDONS` + status case
+- Each addon is testable in isolation
+- Users install only what they need
+- Portal complexity isolated in `addons/portal/` (see ADR-002, ADR-004)
+
+### Negative
+
+- No formal addon metadata schema (version, dependencies) — convention only
+- `AVAILABLE_ADDONS` list can drift from `addons/` directory contents
+- Status reporting is per-addon switch/case, not auto-discovered
+
+### Neutral
+
+- Windows PowerShell implements subset of addons natively (`mcp-server`); others may delegate to Git Bash or remain Unix-only
+
+## Alternatives Considered
+
+### Subcommands in monolithic script only
+
+Rejected: portal deploy alone is 700+ lines — unmaintainable inline.
+
+### Helm umbrella chart for all addons
+
+Rejected: addons have heterogeneous lifecycles (CR vs Helm vs operator-sdk).
+
+### OLM-managed addon operators
+
+Rejected: overkill for optional dev components.
+
+## References
+
+- [addons/](../../addons/)
+- [ADR-002](002-portal-helm-deployment.md)
+- [ADR-004](004-portal-helm-addon.md)
+- [ADR-011](011-mcp-server-addon.md)
+- [ADR-013](013-in-cluster-registry.md)

--- a/docs/adr/009-aap-operator-olm-deployment.md
+++ b/docs/adr/009-aap-operator-olm-deployment.md
@@ -1,0 +1,119 @@
+# ADR-009: AAP Operator Deployment via OLM
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+AAP 2.7 is distributed as the `ansible-automation-platform-operator` on the Red Hat operator
+index. aap-demo must install the operator and reconcile an `AnsibleAutomationPlatform` CR using
+the same mechanism as customer OpenShift deployments.
+
+Constraints:
+
+- Valid `registry.redhat.io` pull secret required
+- Operator channel must match target AAP version (e.g., `stable-2.7`)
+- Namespace needs SCCs and PSA labels before pods schedule
+- Hub requires RWX storage (ADR-006)
+
+## Decision
+
+Deploy AAP via a **four-step OLM pipeline** triggered by `aap-demo deploy`:
+
+```text
+1. Namespace prep     → SCCs, PSA labels, pull secret copy
+2. CatalogSource      → redhat-operators in target namespace
+3. Subscription       → ansible-automation-platform-operator
+4. AAP CR             → config/crs/aap-minimal.yaml (or variant)
+```
+
+### Manifest templates
+
+| File | Purpose |
+|------|---------|
+| `config/olm/operatorgroup.yaml` | Targets operator to namespace |
+| `config/olm/catalogsource.yaml` | `redhat-operator-index:v4.20` (overridable) |
+| `config/olm/subscription.yaml` | Channel `stable-2.7`, automatic installPlan |
+| `config/crs/aap-minimal.yaml` | Controller + EDA + Hub, nfs-local-rwx for Hub |
+| `config/crs/aap-minimal-noingress.yaml` | Lab/k8s without Routes |
+| `config/crs/aap-controller.yaml` | Controller-only variant |
+
+Runtime substitution replaces namespace placeholders and adjusts Hub storage when `nfs-local-rwx` is missing.
+
+### Namespace preparation
+
+Before Subscription:
+
+```bash
+oc adm policy add-scc-to-group anyuid system:serviceaccounts:<namespace>
+oc adm policy add-scc-to-group privileged system:serviceaccounts:<namespace>
+kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=privileged ...
+```
+
+Pull secret copied/created as `redhat-operators-pull-secret`.
+
+### Deploy modes
+
+| Command | Behavior |
+|---------|----------|
+| `aap-demo deploy` | Operator + AAP CR (full stack) |
+| `aap-demo deploy-operator` | Subscription only |
+| `aap-demo deploy-aap` | AAP CR only (operator must exist) |
+| `CR=controller` | Select alternate CR manifest |
+
+### Controller git safe-directory
+
+`aap-minimal.yaml` sets `GIT_CONFIG_*` env vars and `fsGroup: 996` so AWX project sync works
+on emptyDir volumes — a common local-dev failure mode.
+
+### Reconciliation monitoring
+
+- `aap-demo watch` — polls AAP CR conditions
+- `aap-demo diagnose` — checks CR phase, pod health, PVC binding
+- Expected deploy time: 5–15 minutes depending on preset and hardware
+
+## Consequences
+
+### Positive
+
+- Matches production OpenShift install path — high fidelity
+- Channel pinning enables version-specific testing
+- CR variants support minimal, controller-only, and no-ingress lab setups
+- `idle` patch on AAP CR scales down for resource savings
+
+### Negative
+
+- Requires Red Hat pull secret — barrier for contributors without subscription
+- Catalog index version must align with cluster OCP version mapping
+- Automatic installPlan can pull unexpected CSV if channel moves
+- Bundle unpack needs privileged SCC (OLM internals)
+
+### Neutral
+
+- Operator manages all AAP component lifecycle after CR apply
+- Multiple AAP instances possible via `NAMESPACE` override
+
+## Alternatives Considered
+
+### Direct manifest install without operator
+
+Rejected: unsupported; loses upgrade and reconciliation machinery.
+
+### Ansible installer (aap-setup)
+
+Rejected: different target (RPM/VM installs); not OpenShift-native.
+
+### Pin CSV manually instead of Subscription channel
+
+Rejected: channel subscription is the supported customer path.
+
+## References
+
+- [config/olm/](../../config/olm/)
+- [config/crs/](../../config/crs/)
+- [ADR-005](005-olm-on-microshift.md)
+- [ADR-006](006-storage-architecture.md)
+- [ADR-012](012-scc-and-pod-security.md)

--- a/docs/adr/009-aap-operator-olm-deployment.md
+++ b/docs/adr/009-aap-operator-olm-deployment.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/010-cross-platform-cli.md
+++ b/docs/adr/010-cross-platform-cli.md
@@ -1,0 +1,116 @@
+# ADR-010: Cross-Platform CLI (Bash and PowerShell)
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+aap-demo targets macOS and Linux (bash) and Windows (PowerShell). Windows lacks native bash,
+CRC uses Hyper-V, and path conventions differ (`%USERPROFILE%` vs `$HOME`).
+
+Requirements:
+
+- Same command names and semantics across platforms
+- Windows users should not require WSL for core workflow
+- Ingress TLS must work in browsers on all platforms
+
+## Decision
+
+Maintain **two parallel CLI implementations** sharing behavior but not code:
+
+| Platform | Implementation | Kube CLI |
+|----------|----------------|----------|
+| macOS / Linux | `aap-demo.sh` (bash) | `kubectl` + `oc` |
+| Windows | `powershell/native/*.ps1` | `oc` only |
+
+### Windows architecture
+
+```text
+powershell/aap-demo.ps1
+      │
+      ▼
+AapDemo.psm1
+      ├── Create.ps1    — CRC create, CoreDNS, OLM
+      ├── Deploy.ps1    — OLM, Subscription, AAP CR
+      ├── Status.ps1    — routes, credentials, addons
+      ├── Diagnose.ps1  — health checks (parity with bash)
+      ├── Commands.ps1  — idle, destroy, clean, must-gather
+      └── Helpers.ps1   — oc wrappers, config, SCC grants
+```
+
+`powershell/install.ps1` registers `aap-demo` in `%USERPROFILE%\.local\bin` and installs `oc` via winget when missing.
+
+### Parity scope
+
+| Feature | Bash | PowerShell |
+|---------|------|------------|
+| create, deploy, status | ✓ | ✓ |
+| diagnose | ✓ | ✓ |
+| diagnose --ai | ✓ (claude CLI) | Delegates to Git Bash |
+| enable mcp-server | ✓ | ✓ |
+| enable portal | ✓ | Limited / Git Bash |
+| test, watch | ✓ | Git Bash delegation |
+| ingress CA trust | `ingress-ca-trust.sh` | `Install-AapIngressCaTrust` |
+
+PowerShell uses **native CRC/OpenShift operations** for the critical path; Git Bash is optional for advanced commands.
+
+### Ingress CA trust
+
+MicroShift generates a self-signed ingress CA. Without trust, browsers and `curl` fail TLS validation.
+
+- **macOS**: `security add-trusted-cert` to keychain
+- **Linux**: copy to `/etc/pki/ca-trust/source/anchors/` + `update-ca-trust`
+- **Windows**: `certutil -addstore` via UAC prompt in `aap-demo status`
+
+CA saved to `~/.aap-demo/crc-ingress-ca.crt`; `CURL_CA_BUNDLE` exported for CLI tools.
+
+Skip with `AAP_DEMO_TRUST_CA=false`.
+
+### Configuration parity
+
+Both platforms read `%USERPROFILE%\.aap-demo\config` / `~/.aap-demo/config` with `CRC_PRESET`,
+namespace preferences, and infra type.
+
+## Consequences
+
+### Positive
+
+- Windows developers use PowerShell natively — no WSL required for deploy
+- Ingress CA automation fixes the most common Windows TLS pain point
+- Modular PowerShell files mirror bash command categories
+
+### Negative
+
+- **Dual maintenance** — behavior changes need updates in two codebases
+- Feature parity gaps (portal, test) on Windows without Git Bash
+- Subtle semantic differences risk drift (e.g., SCC grant timing)
+
+### Neutral
+
+- `install.sh` / `install.ps1` are separate but symmetric
+- Shell completions only for bash/zsh today
+
+## Alternatives Considered
+
+### WSL-only on Windows
+
+Rejected: excludes developers who cannot use WSL; Hyper-V conflict concerns.
+
+### Single bash script via Git Bash on Windows
+
+Rejected: poor UX; path and CRC integration awkward.
+
+### Go/Rust rewrite
+
+Deferred: high effort; shell matches target audience (Ansible/OpenShift admins).
+
+## References
+
+- [powershell/README.md](../../powershell/README.md)
+- [includes/ingress-ca-trust.sh](../../includes/ingress-ca-trust.sh)
+- [install.sh](../../install.sh)
+- [powershell/install.ps1](../../powershell/install.ps1)
+- [ADR-001](001-project-cli-architecture.md)

--- a/docs/adr/010-cross-platform-cli.md
+++ b/docs/adr/010-cross-platform-cli.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-15
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/010-cross-platform-cli.md
+++ b/docs/adr/010-cross-platform-cli.md
@@ -69,6 +69,9 @@ CA saved to `~/.aap-demo/crc-ingress-ca.crt`; `CURL_CA_BUNDLE` exported for CLI 
 
 Skip with `AAP_DEMO_TRUST_CA=false`.
 
+See [ADR-015](015-ingress-ca-user-store-trust.md) for the user-store trust strategy
+(Windows CurrentUser, Linux NSS, macOS keychain).
+
 ### Configuration parity
 
 Both platforms read `%USERPROFILE%\.aap-demo\config` / `~/.aap-demo/config` with `CRC_PRESET`,

--- a/docs/adr/011-mcp-server-addon.md
+++ b/docs/adr/011-mcp-server-addon.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/011-mcp-server-addon.md
+++ b/docs/adr/011-mcp-server-addon.md
@@ -1,0 +1,104 @@
+# ADR-011: MCP Server Addon
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+AI assistants and automation tools increasingly interact with AAP via the **Model Context
+Protocol (MCP)**. AAP operator 2.6+ ships an `AnsibleMCPServer` CRD managed by the operator.
+
+aap-demo users need a one-command path to expose MCP tools against their local AAP instance for
+Cursor, Claude Code, and similar clients.
+
+## Decision
+
+Add **`mcp-server` addon** that applies an `AnsibleMCPServer` CR via `addons/mcp-server/deploy.sh`.
+
+### Deployment
+
+```bash
+aap-demo enable mcp-server
+```
+
+Applies `addons/mcp-server/mcp-server.yaml` with namespace and hostname substitution:
+
+| Field | Value |
+|-------|-------|
+| `public_base_url` | `https://aap-<namespace>.apps.127.0.0.1.nip.io` |
+| `hostname` / `route_host` | `aap-mcp-<namespace>.apps.127.0.0.1.nip.io` |
+| `ingress_type` | Route (Edge TLS) |
+| `allow_write_operations` | `true` (dev/test only) |
+
+### Prerequisites
+
+- AAP operator CSV running in target namespace
+- `AnsibleMCPServer` CRD installed (bundled with operator 2.6+)
+- `redhat-operators-pull-secret` for image pulls
+
+Script warns and proceeds if operator or CRD not yet ready — CR reconciles when available.
+
+### AAP interaction policy
+
+The aap-demo skill explicitly **prohibits awxkit** for AAP operations. Preferred order:
+
+1. MCP server tools (when enabled)
+2. `kubectl`/`oc` for operator resources
+3. Direct REST API via `curl`
+4. Ansible modules (last resort)
+
+This ADR positions MCP as the preferred programmatic interface for AI-assisted workflows.
+
+### Endpoint
+
+```text
+https://aap-mcp-<namespace>.apps.127.0.0.1.nip.io/mcp
+```
+
+Documented in [docs/aap-mcp-server.md](../aap-mcp-server.md).
+
+## Consequences
+
+### Positive
+
+- Single CR — operator handles Deployment, Service, Route
+- Enables 100+ typed MCP tools for AI clients
+- Consistent with production AAP MCP architecture
+- PowerShell native support (`Invoke-AapDeployMcpServerAddon`)
+
+### Negative
+
+- `allow_write_operations: true` is unsafe for production — dev-only default
+- Requires operator 2.6+; older channels lack CRD
+- MCP route depends on CoreDNS nip.io fix (ADR-007)
+- Additional pod resources (~512 Mi–1 Gi memory)
+
+### Neutral
+
+- MCP auth follows AAP gateway OAuth/token model
+- Disable removes CR only — operator cleans up child resources
+
+## Alternatives Considered
+
+### Standalone MCP container outside operator
+
+Rejected: duplicates operator logic; diverges from supported deployment.
+
+### awxkit-based CLI bridge
+
+Rejected: dependency conflicts, inconsistent tooling (see skill policy).
+
+### Disable write operations by default
+
+Deferred: reduces usefulness for dev automation; documented as dev-only risk.
+
+## References
+
+- [addons/mcp-server/deploy.sh](../../addons/mcp-server/deploy.sh)
+- [addons/mcp-server/mcp-server.yaml](../../addons/mcp-server/mcp-server.yaml)
+- [docs/aap-mcp-server.md](../aap-mcp-server.md)
+- [ADR-008](008-addon-system.md)
+- [ADR-009](009-aap-operator-olm-deployment.md)

--- a/docs/adr/012-scc-and-pod-security.md
+++ b/docs/adr/012-scc-and-pod-security.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/012-scc-and-pod-security.md
+++ b/docs/adr/012-scc-and-pod-security.md
@@ -1,0 +1,112 @@
+# ADR-012: Security Context Constraints and Pod Security
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+OpenShift enforces **Security Context Constraints (SCCs)** and **Pod Security Admission (PSA)**
+labels. AAP operator workloads, OLM bundle unpack jobs, NFS, and portal pods require elevated
+permissions beyond the `restricted` default.
+
+MicroShift applies SCCs like full OpenShift but runs on a single node with no separate worker
+pool — misconfiguration blocks entire deploy.
+
+## Decision
+
+Grant SCCs at the **namespace ServiceAccount group level** and set namespace PSA labels to
+**`privileged`** for AAP and addon namespaces.
+
+### AAP namespace (default `aap-operator`)
+
+Applied during `aap-demo deploy`:
+
+```bash
+oc adm policy add-scc-to-group anyuid system:serviceaccounts:<namespace>
+oc adm policy add-scc-to-group privileged system:serviceaccounts:<namespace>
+
+kubectl label namespace <namespace> \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/audit=privileged \
+  pod-security.kubernetes.io/warn=privileged
+```
+
+**Rationale:**
+
+| SCC | Needed for |
+|-----|------------|
+| `anyuid` | AAP components running as non-root UIDs not in default range |
+| `privileged` | OLM bundle unpack (seccomp annotations), some init containers |
+
+### NFS namespace (`nfs-storage`)
+
+```bash
+oc adm policy add-scc-to-group privileged system:serviceaccounts:nfs-storage
+```
+
+NFS server pod requires privileged mount capabilities.
+
+### Portal namespace (`redhat-rhaap-portal`)
+
+Same `anyuid` + `privileged` group grants and PSA labels as AAP namespace (ADR-004).
+
+### Registry namespace
+
+`clusterrolebinding` for `anyuid` on registry ServiceAccount (in-cluster registry pushes).
+
+### Diagnostics
+
+`aap-demo diagnose` verifies:
+
+- Both SCC rolebindings exist for target namespace
+- PSA `enforce=privileged` label present
+- Outputs fix commands when missing
+
+### sysctl tuning
+
+CRC VM configures elevated `inotify` limits (`max_user_instances`, `max_user_watches`) —
+critical for operator performance on constrained VMs. Applied via SSH during create.
+
+## Consequences
+
+### Positive
+
+- AAP operator pods schedule reliably on MicroShift
+- OLM CSV install completes (bundle unpack succeeds)
+- NFS and portal addons work without per-SA SCC patches
+- Diagnose catches most SCC/PSA misconfigurations early
+
+### Negative
+
+- `privileged` PSA is inappropriate for production multitenant clusters — **dev-only pattern**
+- Broad group-level SCC grants are coarser than per-ServiceAccount bindings
+- Security scanners will flag these namespaces
+
+### Neutral
+
+- Production OpenShift uses namespace-specific SCC strategies tuned by admins
+- SCC grants persist until explicitly removed
+
+## Alternatives Considered
+
+### Per-ServiceAccount SCC only
+
+Rejected: operator creates many SAs dynamically; group-level is maintainable for demo.
+
+### Custom SCC with minimal caps
+
+Rejected: high effort; operator and OLM expect standard SCCs.
+
+### Disable PSA labels
+
+Rejected: enforcement would still block pods on newer OpenShift/MicroShift.
+
+## References
+
+- [aap-demo skill](../../.claude/skills/aap-demo/SKILL.md) — Known Fixes table
+- [ADR-006](006-storage-architecture.md) — NFS privileged
+- [ADR-009](009-aap-operator-olm-deployment.md) — namespace prep
+- [ADR-004](004-portal-helm-addon.md) — portal SCCs

--- a/docs/adr/013-in-cluster-registry.md
+++ b/docs/adr/013-in-cluster-registry.md
@@ -1,0 +1,115 @@
+# ADR-013: In-Cluster Container Registry
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+Developers building custom execution environments or testing image workflows need to push images
+and reference them from AAP without external registries. CRC/MicroShift shares **Podman/CRI-O
+storage** with the VM — but in-cluster pods pull via kubelet/CRI-O, not the host Podman socket.
+
+Requirements:
+
+- Push from laptop Podman to a registry pods can pull from
+- HTTPS route for developer ergonomics
+- Insecure/mirror config for local TLS limitations
+
+## Decision
+
+Provide **`registry` addon** deploying a simple in-cluster registry at `addons/registry/`.
+
+### Architecture
+
+```text
+aap-demo enable registry
+      │
+      ▼
+Namespace: aap-demo-registry
+  ├── Deployment: registry (port 5000)
+  ├── Service: ClusterIP
+  └── Route: registry.apps.127.0.0.1.nip.io
+      │
+      ▼
+CRI-O mirror on CRC VM (via SSH):
+  registry.apps.127.0.0.1.nip.io → <ClusterIP>:5000 (insecure)
+```
+
+### CRI-O mirror configuration
+
+After deploy, `deploy.sh` SSHs to CRC VM and writes `/etc/containers/registries.conf.d/999-aap-demo-registry.conf`:
+
+```toml
+[[registry]]
+location = "registry.apps.127.0.0.1.nip.io"
+insecure = true
+[[registry.mirror]]
+location = "<service-cluster-ip>:5000"
+insecure = true
+```
+
+Then `systemctl reload crio`.
+
+### Usage pattern
+
+```bash
+podman tag <image> registry.apps.127.0.0.1.nip.io/<repo>:<tag>
+podman push --tls-verify=false registry.apps.127.0.0.1.nip.io/<repo>:<tag>
+```
+
+Reference in deployments:
+
+```yaml
+image: registry.apps.127.0.0.1.nip.io/<repo>:<tag>
+imagePullPolicy: Always
+```
+
+### Shared storage benefit
+
+On CRC, images loaded into the VM's CRI-O store are visible to pods when tagged through this
+registry — supports rapid iteration without external pushes.
+
+## Consequences
+
+### Positive
+
+- Local image push/pull loop without quay.io or Docker Hub
+- Route hostname follows standard nip.io pattern
+- CRI-O mirror avoids in-cluster TLS verification issues
+- Documented in README architecture section
+
+### Negative
+
+- Insecure registry — dev only
+- SSH-dependent CRI-O config (CRC-specific; no-op without CRC SSH key)
+- No garbage collection or RBAC beyond namespace
+- Registry data lost on namespace delete
+
+### Neutral
+
+- Not enabled by default
+- Production uses enterprise registries (quay, ECR, etc.)
+
+## Alternatives Considered
+
+### Host Podman socket mount into cluster
+
+Rejected: MicroShift/CRI-O isolation prevents direct socket sharing.
+
+### External Docker Registry container on laptop
+
+Rejected: kubelet cannot reach host localhost:5000 without extra networking.
+
+### OpenShift internal registry (image-registry-operator)
+
+Rejected: not available on MicroShift; heavy for demo use case.
+
+## References
+
+- [addons/registry/deploy.sh](../../addons/registry/deploy.sh)
+- [addons/registry/registry.yaml](../../addons/registry/registry.yaml)
+- [ADR-008](008-addon-system.md)
+- [README.md](../../README.md) — shared Podman/CRI-O storage

--- a/docs/adr/013-in-cluster-registry.md
+++ b/docs/adr/013-in-cluster-registry.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-10
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/014-testing-strategy.md
+++ b/docs/adr/014-testing-strategy.md
@@ -1,0 +1,102 @@
+# ADR-014: CLI Testing Strategy
+
+**Status**: Accepted
+
+**Date**: 2026-07-02
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+aap-demo is primarily a shell CLI orchestrating cluster operations. Full integration tests (create → deploy → destroy) are:
+
+- Slow (15–30 minutes)
+- Destructive
+- Require pull secrets, CRC, and significant RAM
+- Impractical in CI for every PR
+
+Contributors still need confidence that argument parsing, help text, and error paths work after changes.
+
+## Decision
+
+Use **non-destructive CLI integration tests** that validate the command surface without requiring a running cluster.
+
+### Test suites
+
+| Script | Scope |
+|--------|-------|
+| `test/test-core-commands.sh` | Subset documented in README |
+| `test/test-aap-demo.sh` | Comprehensive CLI coverage |
+
+### What tests validate
+
+1. **Argument parsing** — env vars (`NAMESPACE`, `QUIET`, `FORCE`), flags (`--ai`, `--reset`, `--context`)
+2. **Help text** — `help`, `-h`, `--help`, welcome banner on no args
+3. **Error handling** — unknown commands, unknown addons, invalid `idle` args
+4. **Non-destructive execution** — `diagnose` runs without cluster; destructive commands grep-checked for warnings only
+5. **Graceful degradation** — commands fail cleanly when cluster absent
+
+### What tests explicitly skip
+
+- Actual `create` / `destroy` / full `deploy` (destructive or slow)
+- Live AAP API operations
+- Network endpoints (in `--quick` mode)
+- Interactive prompts (suppressed via `QUIET=true`)
+
+### CI integration
+
+`.github/workflows/test.yaml` runs test scripts on PRs. `.github/workflows/lint.yaml` runs
+shellcheck, yamllint, ansible-lint, and markdownlint via `lint.mk` / pre-commit.
+
+### Test patterns
+
+```bash
+# Capture output and exit code without side effects
+output=$(_run_aap_demo my-command 2>&1) && rc=0 || rc=$?
+echo "$output" | grep -q "expected string"
+```
+
+Mocking used where commands would touch CRC (e.g., `start`/`stop` delegation checks).
+
+## Consequences
+
+### Positive
+
+- Fast PR feedback (< 1 minute for CLI tests)
+- No pull secret or cluster required in CI
+- Documents expected CLI behavior in executable form
+- `--quick` and `--verbose` modes for local dev
+
+### Negative
+
+- Does not catch regressions in actual OpenShift deploy logic
+- grep-based assertions brittle to wording changes
+- Bash tests don't cover PowerShell implementation (ADR-010 gap)
+- Cluster-state-dependent commands behave differently when CRC exists
+
+### Neutral
+
+- Manual testing still required for release validation
+- `aap-demo test` (ATF) is separate — requires deployed AAP and VPN for internal collections
+
+## Alternatives Considered
+
+### Full E2E in CI with CRC
+
+Rejected: resource cost, pull secret management, and 30+ minute runs.
+
+### Pure unit tests (bats with heavy mocking)
+
+Rejected: mock maintenance cost high for monolithic bash script.
+
+### No automated tests
+
+Rejected: CLI regressions are common with argument parsing changes.
+
+## References
+
+- [test/README.md](../../test/README.md)
+- [test/test-core-commands.sh](../../test/test-core-commands.sh)
+- [.github/workflows/test.yaml](../../.github/workflows/test.yaml)
+- [ADR-001](001-project-cli-architecture.md)
+- [ADR-010](010-cross-platform-cli.md)

--- a/docs/adr/014-testing-strategy.md
+++ b/docs/adr/014-testing-strategy.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 
-**Date**: 2026-07-02
+**Date**: 2026-06-12
 
 **Authors**: aap-demo maintainers
 

--- a/docs/adr/015-ingress-ca-user-store-trust.md
+++ b/docs/adr/015-ingress-ca-user-store-trust.md
@@ -1,0 +1,188 @@
+# ADR-015: Ingress CA Trust via User Certificate Stores
+
+**Status**: Accepted
+
+**Date**: 2026-06-22
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+MicroShift generates a self-signed **ingress CA** for OpenShift Routes (e.g.
+`https://aap-aap-operator.apps.127.0.0.1.nip.io`). Without trusting that CA,
+browsers show certificate warnings and CLI tools fail TLS validation.
+
+Requirements:
+
+- Trust must be **automatic** during normal workflow (`create`, `deploy`, `status`)
+- Import should **not require Administrator** when possible — corporate laptops often
+  block UAC elevation
+- **Chrome and Edge on Windows** read the **Local Machine** root store, not only
+  Current User — both stores may be needed
+- **Chrome and Firefox on Linux** use **NSS databases** in the user home directory,
+  not the system `ca-trust` store
+- The CA PEM must be **saved locally** so curl and other tools can use
+  `CURL_CA_BUNDLE` / `SSL_CERT_FILE` without re-fetching from the cluster
+- Cluster recreate issues a **new CA** — stale certificates must be removed before re-import
+
+ADR-010 documents cross-platform CLI parity at a high level. This ADR records the
+**user-store trust strategy** and how it differs by platform.
+
+## Decision
+
+Implement a **tiered trust model**: import the ingress CA into **user-scoped
+certificate stores first**, then attempt **system-scoped stores** when admin
+access is available. Always persist the CA to `~/.aap-demo/crc-ingress-ca.crt`.
+
+### CA source and persistence
+
+1. SSH to the CRC VM (`core@127.0.0.1:2222`) and read
+   `/var/lib/microshift/certs/ingress-ca/ca.crt`
+2. Save to `~/.aap-demo/crc-ingress-ca.crt` (Windows: `%USERPROFILE%\.aap-demo\`)
+3. Export `CURL_CA_BUNDLE` and `SSL_CERT_FILE` pointing at the saved file
+
+If fetch fails but a previously saved PEM exists, import from the saved copy.
+
+Skip all automatic import when `AAP_DEMO_TRUST_CA=false`.
+
+### Windows — Current User root store (primary user store)
+
+`powershell/native/Private/Helpers.ps1` → `Import-AapIngressCaCertificate`:
+
+1. Compute SHA-1 thumbprint; skip if already in **LocalMachine** Root
+2. Remove stale `CN=ingress-ca` entries from **CurrentUser** and **LocalMachine** Root
+3. Import to **CurrentUser → Trusted Root Certification Authorities**:
+   - Primary: .NET `X509Store('Root', 'CurrentUser')` with `ReadWrite` + `Add()`
+   - Fallback: `certutil -user -addstore Root <path>`
+4. If running as Administrator, import to **LocalMachine** Root via `certutil`
+5. If not elevated, prompt UAC via `Start-Process certutil -Verb RunAs` for
+   **LocalMachine** import (required for Chrome/Edge)
+
+User-store import **never requires elevation**. System-store import is best-effort
+with UAC; failures emit warnings but do not abort `status`.
+
+### Linux — NSS user databases (browser user store)
+
+`includes/ingress-ca-trust.sh` → `_import_ingress_ca_nss`:
+
+Chrome/Chromium and Firefox trust CAs in **NSS databases**, not system
+`ca-trust`:
+
+| Path | When used |
+|------|-----------|
+| `~/.pki/nssdb` | Default; created if missing |
+| `~/.local/share/pki/nssdb` | Chromium M146+ when `.pki/nssdb` absent |
+
+Import via `certutil`:
+
+```bash
+certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n crc-ingress-ca -i <ca-path>
+```
+
+Nickname `crc-ingress-ca` is used for idempotency checks (`certutil -L`).
+Existing entries with the same nickname are deleted before re-import.
+
+Requires `nss-tools` package (`certutil`). Without it, system trust may work for
+curl but browsers remain untrusted.
+
+### Linux — system trust (requires sudo, not user store)
+
+After user-store NSS import, also attempt system trust for CLI tools:
+
+- RHEL/Fedora: `/etc/pki/ca-trust/source/anchors/crc-ingress-ca.crt` +
+  `update-ca-trust`
+- Debian/Ubuntu: `/usr/local/share/ca-certificates/crc-ingress-ca.crt` +
+  `update-ca-certificates`
+
+### macOS — system keychain (no separate user-store path)
+
+macOS uses a single **System keychain** import via
+`security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain`.
+This requires `sudo` (admin password), not a user-only store. Stale `ingress-ca`
+entries are deleted before re-import.
+
+Fingerprint comparison uses the installed system certificate vs the fetched PEM
+to detect cluster recreate.
+
+### Idempotency and trigger points
+
+Trust is considered complete when:
+
+- **Windows**: thumbprint present in LocalMachine Root (preferred) or CurrentUser Root
+- **Linux**: fingerprint matches in system anchors **and** NSS nickname present in
+  all detected NSS DBs
+- **macOS**: matching fingerprint in System keychain
+
+`install_ingress_ca_trust` / `Install-AapIngressCaTrust` runs from:
+
+- `create` (end of cluster setup)
+- `deploy`
+- `status`
+
+When already trusted, commands stay silent. Import failures are warnings only —
+`status` never aborts.
+
+### Implementation map
+
+| Platform | User store | System store | Module |
+|----------|------------|--------------|--------|
+| Windows | CurrentUser Root | LocalMachine Root (UAC) | `Helpers.ps1` |
+| Linux | NSS (`~/.pki/nssdb`, etc.) | ca-trust / ca-certificates (sudo) | `ingress-ca-trust.sh` |
+| macOS | — | System keychain (sudo) | `ingress-ca-trust.sh` |
+
+## Consequences
+
+### Positive
+
+- Windows developers get TLS working for PowerShell/.NET without admin rights
+  (CurrentUser store)
+- Linux Chrome/Firefox trust via NSS without sudo when `nss-tools` is installed
+- Saved PEM + env vars give curl/openssl a reliable CA bundle independent of OS stores
+- Stale CA cleanup prevents trust mismatches after cluster recreate
+- Opt-out via `AAP_DEMO_TRUST_CA=false` for locked-down environments
+
+### Negative
+
+- **Windows Chrome/Edge still need LocalMachine** — user store alone is insufficient;
+  UAC prompt is a recurring friction point
+- **Dual stores on Linux** — system ca-trust and NSS must both be updated for full coverage
+- **macOS always needs sudo** — no user-only path
+- NSS/Chromium path changes (e.g. M146 `.local/share/pki/nssdb`) require maintenance
+- Corporate policies blocking UAC or cert import leave browsers untrusted despite warnings
+
+### Neutral
+
+- Ingress CA trust is orthogonal to CoreDNS nip.io resolution (ADR-007)
+- mkcert for other local certs is separate (`aap-demo.sh` preflight messaging)
+- Windows `curl.exe` may still need `--ssl-no-revoke` for Schannel revocation checks
+
+## Alternatives Considered
+
+### System store only (skip user store)
+
+Rejected on Windows: requires Administrator for every developer; blocks locked-down laptops.
+
+### User store only (skip system store)
+
+Rejected on Windows: Chrome and Edge ignore CurrentUser Root for HTTPS validation.
+
+### Browser-specific installers (Chrome policy, Firefox policies.json)
+
+Rejected: too invasive; requires admin or enterprise policy; poor portability.
+
+### Manual trust instructions only
+
+Rejected: highest support burden; TLS is the most common Windows onboarding failure.
+
+### mkcert for ingress CA
+
+Rejected: MicroShift owns ingress certificate lifecycle; replacing it would fight the platform.
+
+## References
+
+- [includes/ingress-ca-trust.sh](../../includes/ingress-ca-trust.sh) — bash/Linux/macOS implementation
+- [powershell/native/Private/Helpers.ps1](../../powershell/native/Private/Helpers.ps1) —
+  `Import-AapIngressCaCertificate`, `Install-AapIngressCaTrust`
+- [powershell/README.md](../../powershell/README.md) — Windows troubleshooting (UAC, Chrome HSTS)
+- [ADR-007](007-coredns-route-resolution.md) — route DNS (separate from TLS trust)
+- [ADR-010](010-cross-platform-cli.md) — cross-platform CLI parity overview

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,7 @@ We use a simplified ADR format based on [Michael Nygard's template](https://cogn
 | [012](012-scc-and-pod-security.md) | Security Context Constraints and Pod Security | Accepted |
 | [013](013-in-cluster-registry.md) | In-Cluster Container Registry | Accepted |
 | [014](014-testing-strategy.md) | CLI Testing Strategy | Accepted |
+| [015](015-ingress-ca-user-store-trust.md) | Ingress CA Trust via User Certificate Stores | Accepted |
 
 ## Creating a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,12 +18,42 @@ We use a simplified ADR format based on [Michael Nygard's template](https://cogn
 - **Decision**: What is the change we're proposing/doing?
 - **Consequences**: What becomes easier or more difficult because of this change?
 
+## Architecture Overview
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│  aap-demo CLI (bash / PowerShell)                                       │
+│    create │ deploy │ status │ diagnose │ enable <addon> │ destroy       │
+└───────────────────────────────┬─────────────────────────────────────────┘
+                                │
+        ┌───────────────────────┼───────────────────────┐
+        ▼                       ▼                       ▼
+  CRC / MicroShift          OLM + Operator           Addons
+  (ADR-003)                 (ADR-005, 009)          (ADR-008)
+        │                       │                       │
+        ├─ NFS RWX (006)        ├─ AAP CR              ├─ portal (002, 004)
+        ├─ CoreDNS (007)        └─ SCC/PSA (012)       ├─ mcp-server (011)
+        └─ Registry (013)                              └─ registry (013)
+```
+
 ## Index
 
 | ADR | Title | Status |
 |-----|-------|--------|
+| [001](001-project-cli-architecture.md) | Project Purpose and CLI Architecture | Accepted |
 | [002](002-portal-helm-deployment.md) | Portal Helm Deployment Architecture (x86 and ARM) | Accepted |
+| [003](003-infrastructure-backend-selection.md) | Infrastructure Backend Selection | Accepted |
 | [004](004-portal-helm-addon.md) | Portal Helm Addon Architecture | Accepted |
+| [005](005-olm-on-microshift.md) | OLM Installation on MicroShift | Accepted |
+| [006](006-storage-architecture.md) | Storage Architecture | Accepted |
+| [007](007-coredns-route-resolution.md) | CoreDNS Route Resolution for nip.io | Accepted |
+| [008](008-addon-system.md) | Addon System Architecture | Accepted |
+| [009](009-aap-operator-olm-deployment.md) | AAP Operator Deployment via OLM | Accepted |
+| [010](010-cross-platform-cli.md) | Cross-Platform CLI (Bash and PowerShell) | Accepted |
+| [011](011-mcp-server-addon.md) | MCP Server Addon | Accepted |
+| [012](012-scc-and-pod-security.md) | Security Context Constraints and Pod Security | Accepted |
+| [013](013-in-cluster-registry.md) | In-Cluster Container Registry | Accepted |
+| [014](014-testing-strategy.md) | CLI Testing Strategy | Accepted |
 
 ## Creating a New ADR
 
@@ -34,3 +64,15 @@ We use a simplified ADR format based on [Michael Nygard's template](https://cogn
 5. Commit with message: `docs(adr): Add ADR-XXX: Title`
 
 Note: Numbers may not be sequential; gaps indicate removed or consolidated drafts.
+
+## Reading Order
+
+For new contributors, read ADRs in this order:
+
+1. **001** — what aap-demo is and how the CLI is structured
+2. **003** — why CRC MicroShift is the default backend
+3. **005** + **009** — how AAP gets installed
+4. **006** + **007** + **012** — common deploy failure areas
+5. **008** — how optional components plug in
+6. **002** + **004** — portal (if using Self-Service Portal)
+7. **010** + **014** — Windows and testing


### PR DESCRIPTION
## Summary

- Adds 12 new ADRs (001, 003, 005–014) documenting core aap-demo architecture: CLI design, CRC/MicroShift backend, OLM, storage, CoreDNS, addons, AAP operator deployment, cross-platform CLI, MCP server, SCC/PSA, in-cluster registry, and testing strategy
- Updates `docs/adr/README.md` with a full index, architecture overview diagram, and suggested reading order for new contributors
- Links the main README Architecture section to the ADR index

## Test plan

- [x] `markdownlint` passes on all ADR files and README (pre-commit hook)
- [x] ADR index links resolve to all new files
- [ ] Review ADR content for technical accuracy against current codebase

Made with [Cursor](https://cursor.com)