### PR TITLE
feat: add console.redhat.com and PAH authentication for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ aap-demo deploys Ansible Automation Platform 2.7 to OpenShift Local (MicroShift)
 
 aap-demo automatically configures Ansible Galaxy authentication for downloading certified and private collections:
 
-- **Red Hat Certified Collections**: Configure offline token from [console.redhat.com](https://console.redhat.com/ansible/automation-hub/token) in `~/.aap-demo/galaxy-token`
+- **Red Hat Certified Collections**: Offline token from console.redhat.com in `~/.aap-demo/galaxy-token`
 - **Private Automation Hub**: Configure URL and credentials in `~/.aap-demo/pah-config.yml`
 - **Priority-based fallback**: PAH → console.redhat.com → galaxy.ansible.com (community)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ aap-demo deploys Ansible Automation Platform 2.7 to OpenShift Local (MicroShift)
 - Addon system: `aap-demo enable mcp-server`
 - Reproducible — destroy and recreate in minutes
 
+## Collection Authentication
+
+aap-demo automatically configures Ansible Galaxy authentication for downloading certified and private collections:
+
+- **Red Hat Certified Collections**: Configure offline token from [console.redhat.com](https://console.redhat.com/ansible/automation-hub/token) in `~/.aap-demo/galaxy-token`
+- **Private Automation Hub**: Configure URL and credentials in `~/.aap-demo/pah-config.yml`
+- **Priority-based fallback**: PAH → console.redhat.com → galaxy.ansible.com (community)
+
+Collections are installed automatically during deployment from `config/requirements.yml`. Skip with `SKIP_COLLECTIONS=true`.
+
+**Status**: View configured sources with `aap-demo status`
+**Diagnostics**: Validate authentication with `aap-demo diagnose`
+**Documentation**: See [docs/collection-authentication.md](docs/collection-authentication.md)
+
 ## Quick Start
 
 ### Prerequisites

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2029,7 +2029,7 @@ detect_galaxy_credentials() {
 
 validate_galaxy_token() {
   if [ -z "$GALAXY_TOKEN" ]; then
-    return 0  # Not configured, skip validation
+    return 0 # Not configured, skip validation
   fi
 
   # Check token format (offline tokens are typically 1500+ chars)
@@ -2054,7 +2054,7 @@ validate_galaxy_token() {
 
 validate_pah_config() {
   if [ -z "$PAH_URL" ]; then
-    return 0  # Not configured, skip validation
+    return 0 # Not configured, skip validation
   fi
 
   # Check URL format
@@ -2091,7 +2091,7 @@ generate_ansible_cfg() {
   galaxy_servers="${galaxy_servers%,}"
 
   # Generate ansible.cfg with [galaxy] section
-  cat > "$cfg_file" <<'EOF'
+  cat >"$cfg_file" <<'EOF'
 [defaults]
 roles_path = ./ansible/roles
 inventory = ./ansible/inventory/localhost.yml
@@ -2103,7 +2103,7 @@ fact_caching_timeout = 3600
 EOF
 
   # Add galaxy configuration
-  cat >> "$cfg_file" <<EOF
+  cat >>"$cfg_file" <<EOF
 [galaxy]
 server_list = ${galaxy_servers}
 
@@ -2111,18 +2111,18 @@ EOF
 
   # Append PAH server configuration
   if [ -n "$PAH_URL" ]; then
-    cat >> "$cfg_file" <<EOF
+    cat >>"$cfg_file" <<EOF
 [galaxy_server.pah]
 url = ${PAH_URL}
 EOF
 
     if [ -n "$PAH_TOKEN" ]; then
-      cat >> "$cfg_file" <<EOF
+      cat >>"$cfg_file" <<EOF
 token = ${PAH_TOKEN}
 
 EOF
     elif [ -n "$PAH_USER" ] && [ -n "$PAH_PASS" ]; then
-      cat >> "$cfg_file" <<EOF
+      cat >>"$cfg_file" <<EOF
 username = ${PAH_USER}
 password = ${PAH_PASS}
 
@@ -2132,7 +2132,7 @@ EOF
 
   # Append console.redhat.com server configuration
   if [ -n "$GALAXY_TOKEN" ]; then
-    cat >> "$cfg_file" <<EOF
+    cat >>"$cfg_file" <<EOF
 [galaxy_server.console]
 url = https://console.redhat.com/api/automation-hub/content/published/
 token = ${GALAXY_TOKEN}
@@ -2141,7 +2141,7 @@ EOF
   fi
 
   # Append community galaxy server
-  cat >> "$cfg_file" <<'EOF'
+  cat >>"$cfg_file" <<'EOF'
 [galaxy_server.community]
 url = https://galaxy.ansible.com/
 
@@ -2283,7 +2283,6 @@ configure_pah_remotes() {
       echo "✓ (background)"
     fi
 
-
     # Create and configure rh-validated remote
     printf "  Configuring rh-validated remote... "
 
@@ -2380,7 +2379,6 @@ cmd_setup() {
   echo "CRC setup is handled during 'aap-demo create'"
 }
 
-
 cmd_setup_pah() {
   echo "Setting up Private Automation Hub..."
   echo ""
@@ -2395,13 +2393,13 @@ cmd_setup_pah() {
 
     # Open browser
     if command -v open >/dev/null 2>&1; then
-      open "$url"  # macOS
+      open "$url" # macOS
       echo "Opening browser to Red Hat Automation Hub..."
     elif command -v xdg-open >/dev/null 2>&1; then
-      xdg-open "$url"  # Linux
+      xdg-open "$url" # Linux
       echo "Opening browser to Red Hat Automation Hub..."
     elif command -v start >/dev/null 2>&1; then
-      start "$url"  # Windows/Git Bash
+      start "$url" # Windows/Git Bash
       echo "Opening browser to Red Hat Automation Hub..."
     else
       echo "Visit this URL in your browser:"
@@ -2625,7 +2623,6 @@ deploy_latest() {
 
     # Watch deployment
     watch_aap
-
 
     # Remind to configure PAH
     echo ""

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -445,8 +445,8 @@ COMMANDS:
     ssh             SSH into cluster node
     repair          Repair cluster after crash
     setup           Run setup only (storage, coredns, mkcert)
-    setup-auth      Open browser to configure collection authentication
-    check-auth      Validate collection authentication (galaxy token, PAH)
+    setup-auth      Open browser to configure console.redhat.com token
+    check-auth      Validate collection authentication (console.redhat.com, PAH)
     kubeconfig      Extract and merge kubeconfig
     redeploy-all    Destroy cluster and redeploy fresh
 
@@ -2417,6 +2417,21 @@ cmd_check_auth() {
 cmd_setup_auth() {
   echo "Setting up collection authentication..."
   echo ""
+
+  # Check if token already exists
+  if [ -f "$GALAXY_TOKEN_FILE" ]; then
+    echo "✓ Galaxy token already configured at $GALAXY_TOKEN_FILE"
+    echo ""
+    echo "To update the token:"
+    echo "  1. Visit: https://console.redhat.com/ansible/automation-hub/token"
+    echo "  2. Copy the Offline Token"
+    echo "  3. Run: echo \"YOUR_TOKEN\" > $GALAXY_TOKEN_FILE"
+    echo ""
+    echo "Or delete the existing token to reconfigure:"
+    echo "  rm $GALAXY_TOKEN_FILE"
+    echo "  aap-demo setup-auth"
+    return 0
+  fi
 
   local url="https://console.redhat.com/ansible/automation-hub/token"
 

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2209,7 +2209,7 @@ configure_pah_remotes() {
       | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$remote_href" ]; then
-      # Update token
+      # Update existing token
       local task_url
       task_url=$(curl -sk -u "admin:${admin_pass}" \
         -X PATCH \
@@ -2228,9 +2228,27 @@ configure_pah_remotes() {
           [ "$state" = "completed" ] && break
         done
         echo "✓"
+      fi
+    else
+      # Create rh-certified remote
+      local create_result
+      create_result=$(curl -sk -u "admin:${admin_pass}" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"name\": \"rh-certified\",
+          \"url\": \"https://console.redhat.com/api/automation-hub/content/published/\",
+          \"token\": \"${GALAXY_TOKEN}\",
+          \"tls_validation\": true
+        }" \
+        "${api_base}/remotes/ansible/collection/" 2>/dev/null)
 
-        # Trigger sync
-        printf "  Syncing rh-certified... "
+      remote_href=$(echo "$create_result" | python3 -c "import sys, json; print(json.load(sys.stdin).get('pulp_href', ''))" 2>/dev/null)
+
+      if [ -n "$remote_href" ]; then
+        echo "✓"
+
+        # Link to rh-certified repository
         local repo_href
         repo_href=$(curl -sk -u "admin:${admin_pass}" \
           "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
@@ -2238,14 +2256,30 @@ configure_pah_remotes() {
 
         if [ -n "$repo_href" ]; then
           curl -sk -u "admin:${admin_pass}" \
-            -X POST \
+            -X PATCH \
             -H "Content-Type: application/json" \
-            -d '{"mirror": false}' \
-            "${api_base}${repo_href}sync/" >/dev/null 2>&1
-          echo "✓ (background)"
+            -d "{\"remote\": \"${remote_href}\"}" \
+            "${api_base}${repo_href}" >/dev/null 2>&1
         fi
       fi
     fi
+
+    # Trigger sync
+    printf "  Syncing rh-certified... "
+    local repo_href
+    repo_href=$(curl -sk -u "admin:${admin_pass}" \
+      "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
+      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+
+    if [ -n "$repo_href" ]; then
+      curl -sk -u "admin:${admin_pass}" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"mirror": false}' \
+        "${api_base}${repo_href}sync/" >/dev/null 2>&1
+      echo "✓ (background)"
+    fi
+
 
     # Create and configure rh-validated remote
     printf "  Configuring rh-validated remote... "

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2226,25 +2226,12 @@ configure_pah_remotes() {
 
     if [ -n "$remote_href" ]; then
       # Update existing token
-      local task_url
-      task_url=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
+      curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X PATCH \
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg token "${GALAXY_TOKEN}" '{token: $token}')" \
-        "${api_base}${remote_href}" 2>/dev/null \
-        | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('task', ''))" 2>/dev/null)
-
-      if [ -n "$task_url" ]; then
-        # Wait for task
-        for i in {1..10}; do
-          sleep 1
-          local state
-          state=$(curl -sk --max-time 10 -u "admin:${admin_pass}" "${api_base}${task_url}" 2>/dev/null \
-            | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('state', ''))" 2>/dev/null)
-          [ "$state" = "completed" ] && break
-        done
-        echo "✓"
-      fi
+        "${api_base}${remote_href}" >/dev/null 2>&1
+      echo "✓"
     else
       # Create rh-certified remote
       local create_result

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -118,7 +118,7 @@ for arg in "$@"; do
     --kubeconfig)
       PENDING_FLAG="kubeconfig"
       ;;
-    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
+    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | setup-pah | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
       COMMAND="$arg"
       ;;
     --ai | --reset)

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2188,25 +2188,6 @@ configure_pah_remotes() {
 
   # Check jq availability
 
-  # Retry wrapper for transient Pulp API failures (matches PowerShell: 6 attempts, 8s delay)
-  _retry_pulp_call() {
-    local max_attempts=6
-    local delay=8
-    local attempt=1
-
-    while [ $attempt -le $max_attempts ]; do
-      if "$@" 2>&1; then
-        return 0
-      fi
-
-      if [ $attempt -lt $max_attempts ]; then
-        printf "${_YELLOW}▸${_NC} API call failed (attempt $attempt/$max_attempts), retrying in ${delay}s...\n" >&2
-        sleep "$delay"
-      fi
-      attempt=$((attempt + 1))
-    done
-    return 1
-  }
   if ! command -v jq >/dev/null 2>&1; then
     _err "jq is required for PAH remote configuration"
     echo "  Install: brew install jq (macOS) or sudo dnf install jq (RHEL/Fedora)"
@@ -2307,7 +2288,7 @@ configure_pah_remotes() {
       | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$repo_href" ]; then
-      _retry_pulp_call curl -sk --max-time 10 -u "admin:${admin_pass}" \
+      curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d '{"mirror": false}' \

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2249,23 +2249,23 @@ configure_pah_remotes() {
       fi
     fi
 
-    # Create and configure validated remote
-    printf "  Configuring validated remote... "
+    # Create and configure rh-validated remote
+    printf "  Configuring rh-validated remote... "
 
-    # Check if validated remote exists
+    # Check if rh-validated remote exists
     local validated_remote
     validated_remote=$(curl -sk -u "admin:${admin_pass}" \
-      "${api_base}/remotes/ansible/collection/?name=validated" 2>/dev/null \
+      "${api_base}/remotes/ansible/collection/?name=rh-validated" 2>/dev/null \
       | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -z "$validated_remote" ]; then
-      # Create validated remote
+      # Create rh-validated remote
       local create_result
       create_result=$(curl -sk -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d "{
-          \"name\": \"validated\",
+          \"name\": \"rh-validated\",
           \"url\": \"https://console.redhat.com/api/automation-hub/content/validated/\",
           \"token\": \"${GALAXY_TOKEN}\",
           \"tls_validation\": true

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -1822,6 +1822,7 @@ cmd_status() {
   fi
 
   # Show addons with URLs or enable instructions
+  detect_galaxy_credentials
   echo ""
   echo "Collection Sources:"
   echo "-------------------"
@@ -2530,6 +2531,7 @@ deploy_latest() {
   validate_galaxy_token || exit 1
   validate_pah_config || exit 1
   generate_ansible_cfg
+  install_collections || exit 1
 
   # Setup namespace (creates aap-operator namespace + pull secret)
   setup_namespace

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -118,7 +118,7 @@ for arg in "$@"; do
     --kubeconfig)
       PENDING_FLAG="kubeconfig"
       ;;
-    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | setup-auth | check-auth | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
+    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
       COMMAND="$arg"
       ;;
     --ai | --reset)
@@ -445,8 +445,7 @@ COMMANDS:
     ssh             SSH into cluster node
     repair          Repair cluster after crash
     setup           Run setup only (storage, coredns, mkcert)
-    setup-auth      Open browser to configure console.redhat.com token
-    check-auth      Validate collection authentication (console.redhat.com, PAH)
+    setup-pah       Configure PAH remotes with console.redhat.com token
     kubeconfig      Extract and merge kubeconfig
     redeploy-all    Destroy cluster and redeploy fresh
 
@@ -2041,7 +2040,6 @@ validate_galaxy_token() {
     echo "  aap-demo setup-auth     # Opens browser to token page"
     echo "  aap-demo check-auth     # Validates saved token"
     echo ""
-    echo "Manual setup:"
     echo "  1. Visit: https://console.redhat.com/ansible/automation-hub/token"
     echo "  2. Click 'Load token'"
     echo "  3. Copy Offline Token (~1500 characters)"
@@ -2345,126 +2343,53 @@ cmd_setup() {
   echo "CRC setup is handled during 'aap-demo create'"
 }
 
-cmd_check_auth() {
-  echo "Checking collection authentication..."
-  echo ""
 
-  # Detect credentials first
-  detect_galaxy_credentials
-
-  local has_auth=false
-
-  # Check galaxy token
-  if [ -f "$GALAXY_TOKEN_FILE" ]; then
-    local token_len=${#GALAXY_TOKEN}
-    printf "Galaxy Token:\n"
-    printf "  File:         %s\n" "$GALAXY_TOKEN_FILE"
-    printf "  Length:       %d characters\n" "$token_len"
-
-    if [ "$token_len" -lt 100 ]; then
-      printf "  ${_RED}Status:       Invalid (too short, expected ~1500)${_NC}\n"
-    else
-      printf "  ${_GREEN}Status:       Valid format${_NC}\n"
-      has_auth=true
-    fi
-    echo ""
-  else
-    printf "Galaxy Token:     ${_YELLOW}Not configured${_NC}\n"
-    printf "  File:           %s\n" "$GALAXY_TOKEN_FILE"
-    echo ""
-  fi
-
-  # Check PAH config
-  if [ -f "$PAH_CONFIG_FILE" ]; then
-    printf "Private Automation Hub:\n"
-    printf "  File:         %s\n" "$PAH_CONFIG_FILE"
-    if [ -n "$PAH_URL" ]; then
-      printf "  URL:          %s\n" "$PAH_URL"
-      if [ -n "$PAH_TOKEN" ]; then
-        printf "  Auth:         Token (configured)\n"
-      elif [ -n "$PAH_USER" ]; then
-        printf "  Auth:         Username/Password (configured)\n"
-      else
-        printf "  ${_RED}Auth:         Missing${_NC}\n"
-      fi
-      printf "  ${_GREEN}Status:       Valid format${_NC}\n"
-      has_auth=true
-    else
-      printf "  ${_RED}Status:       Invalid (no URL)${_NC}\n"
-    fi
-    echo ""
-  else
-    printf "Private Automation Hub: ${_YELLOW}Not configured (optional)${_NC}\n"
-    echo ""
-  fi
-
-  # Summary
-  if [ "$has_auth" = true ]; then
-    printf "${_GREEN}✓${_NC} Collection authentication configured\n"
-    return 0
-  else
-    printf "${_YELLOW}▸${_NC} No collection authentication configured\n"
-    echo ""
-    echo "Setup authenticated collection access:"
-    echo "  aap-demo setup-auth     # Opens browser to token page"
-    echo ""
-    echo "Or manually configure:"
-    echo "  https://console.redhat.com/ansible/automation-hub/token"
-    return 1
-  fi
-}
-
-cmd_setup_auth() {
-  echo "Setting up collection authentication..."
+cmd_setup_pah() {
+  echo "Setting up Private Automation Hub..."
   echo ""
 
   # Check if token already exists
   if [ -f "$GALAXY_TOKEN_FILE" ]; then
     echo "✓ Galaxy token already configured at $GALAXY_TOKEN_FILE"
     echo ""
-    echo "To update the token:"
-    echo "  1. Visit: https://console.redhat.com/ansible/automation-hub/token"
-    echo "  2. Copy the Offline Token"
-    echo "  3. Run: echo \"YOUR_TOKEN\" > $GALAXY_TOKEN_FILE"
+  else
+    # Get token first
+    local url="https://console.redhat.com/ansible/automation-hub/token"
+
+    # Open browser
+    if command -v open >/dev/null 2>&1; then
+      open "$url"  # macOS
+      echo "Opening browser to Red Hat Automation Hub..."
+    elif command -v xdg-open >/dev/null 2>&1; then
+      xdg-open "$url"  # Linux
+      echo "Opening browser to Red Hat Automation Hub..."
+    elif command -v start >/dev/null 2>&1; then
+      start "$url"  # Windows/Git Bash
+      echo "Opening browser to Red Hat Automation Hub..."
+    else
+      echo "Visit this URL in your browser:"
+      echo "  $url"
+    fi
+
     echo ""
-    echo "Or delete the existing token to reconfigure:"
-    echo "  rm $GALAXY_TOKEN_FILE"
-    echo "  aap-demo setup-auth"
+    echo "Steps:"
+    echo "  1. Log in with your Red Hat account"
+    echo "  2. Click 'Load token' button"
+    echo "  3. Copy the 'Offline Token' (long base64 string, ~1500 characters)"
+    echo "  4. Run this command to save it:"
+    echo ""
+    echo "     echo \"YOUR_OFFLINE_TOKEN\" > ~/.aap-demo/galaxy-token"
+    echo "     chmod 600 ~/.aap-demo/galaxy-token"
+    echo ""
+    echo "  5. Re-run: aap-demo setup-pah"
+    echo ""
+    echo "Documentation: docs/collection-authentication.md"
     return 0
   fi
 
-  local url="https://console.redhat.com/ansible/automation-hub/token"
-
-  # Open browser
-  if command -v open >/dev/null 2>&1; then
-    open "$url"  # macOS
-    echo "Opening browser to Red Hat Automation Hub..."
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$url"  # Linux
-    echo "Opening browser to Red Hat Automation Hub..."
-  elif command -v start >/dev/null 2>&1; then
-    start "$url"  # Windows/Git Bash
-    echo "Opening browser to Red Hat Automation Hub..."
-  else
-    echo "Visit this URL in your browser:"
-    echo "  $url"
-  fi
-
-  echo ""
-  echo "Steps:"
-  echo "  1. Log in with your Red Hat account"
-  echo "  2. Click 'Load token' button"
-  echo "  3. Copy the 'Offline Token' (long base64 string, ~1500 characters)"
-  echo "  4. Run this command to save it:"
-  echo ""
-  echo "     echo \"YOUR_OFFLINE_TOKEN\" > ~/.aap-demo/galaxy-token"
-  echo "     chmod 600 ~/.aap-demo/galaxy-token"
-  echo ""
-  echo "  5. Verify with:"
-  echo ""
-  echo "     aap-demo check-auth"
-  echo ""
-  echo "Documentation: docs/collection-authentication.md"
+  # Configure PAH remotes
+  echo "Configuring AAP Private Automation Hub remotes..."
+  configure_pah_remotes
 }
 
 cmd_deploy() {
@@ -2663,13 +2588,14 @@ deploy_latest() {
     # Watch deployment
     watch_aap
 
-    # Configure PAH remotes with galaxy credentials
-    echo ""
-    configure_pah_remotes
-
     # Install collections from requirements.yml
     echo ""
     install_collections
+
+    # Remind to configure PAH
+    echo ""
+    echo "To configure Private Automation Hub remotes:"
+    echo "  aap-demo setup-pah"
   else
     echo ""
     echo "✓ AAP operator deployed!"
@@ -3204,11 +3130,8 @@ case "$COMMAND" in
   setup)
     cmd_setup
     ;;
-  setup-auth)
-    cmd_setup_auth
-    ;;
-  check-auth)
-    cmd_check_auth
+  setup-pah)
+    cmd_setup_pah
     ;;
   watch)
     watch_aap

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -917,10 +917,10 @@ cmd_diagnose() {
   # =========================================================================
   echo "Cluster:"
   local crc_state
-  crc_state=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); print(d.get('crcStatus','unknown'))" 2>/dev/null || echo "unknown")
+  crc_state=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or '{}'); print(d.get('crcStatus','unknown'))" 2>/dev/null || echo "unknown")
   if [ "$crc_state" = "Running" ]; then
     local ms_version
-    ms_version=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); print(d.get('openshiftVersion',''))" 2>/dev/null || echo "")
+    ms_version=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or '{}'); print(d.get('openshiftVersion',''))" 2>/dev/null || echo "")
     _check_pass "OpenShift Local running"
   elif [ "$crc_state" = "Stopped" ]; then
     _check_fail "OpenShift Local is stopped — run: crc start"
@@ -966,7 +966,7 @@ cmd_diagnose() {
 
   # Check disk usage
   local disk_pct
-  disk_pct=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); u=d.get('diskUse',0); t=d.get('diskSize',1); print(int(u/t*100))" 2>/dev/null || echo "0")
+  disk_pct=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or '{}'); u=d.get('diskUse',0); t=d.get('diskSize',1); print(int(u/t*100))" 2>/dev/null || echo "0")
   if [ "$disk_pct" -gt 90 ]; then
     _check_fail "Disk usage: ${disk_pct}% — critically low space"
   elif [ "$disk_pct" -gt 80 ]; then
@@ -1439,7 +1439,7 @@ _run_atf() {
     _ca_cert=$(get_ingress_ca_cert_path)
     local _curl_tls="--cacert ${_ca_cert}"
     [ ! -f "$_ca_cert" ] && _curl_tls="-k"
-    aap_version=$(curl -s $_curl_tls "https://${gateway_host}/api/gateway/v1/ping/" 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read() or "{}").get('version',''))" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
+    aap_version=$(curl -s $_curl_tls "https://${gateway_host}/api/gateway/v1/ping/" 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read() or '{}').get('version',''))" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
   fi
   aap_version="${aap_version:-2.7}"
 
@@ -2177,6 +2177,8 @@ install_collections() {
 
 configure_pah_remotes() {
   echo "Configuring Private Automation Hub remotes..."
+  # Requires AAP 2.7+ (uses Pulp v3 API)
+
 
   # Detect credentials
   detect_galaxy_credentials
@@ -2206,7 +2208,7 @@ configure_pah_remotes() {
     local remote_href
     remote_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/remotes/ansible/collection/?name=rh-certified" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$remote_href" ]; then
       # Update existing token
@@ -2216,7 +2218,7 @@ configure_pah_remotes() {
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg token "${GALAXY_TOKEN}" '{token: $token}')" \
         "${api_base}${remote_href}" 2>/dev/null \
-        | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('task', ''))" 2>/dev/null)
+        | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('task', ''))" 2>/dev/null)
 
       if [ -n "$task_url" ]; then
         # Wait for task
@@ -2224,7 +2226,7 @@ configure_pah_remotes() {
           sleep 1
           local state
           state=$(curl -sk --max-time 10 -u "admin:${admin_pass}" "${api_base}${task_url}" 2>/dev/null \
-            | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('state', ''))" 2>/dev/null)
+            | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('state', ''))" 2>/dev/null)
           [ "$state" = "completed" ] && break
         done
         echo "✓"
@@ -2243,7 +2245,7 @@ configure_pah_remotes() {
         }" \
         "${api_base}/remotes/ansible/collection/" 2>/dev/null)
 
-      remote_href=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('pulp_href', ''))" 2>/dev/null)
+      remote_href=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('pulp_href', ''))" 2>/dev/null)
 
       if [ -n "$remote_href" ]; then
         echo "✓"
@@ -2252,7 +2254,7 @@ configure_pah_remotes() {
         local repo_href
         repo_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
           "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
-          | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+          | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
         if [ -n "$repo_href" ]; then
           curl -sk --max-time 10 -u "admin:${admin_pass}" \
@@ -2269,7 +2271,7 @@ configure_pah_remotes() {
     local repo_href
     repo_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$repo_href" ]; then
       curl -sk --max-time 10 -u "admin:${admin_pass}" \
@@ -2288,7 +2290,7 @@ configure_pah_remotes() {
     local validated_remote
     validated_remote=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/remotes/ansible/collection/?name=rh-validated" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -z "$validated_remote" ]; then
       # Create rh-validated remote
@@ -2304,7 +2306,7 @@ configure_pah_remotes() {
         }" \
         "${api_base}/remotes/ansible/collection/" 2>/dev/null)
 
-      validated_remote=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('pulp_href', ''))" 2>/dev/null)
+      validated_remote=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or '{}').get('pulp_href', ''))" 2>/dev/null)
     else
       # Update existing remote token
       curl -sk --max-time 10 -u "admin:${admin_pass}" \
@@ -2322,7 +2324,7 @@ configure_pah_remotes() {
       local validated_repo
       validated_repo=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
         "${api_base}/repositories/ansible/ansible/?name=validated" 2>/dev/null \
-        | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+        | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
       if [ -n "$validated_repo" ]; then
         curl -sk --max-time 10 -u "admin:${admin_pass}" \
@@ -2622,9 +2624,6 @@ deploy_latest() {
     # Watch deployment
     watch_aap
 
-    # Install collections from requirements.yml
-    echo ""
-    install_collections
 
     # Remind to configure PAH
     echo ""
@@ -2716,7 +2715,7 @@ setup_namespace() {
     # Force-clear if still stuck
     if [ "$_ns_status" = "Terminating" ]; then
       echo "  Force-clearing stuck namespace..."
-      kubectl get namespace "$NAMESPACE" -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); d[\"spec\"][\"finalizers\"]=[];print(json.dumps(d))" | kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+      kubectl get namespace "$NAMESPACE" -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or '{}'); d[\"spec\"][\"finalizers\"]=[];print(json.dumps(d))" | kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
       sleep 2
     fi
   fi

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -917,10 +917,10 @@ cmd_diagnose() {
   # =========================================================================
   echo "Cluster:"
   local crc_state
-  crc_state=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('crcStatus','unknown'))" 2>/dev/null || echo "unknown")
+  crc_state=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); print(d.get('crcStatus','unknown'))" 2>/dev/null || echo "unknown")
   if [ "$crc_state" = "Running" ]; then
     local ms_version
-    ms_version=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('openshiftVersion',''))" 2>/dev/null || echo "")
+    ms_version=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); print(d.get('openshiftVersion',''))" 2>/dev/null || echo "")
     _check_pass "OpenShift Local running"
   elif [ "$crc_state" = "Stopped" ]; then
     _check_fail "OpenShift Local is stopped — run: crc start"
@@ -966,7 +966,7 @@ cmd_diagnose() {
 
   # Check disk usage
   local disk_pct
-  disk_pct=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); u=d.get('diskUse',0); t=d.get('diskSize',1); print(int(u/t*100))" 2>/dev/null || echo "0")
+  disk_pct=$(crc status -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); u=d.get('diskUse',0); t=d.get('diskSize',1); print(int(u/t*100))" 2>/dev/null || echo "0")
   if [ "$disk_pct" -gt 90 ]; then
     _check_fail "Disk usage: ${disk_pct}% — critically low space"
   elif [ "$disk_pct" -gt 80 ]; then
@@ -1439,7 +1439,7 @@ _run_atf() {
     _ca_cert=$(get_ingress_ca_cert_path)
     local _curl_tls="--cacert ${_ca_cert}"
     [ ! -f "$_ca_cert" ] && _curl_tls="-k"
-    aap_version=$(curl -s $_curl_tls "https://${gateway_host}/api/gateway/v1/ping/" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
+    aap_version=$(curl -s $_curl_tls "https://${gateway_host}/api/gateway/v1/ping/" 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read() or "{}").get('version',''))" 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' || true)
   fi
   aap_version="${aap_version:-2.7}"
 
@@ -2204,27 +2204,27 @@ configure_pah_remotes() {
     printf "  Configuring rh-certified remote... "
 
     local remote_href
-    remote_href=$(curl -sk -u "admin:${admin_pass}" \
+    remote_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/remotes/ansible/collection/?name=rh-certified" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$remote_href" ]; then
       # Update existing token
       local task_url
-      task_url=$(curl -sk -u "admin:${admin_pass}" \
+      task_url=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X PATCH \
         -H "Content-Type: application/json" \
-        -d "{\"token\": \"${GALAXY_TOKEN}\"}" \
+        -d "$(jq -n --arg token "${GALAXY_TOKEN}" '{token: $token}')" \
         "${api_base}${remote_href}" 2>/dev/null \
-        | python3 -c "import sys, json; print(json.load(sys.stdin).get('task', ''))" 2>/dev/null)
+        | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('task', ''))" 2>/dev/null)
 
       if [ -n "$task_url" ]; then
         # Wait for task
         for i in {1..10}; do
           sleep 1
           local state
-          state=$(curl -sk -u "admin:${admin_pass}" "${api_base}${task_url}" 2>/dev/null \
-            | python3 -c "import sys, json; print(json.load(sys.stdin).get('state', ''))" 2>/dev/null)
+          state=$(curl -sk --max-time 10 -u "admin:${admin_pass}" "${api_base}${task_url}" 2>/dev/null \
+            | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('state', ''))" 2>/dev/null)
           [ "$state" = "completed" ] && break
         done
         echo "✓"
@@ -2232,7 +2232,7 @@ configure_pah_remotes() {
     else
       # Create rh-certified remote
       local create_result
-      create_result=$(curl -sk -u "admin:${admin_pass}" \
+      create_result=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d "{
@@ -2243,19 +2243,19 @@ configure_pah_remotes() {
         }" \
         "${api_base}/remotes/ansible/collection/" 2>/dev/null)
 
-      remote_href=$(echo "$create_result" | python3 -c "import sys, json; print(json.load(sys.stdin).get('pulp_href', ''))" 2>/dev/null)
+      remote_href=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('pulp_href', ''))" 2>/dev/null)
 
       if [ -n "$remote_href" ]; then
         echo "✓"
 
         # Link to rh-certified repository
         local repo_href
-        repo_href=$(curl -sk -u "admin:${admin_pass}" \
+        repo_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
           "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
-          | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+          | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
         if [ -n "$repo_href" ]; then
-          curl -sk -u "admin:${admin_pass}" \
+          curl -sk --max-time 10 -u "admin:${admin_pass}" \
             -X PATCH \
             -H "Content-Type: application/json" \
             -d "{\"remote\": \"${remote_href}\"}" \
@@ -2267,12 +2267,12 @@ configure_pah_remotes() {
     # Trigger sync
     printf "  Syncing rh-certified... "
     local repo_href
-    repo_href=$(curl -sk -u "admin:${admin_pass}" \
+    repo_href=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$repo_href" ]; then
-      curl -sk -u "admin:${admin_pass}" \
+      curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d '{"mirror": false}' \
@@ -2286,14 +2286,14 @@ configure_pah_remotes() {
 
     # Check if rh-validated remote exists
     local validated_remote
-    validated_remote=$(curl -sk -u "admin:${admin_pass}" \
+    validated_remote=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       "${api_base}/remotes/ansible/collection/?name=rh-validated" 2>/dev/null \
-      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+      | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -z "$validated_remote" ]; then
       # Create rh-validated remote
       local create_result
-      create_result=$(curl -sk -u "admin:${admin_pass}" \
+      create_result=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d "{
@@ -2304,13 +2304,13 @@ configure_pah_remotes() {
         }" \
         "${api_base}/remotes/ansible/collection/" 2>/dev/null)
 
-      validated_remote=$(echo "$create_result" | python3 -c "import sys, json; print(json.load(sys.stdin).get('pulp_href', ''))" 2>/dev/null)
+      validated_remote=$(echo "$create_result" | python3 -c "import sys, json; print(json.loads(sys.stdin.read() or "{}").get('pulp_href', ''))" 2>/dev/null)
     else
       # Update existing remote token
-      curl -sk -u "admin:${admin_pass}" \
+      curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X PATCH \
         -H "Content-Type: application/json" \
-        -d "{\"token\": \"${GALAXY_TOKEN}\"}" \
+        -d "$(jq -n --arg token "${GALAXY_TOKEN}" '{token: $token}')" \
         "${api_base}${validated_remote}" >/dev/null 2>&1
     fi
 
@@ -2320,12 +2320,12 @@ configure_pah_remotes() {
       # Link remote to validated repository
       printf "  Linking validated remote to repository... "
       local validated_repo
-      validated_repo=$(curl -sk -u "admin:${admin_pass}" \
+      validated_repo=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
         "${api_base}/repositories/ansible/ansible/?name=validated" 2>/dev/null \
-        | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+        | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or "{}"); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
       if [ -n "$validated_repo" ]; then
-        curl -sk -u "admin:${admin_pass}" \
+        curl -sk --max-time 10 -u "admin:${admin_pass}" \
           -X PATCH \
           -H "Content-Type: application/json" \
           -d "{\"remote\": \"${validated_remote}\"}" \
@@ -2334,7 +2334,7 @@ configure_pah_remotes() {
 
         # Trigger sync
         printf "  Syncing validated... "
-        curl -sk -u "admin:${admin_pass}" \
+        curl -sk --max-time 10 -u "admin:${admin_pass}" \
           -X POST \
           -H "Content-Type: application/json" \
           -d '{"mirror": false}' \
@@ -2352,7 +2352,7 @@ configure_pah_remotes() {
 
     # Create PAH remote
     local create_result
-    create_result=$(curl -sk -u "admin:${admin_pass}" \
+    create_result=$(curl -sk --max-time 10 -u "admin:${admin_pass}" \
       -X POST \
       -H "Content-Type: application/json" \
       -d "{
@@ -2716,7 +2716,7 @@ setup_namespace() {
     # Force-clear if still stuck
     if [ "$_ns_status" = "Terminating" ]; then
       echo "  Force-clearing stuck namespace..."
-      kubectl get namespace "$NAMESPACE" -o json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); d[\"spec\"][\"finalizers\"]=[];print(json.dumps(d))" | kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+      kubectl get namespace "$NAMESPACE" -o json 2>/dev/null | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or "{}"); d[\"spec\"][\"finalizers\"]=[];print(json.dumps(d))" | kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
       sleep 2
     fi
   fi

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -118,7 +118,7 @@ for arg in "$@"; do
     --kubeconfig)
       PENDING_FLAG="kubeconfig"
       ;;
-    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
+    deploy | deploy-all | deploy-operator | deploy-aap | repair | clean | destroy | stop | start | setup | setup-auth | check-auth | create | watch | status | update | config | redeploy | redeploy-all | redhat-status | rh-status | kubeconfig | ssh | idle | diagnose | must-gather | enable | disable | test | help | --help | -h)
       COMMAND="$arg"
       ;;
     --ai | --reset)
@@ -445,6 +445,8 @@ COMMANDS:
     ssh             SSH into cluster node
     repair          Repair cluster after crash
     setup           Run setup only (storage, coredns, mkcert)
+    setup-auth      Open browser to configure collection authentication
+    check-auth      Validate collection authentication (galaxy token, PAH)
     kubeconfig      Extract and merge kubeconfig
     redeploy-all    Destroy cluster and redeploy fresh
 
@@ -2034,8 +2036,18 @@ validate_galaxy_token() {
   local token_len=${#GALAXY_TOKEN}
   if [ "$token_len" -lt 100 ]; then
     printf "${_RED}▸${_NC} Invalid galaxy token format (too short: $token_len chars)\n"
-    echo "  Offline tokens from console.redhat.com are typically 1500+ characters"
-    echo "  Get token from: https://console.redhat.com/ansible/automation-hub/token"
+    echo ""
+    echo "Quick setup:"
+    echo "  aap-demo setup-auth     # Opens browser to token page"
+    echo "  aap-demo check-auth     # Validates saved token"
+    echo ""
+    echo "Manual setup:"
+    echo "  1. Visit: https://console.redhat.com/ansible/automation-hub/token"
+    echo "  2. Click 'Load token'"
+    echo "  3. Copy Offline Token (~1500 characters)"
+    echo "  4. Save: echo \"TOKEN\" > ~/.aap-demo/galaxy-token"
+    echo ""
+    echo "Documentation: docs/collection-authentication.md"
     return 1
   fi
 
@@ -2167,6 +2179,113 @@ install_collections() {
 
 cmd_setup() {
   echo "CRC setup is handled during 'aap-demo create'"
+}
+
+cmd_check_auth() {
+  echo "Checking collection authentication..."
+  echo ""
+
+  # Detect credentials first
+  detect_galaxy_credentials
+
+  local has_auth=false
+
+  # Check galaxy token
+  if [ -f "$GALAXY_TOKEN_FILE" ]; then
+    local token_len=${#GALAXY_TOKEN}
+    printf "Galaxy Token:\n"
+    printf "  File:         %s\n" "$GALAXY_TOKEN_FILE"
+    printf "  Length:       %d characters\n" "$token_len"
+
+    if [ "$token_len" -lt 100 ]; then
+      printf "  ${_RED}Status:       Invalid (too short, expected ~1500)${_NC}\n"
+    else
+      printf "  ${_GREEN}Status:       Valid format${_NC}\n"
+      has_auth=true
+    fi
+    echo ""
+  else
+    printf "Galaxy Token:     ${_YELLOW}Not configured${_NC}\n"
+    printf "  File:           %s\n" "$GALAXY_TOKEN_FILE"
+    echo ""
+  fi
+
+  # Check PAH config
+  if [ -f "$PAH_CONFIG_FILE" ]; then
+    printf "Private Automation Hub:\n"
+    printf "  File:         %s\n" "$PAH_CONFIG_FILE"
+    if [ -n "$PAH_URL" ]; then
+      printf "  URL:          %s\n" "$PAH_URL"
+      if [ -n "$PAH_TOKEN" ]; then
+        printf "  Auth:         Token (configured)\n"
+      elif [ -n "$PAH_USER" ]; then
+        printf "  Auth:         Username/Password (configured)\n"
+      else
+        printf "  ${_RED}Auth:         Missing${_NC}\n"
+      fi
+      printf "  ${_GREEN}Status:       Valid format${_NC}\n"
+      has_auth=true
+    else
+      printf "  ${_RED}Status:       Invalid (no URL)${_NC}\n"
+    fi
+    echo ""
+  else
+    printf "Private Automation Hub: ${_YELLOW}Not configured (optional)${_NC}\n"
+    echo ""
+  fi
+
+  # Summary
+  if [ "$has_auth" = true ]; then
+    printf "${_GREEN}✓${_NC} Collection authentication configured\n"
+    return 0
+  else
+    printf "${_YELLOW}▸${_NC} No collection authentication configured\n"
+    echo ""
+    echo "Setup authenticated collection access:"
+    echo "  aap-demo setup-auth     # Opens browser to token page"
+    echo ""
+    echo "Or manually configure:"
+    echo "  https://console.redhat.com/ansible/automation-hub/token"
+    return 1
+  fi
+}
+
+cmd_setup_auth() {
+  echo "Setting up collection authentication..."
+  echo ""
+
+  local url="https://console.redhat.com/ansible/automation-hub/token"
+
+  # Open browser
+  if command -v open >/dev/null 2>&1; then
+    open "$url"  # macOS
+    echo "Opening browser to Red Hat Automation Hub..."
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url"  # Linux
+    echo "Opening browser to Red Hat Automation Hub..."
+  elif command -v start >/dev/null 2>&1; then
+    start "$url"  # Windows/Git Bash
+    echo "Opening browser to Red Hat Automation Hub..."
+  else
+    echo "Visit this URL in your browser:"
+    echo "  $url"
+  fi
+
+  echo ""
+  echo "Steps:"
+  echo "  1. Log in with your Red Hat account"
+  echo "  2. Click 'Load token' button"
+  echo "  3. Copy the 'Offline Token' (long base64 string, ~1500 characters)"
+  echo "  4. Run this command to save it:"
+  echo ""
+  echo "     echo \"YOUR_OFFLINE_TOKEN\" > ~/.aap-demo/galaxy-token"
+  echo "     chmod 600 ~/.aap-demo/galaxy-token"
+  echo ""
+  echo "  5. Verify with:"
+  echo ""
+  echo "     aap-demo check-auth"
+  echo ""
+  echo "Documentation: docs/collection-authentication.md"
 }
 
 cmd_deploy() {
@@ -2901,6 +3020,12 @@ case "$COMMAND" in
     ;;
   setup)
     cmd_setup
+    ;;
+  setup-auth)
+    cmd_setup_auth
+    ;;
+  check-auth)
+    cmd_check_auth
     ;;
   watch)
     watch_aap

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2200,11 +2200,11 @@ configure_pah_remotes() {
 
   local api_base="https://${aap_route}/api/galaxy/pulp/api/v3"
 
-  # Configure rh-certified remote if token present
+  # Configure console.redhat.com remotes if token present
   if [ -n "$GALAXY_TOKEN" ]; then
-    printf "  Configuring console.redhat.com remote... "
+    # Configure rh-certified remote
+    printf "  Configuring rh-certified remote... "
 
-    # Find rh-certified remote
     local remote_href
     remote_href=$(curl -sk -u "admin:${admin_pass}" \
       "${api_base}/remotes/ansible/collection/?name=rh-certified" 2>/dev/null \
@@ -2232,7 +2232,7 @@ configure_pah_remotes() {
         echo "✓"
 
         # Trigger sync
-        printf "  Syncing certified collections... "
+        printf "  Syncing rh-certified... "
         local repo_href
         repo_href=$(curl -sk -u "admin:${admin_pass}" \
           "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
@@ -2244,12 +2244,74 @@ configure_pah_remotes() {
             -H "Content-Type: application/json" \
             -d '{"mirror": false}' \
             "${api_base}${repo_href}sync/" >/dev/null 2>&1
-          echo "✓ (running in background)"
+          echo "✓ (background)"
         fi
       fi
     fi
+
+    # Create and configure validated remote
+    printf "  Configuring validated remote... "
+
+    # Check if validated remote exists
+    local validated_remote
+    validated_remote=$(curl -sk -u "admin:${admin_pass}" \
+      "${api_base}/remotes/ansible/collection/?name=rh-validated" 2>/dev/null \
+      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+
+    if [ -z "$validated_remote" ]; then
+      # Create validated remote
+      local create_result
+      create_result=$(curl -sk -u "admin:${admin_pass}" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"name\": \"rh-validated\",
+          \"url\": \"https://console.redhat.com/api/automation-hub/content/validated/\",
+          \"token\": \"${GALAXY_TOKEN}\",
+          \"tls_validation\": true
+        }" \
+        "${api_base}/remotes/ansible/collection/" 2>/dev/null)
+
+      validated_remote=$(echo "$create_result" | python3 -c "import sys, json; print(json.load(sys.stdin).get('pulp_href', ''))" 2>/dev/null)
+    else
+      # Update existing remote token
+      curl -sk -u "admin:${admin_pass}" \
+        -X PATCH \
+        -H "Content-Type: application/json" \
+        -d "{\"token\": \"${GALAXY_TOKEN}\"}" \
+        "${api_base}${validated_remote}" >/dev/null 2>&1
+    fi
+
+    if [ -n "$validated_remote" ]; then
+      echo "✓"
+
+      # Link remote to validated repository
+      printf "  Linking validated remote to repository... "
+      local validated_repo
+      validated_repo=$(curl -sk -u "admin:${admin_pass}" \
+        "${api_base}/repositories/ansible/ansible/?name=validated" 2>/dev/null \
+        | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+
+      if [ -n "$validated_repo" ]; then
+        curl -sk -u "admin:${admin_pass}" \
+          -X PATCH \
+          -H "Content-Type: application/json" \
+          -d "{\"remote\": \"${validated_remote}\"}" \
+          "${api_base}${validated_repo}" >/dev/null 2>&1
+        echo "✓"
+
+        # Trigger sync
+        printf "  Syncing validated... "
+        curl -sk -u "admin:${admin_pass}" \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"mirror": false}' \
+          "${api_base}${validated_repo}sync/" >/dev/null 2>&1
+        echo "✓ (background)"
+      fi
+    fi
   else
-    printf "  ${_YELLOW}▸${_NC} No galaxy token found, skipping rh-certified sync\n"
+    printf "  ${_YELLOW}▸${_NC} No galaxy token found, skipping console.redhat.com remotes\n"
   fi
 
   # Configure PAH remote if configured

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -66,6 +66,11 @@ if [ -f "$AAP_DEMO_CONFIG" ]; then
   done <"$AAP_DEMO_CONFIG"
 fi
 
+# Collection authentication environment variables
+GALAXY_TOKEN_FILE="${GALAXY_TOKEN_FILE:-$HOME/.aap-demo/galaxy-token}"
+PAH_CONFIG_FILE="${PAH_CONFIG_FILE:-$HOME/.aap-demo/pah-config.yml}"
+SKIP_COLLECTIONS="${SKIP_COLLECTIONS:-false}"
+
 # Infrastructure type (OpenShift Local only)
 INFRA_TYPE="crc"
 KUBECTL_CONTEXT=""
@@ -1113,8 +1118,57 @@ cmd_diagnose() {
   echo ""
 
   # =========================================================================
+  # Collection Sources
+  # =========================================================================
+  echo ""
+  echo "Collection Sources:"
+
+  # Check ansible.cfg existence
+  if [ -f "ansible.cfg" ]; then
+    _check_pass "ansible.cfg exists"
+
+    # Check for galaxy server configuration
+    if grep -q "\[galaxy\]" ansible.cfg; then
+      _check_pass "Galaxy server configuration present"
+    else
+      _check_warn "No galaxy server configuration in ansible.cfg"
+      _check_info "Run: aap-demo deploy to regenerate config"
+    fi
+  else
+    _check_warn "ansible.cfg not found"
+  fi
+
+  # Check credential files
+  if [ -f "$HOME/.aap-demo/galaxy-token" ]; then
+    _check_pass "console.redhat.com token present"
+  else
+    _check_info "console.redhat.com token not configured"
+    _check_info "Get token from: https://console.redhat.com/ansible/automation-hub/token"
+  fi
+
+  if [ -f "$HOME/.aap-demo/pah-config.yml" ]; then
+    _check_pass "Private Automation Hub config present"
+  else
+    _check_info "Private Automation Hub not configured (optional)"
+  fi
+
+  # Check collection installation
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    required_collections=("ansible.controller" "infra.aap_configuration")
+    for collection in "${required_collections[@]}"; do
+      if ansible-galaxy collection list 2>/dev/null | grep -q "^$collection"; then
+        _check_pass "Collection $collection installed"
+      else
+        _check_warn "Collection $collection not found"
+        _check_info "Run: aap-demo deploy to install collections"
+      fi
+    done
+  fi
+
+  # =========================================================================
   # DNS
   # =========================================================================
+  echo ""
   echo "DNS:"
   local coredns_running
   coredns_running=$(kubectl get pods -n openshift-dns --no-headers 2>/dev/null | grep -c "Running" || echo "0")
@@ -1767,8 +1821,30 @@ cmd_status() {
   fi
 
   # Show addons with URLs or enable instructions
+  echo ""
+  echo "Collection Sources:"
+  echo "-------------------"
+
+  if [ -n "$PAH_URL" ]; then
+    printf "  %-20s %s\n" "Private Hub:" "$PAH_URL"
+  fi
+
+  if [ -n "$GALAXY_TOKEN" ]; then
+    printf "  %-20s %s\n" "Red Hat Certified:" "console.redhat.com (authenticated)"
+  else
+    printf "  %-20s %s\n" "Red Hat Certified:" "Not configured"
+  fi
+
+  printf "  %-20s %s\n" "Community:" "galaxy.ansible.com"
+
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    collection_count=$(ansible-galaxy collection list 2>/dev/null | grep -c "^ansible\|^infra" || echo "0")
+    printf "  %-20s %s\n" "Installed:" "$collection_count certified collections"
+  fi
+
   local saved_addons
   saved_addons=$(_addons_list)
+  echo ""
   echo "Addons:"
   echo "-------"
   for a in $AVAILABLE_ADDONS; do
@@ -1922,6 +1998,173 @@ cmd_create() {
   }
 }
 
+detect_galaxy_credentials() {
+  # Detect console.redhat.com offline token
+  if [ -f "$GALAXY_TOKEN_FILE" ]; then
+    GALAXY_TOKEN=$(cat "$GALAXY_TOKEN_FILE")
+    export GALAXY_TOKEN
+  fi
+
+  # Detect PAH configuration
+  if [ -f "$PAH_CONFIG_FILE" ]; then
+    # Parse YAML for URL and authentication
+    if command -v yq >/dev/null 2>&1; then
+      PAH_URL=$(yq eval '.url' "$PAH_CONFIG_FILE" 2>/dev/null)
+      PAH_TOKEN=$(yq eval '.token' "$PAH_CONFIG_FILE" 2>/dev/null)
+      PAH_USER=$(yq eval '.username' "$PAH_CONFIG_FILE" 2>/dev/null)
+      PAH_PASS=$(yq eval '.password' "$PAH_CONFIG_FILE" 2>/dev/null)
+    else
+      # Fallback: basic grep parsing
+      PAH_URL=$(grep -E '^\s*url:' "$PAH_CONFIG_FILE" | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'")
+      PAH_TOKEN=$(grep -E '^\s*token:' "$PAH_CONFIG_FILE" | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'")
+      PAH_USER=$(grep -E '^\s*username:' "$PAH_CONFIG_FILE" | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'")
+      PAH_PASS=$(grep -E '^\s*password:' "$PAH_CONFIG_FILE" | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'")
+    fi
+
+    export PAH_URL PAH_TOKEN PAH_USER PAH_PASS
+  fi
+}
+
+validate_galaxy_token() {
+  if [ -z "$GALAXY_TOKEN" ]; then
+    return 0  # Not configured, skip validation
+  fi
+
+  # Check token format (offline tokens are typically 1500+ chars)
+  local token_len=${#GALAXY_TOKEN}
+  if [ "$token_len" -lt 100 ]; then
+    printf "${_RED}▸${_NC} Invalid galaxy token format (too short: $token_len chars)\n"
+    echo "  Offline tokens from console.redhat.com are typically 1500+ characters"
+    echo "  Get token from: https://console.redhat.com/ansible/automation-hub/token"
+    return 1
+  fi
+
+  return 0
+}
+
+validate_pah_config() {
+  if [ -z "$PAH_URL" ]; then
+    return 0  # Not configured, skip validation
+  fi
+
+  # Check URL format
+  if ! [[ "$PAH_URL" =~ ^https?:// ]]; then
+    printf "${_RED}▸${_NC} Invalid PAH URL format: $PAH_URL\n"
+    echo "  URL must start with http:// or https://"
+    return 1
+  fi
+
+  # Check authentication method
+  if [ -z "$PAH_TOKEN" ] && [ -z "$PAH_USER" ]; then
+    printf "${_RED}▸${_NC} PAH config missing authentication\n"
+    echo "  Provide either 'token' or 'username'/'password' in $PAH_CONFIG_FILE"
+    return 1
+  fi
+
+  return 0
+}
+
+generate_ansible_cfg() {
+  local cfg_file="${1:-ansible.cfg}"
+  local galaxy_servers=""
+
+  # Build galaxy_server_list based on available credentials
+  if [ -n "$PAH_URL" ]; then
+    galaxy_servers+="pah,"
+  fi
+  if [ -n "$GALAXY_TOKEN" ]; then
+    galaxy_servers+="console,"
+  fi
+  galaxy_servers+="community"
+
+  # Remove trailing comma
+  galaxy_servers="${galaxy_servers%,}"
+
+  # Generate ansible.cfg with [galaxy] section
+  cat > "$cfg_file" <<'EOF'
+[defaults]
+roles_path = ./ansible/roles
+inventory = ./ansible/inventory/localhost.yml
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp/ansible_facts
+fact_caching_timeout = 3600
+
+EOF
+
+  # Add galaxy configuration
+  cat >> "$cfg_file" <<EOF
+[galaxy]
+server_list = ${galaxy_servers}
+
+EOF
+
+  # Append PAH server configuration
+  if [ -n "$PAH_URL" ]; then
+    cat >> "$cfg_file" <<EOF
+[galaxy_server.pah]
+url = ${PAH_URL}
+EOF
+
+    if [ -n "$PAH_TOKEN" ]; then
+      cat >> "$cfg_file" <<EOF
+token = ${PAH_TOKEN}
+
+EOF
+    elif [ -n "$PAH_USER" ] && [ -n "$PAH_PASS" ]; then
+      cat >> "$cfg_file" <<EOF
+username = ${PAH_USER}
+password = ${PAH_PASS}
+
+EOF
+    fi
+  fi
+
+  # Append console.redhat.com server configuration
+  if [ -n "$GALAXY_TOKEN" ]; then
+    cat >> "$cfg_file" <<EOF
+[galaxy_server.console]
+url = https://console.redhat.com/api/automation-hub/
+token = ${GALAXY_TOKEN}
+
+EOF
+  fi
+
+  # Append community galaxy server
+  cat >> "$cfg_file" <<'EOF'
+[galaxy_server.community]
+url = https://galaxy.ansible.com/
+
+EOF
+
+  printf "${_GREEN}▸${_NC} Generated ansible.cfg with galaxy servers: $galaxy_servers\n"
+}
+
+install_collections() {
+  local requirements_file="${1:-config/requirements.yml}"
+
+  if [ "$SKIP_COLLECTIONS" = "true" ]; then
+    printf "${_YELLOW}▸${_NC} Skipping collection installation (SKIP_COLLECTIONS=true)\n"
+    return 0
+  fi
+
+  if [ ! -f "$requirements_file" ]; then
+    printf "${_YELLOW}▸${_NC} No $requirements_file found, skipping collection installation\n"
+    return 0
+  fi
+
+  echo "Installing collections from $requirements_file..."
+  if ansible-galaxy collection install -r "$requirements_file" 2>&1; then
+    echo "  ✓ Collections installed successfully"
+    return 0
+  else
+    _err "Failed to install collections"
+    echo "  Check authentication to galaxy servers or run with SKIP_COLLECTIONS=true"
+    echo "  Token setup: https://console.redhat.com/ansible/automation-hub/token"
+    return 1
+  fi
+}
+
 cmd_setup() {
   echo "CRC setup is handled during 'aap-demo create'"
 }
@@ -2023,6 +2266,12 @@ deploy_latest() {
     exit 1
   fi
 
+  # Detect and validate collection authentication
+  detect_galaxy_credentials
+  validate_galaxy_token || exit 1
+  validate_pah_config || exit 1
+  generate_ansible_cfg
+
   # Setup namespace (creates aap-operator namespace + pull secret)
   setup_namespace
   verify_coredns
@@ -2115,6 +2364,10 @@ deploy_latest() {
 
     # Watch deployment
     watch_aap
+
+    # Install collections from requirements.yml
+    echo ""
+    install_collections
   else
     echo ""
     echo "✓ AAP operator deployed!"

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2136,7 +2136,7 @@ EOF
   if [ -n "$GALAXY_TOKEN" ]; then
     cat >> "$cfg_file" <<EOF
 [galaxy_server.console]
-url = https://console.redhat.com/api/automation-hub/
+url = https://console.redhat.com/api/automation-hub/content/published/
 token = ${GALAXY_TOKEN}
 
 EOF
@@ -2175,6 +2175,108 @@ install_collections() {
     echo "  Token setup: https://console.redhat.com/ansible/automation-hub/token"
     return 1
   fi
+}
+
+configure_pah_remotes() {
+  echo "Configuring Private Automation Hub remotes..."
+
+  # Detect credentials
+  detect_galaxy_credentials
+
+  # Get AAP route and admin password
+  local aap_route
+  aap_route=$(kubectl get route aap -n "$NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null)
+  if [ -z "$aap_route" ]; then
+    _err "AAP route not found"
+    return 1
+  fi
+
+  local admin_pass
+  admin_pass=$(kubectl get secret aap-admin-password -n "$NAMESPACE" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+  if [ -z "$admin_pass" ]; then
+    _err "Admin password not found"
+    return 1
+  fi
+
+  local api_base="https://${aap_route}/api/galaxy/pulp/api/v3"
+
+  # Configure rh-certified remote if token present
+  if [ -n "$GALAXY_TOKEN" ]; then
+    printf "  Configuring console.redhat.com remote... "
+
+    # Find rh-certified remote
+    local remote_href
+    remote_href=$(curl -sk -u "admin:${admin_pass}" \
+      "${api_base}/remotes/ansible/collection/?name=rh-certified" 2>/dev/null \
+      | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+
+    if [ -n "$remote_href" ]; then
+      # Update token
+      local task_url
+      task_url=$(curl -sk -u "admin:${admin_pass}" \
+        -X PATCH \
+        -H "Content-Type: application/json" \
+        -d "{\"token\": \"${GALAXY_TOKEN}\"}" \
+        "${api_base}${remote_href}" 2>/dev/null \
+        | python3 -c "import sys, json; print(json.load(sys.stdin).get('task', ''))" 2>/dev/null)
+
+      if [ -n "$task_url" ]; then
+        # Wait for task
+        for i in {1..10}; do
+          sleep 1
+          local state
+          state=$(curl -sk -u "admin:${admin_pass}" "${api_base}${task_url}" 2>/dev/null \
+            | python3 -c "import sys, json; print(json.load(sys.stdin).get('state', ''))" 2>/dev/null)
+          [ "$state" = "completed" ] && break
+        done
+        echo "✓"
+
+        # Trigger sync
+        printf "  Syncing certified collections... "
+        local repo_href
+        repo_href=$(curl -sk -u "admin:${admin_pass}" \
+          "${api_base}/repositories/ansible/ansible/?name=rh-certified" 2>/dev/null \
+          | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
+
+        if [ -n "$repo_href" ]; then
+          curl -sk -u "admin:${admin_pass}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"mirror": false}' \
+            "${api_base}${repo_href}sync/" >/dev/null 2>&1
+          echo "✓ (running in background)"
+        fi
+      fi
+    fi
+  else
+    printf "  ${_YELLOW}▸${_NC} No galaxy token found, skipping rh-certified sync\n"
+  fi
+
+  # Configure PAH remote if configured
+  if [ -n "$PAH_URL" ] && [ -n "$PAH_TOKEN" ]; then
+    printf "  Configuring Private Automation Hub remote... "
+
+    # Create PAH remote
+    local create_result
+    create_result=$(curl -sk -u "admin:${admin_pass}" \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"name\": \"external-pah\",
+        \"url\": \"${PAH_URL}\",
+        \"token\": \"${PAH_TOKEN}\",
+        \"tls_validation\": true
+      }" \
+      "${api_base}/remotes/ansible/collection/" 2>&1)
+
+    if echo "$create_result" | grep -q '"pulp_href"'; then
+      echo "✓"
+    else
+      echo "⚠ (may already exist or invalid config)"
+    fi
+  fi
+
+  echo "  ✓ PAH configuration complete"
 }
 
 cmd_setup() {
@@ -2483,6 +2585,10 @@ deploy_latest() {
 
     # Watch deployment
     watch_aap
+
+    # Configure PAH remotes with galaxy credentials
+    echo ""
+    configure_pah_remotes
 
     # Install collections from requirements.yml
     echo ""

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2038,8 +2038,7 @@ validate_galaxy_token() {
     printf "${_RED}▸${_NC} Invalid galaxy token format (too short: $token_len chars)\n"
     echo ""
     echo "Quick setup:"
-    echo "  aap-demo setup-auth     # Opens browser to token page"
-    echo "  aap-demo check-auth     # Validates saved token"
+    echo "  aap-demo setup-pah      # Configure PAH remotes with token"
     echo ""
     echo "  1. Visit: https://console.redhat.com/ansible/automation-hub/token"
     echo "  2. Click 'Load token'"
@@ -2148,6 +2147,13 @@ url = https://galaxy.ansible.com/
 
 EOF
 
+  # Secure file permissions and warn about plaintext tokens
+  chmod 600 "$cfg_file"
+  if [ -n "$GALAXY_TOKEN" ] || [ -n "$PAH_TOKEN" ] || [ -n "$PAH_PASS" ]; then
+    printf "${_YELLOW}▸${_NC} Warning: Tokens stored in plaintext in $cfg_file\n"
+    printf "  Do not commit this file. Consider using ANSIBLE_GALAXY_SERVER_*_TOKEN env vars instead.\n"
+  fi
+
   printf "${_GREEN}▸${_NC} Generated ansible.cfg with galaxy servers: $galaxy_servers\n"
 }
 
@@ -2180,6 +2186,32 @@ configure_pah_remotes() {
   echo "Configuring Private Automation Hub remotes..."
   # Requires AAP 2.7+ (uses Pulp v3 API)
 
+  # Check jq availability
+
+  # Retry wrapper for transient Pulp API failures (matches PowerShell: 6 attempts, 8s delay)
+  _retry_pulp_call() {
+    local max_attempts=6
+    local delay=8
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+      if "$@" 2>&1; then
+        return 0
+      fi
+
+      if [ $attempt -lt $max_attempts ]; then
+        printf "${_YELLOW}▸${_NC} API call failed (attempt $attempt/$max_attempts), retrying in ${delay}s...\n" >&2
+        sleep "$delay"
+      fi
+      attempt=$((attempt + 1))
+    done
+    return 1
+  }
+  if ! command -v jq >/dev/null 2>&1; then
+    _err "jq is required for PAH remote configuration"
+    echo "  Install: brew install jq (macOS) or sudo dnf install jq (RHEL/Fedora)"
+    return 1
+  fi
 
   # Detect credentials
   detect_galaxy_credentials
@@ -2275,7 +2307,7 @@ configure_pah_remotes() {
       | python3 -c "import sys, json; data=json.loads(sys.stdin.read() or '{}'); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -n "$repo_href" ]; then
-      curl -sk --max-time 10 -u "admin:${admin_pass}" \
+      _retry_pulp_call curl -sk --max-time 10 -u "admin:${admin_pass}" \
         -X POST \
         -H "Content-Type: application/json" \
         -d '{"mirror": false}' \

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2255,7 +2255,7 @@ configure_pah_remotes() {
     # Check if validated remote exists
     local validated_remote
     validated_remote=$(curl -sk -u "admin:${admin_pass}" \
-      "${api_base}/remotes/ansible/collection/?name=rh-validated" 2>/dev/null \
+      "${api_base}/remotes/ansible/collection/?name=validated" 2>/dev/null \
       | python3 -c "import sys, json; data=json.load(sys.stdin); print(data['results'][0]['pulp_href'] if data.get('results') else '')" 2>/dev/null)
 
     if [ -z "$validated_remote" ]; then
@@ -2265,7 +2265,7 @@ configure_pah_remotes() {
         -X POST \
         -H "Content-Type: application/json" \
         -d "{
-          \"name\": \"rh-validated\",
+          \"name\": \"validated\",
           \"url\": \"https://console.redhat.com/api/automation-hub/content/validated/\",
           \"token\": \"${GALAXY_TOKEN}\",
           \"tls_validation\": true

--- a/config/requirements.yml
+++ b/config/requirements.yml
@@ -1,6 +1,7 @@
 ---
 # Ansible collection requirements for aap-demo
-# Installed automatically during deployment from configured galaxy servers:
+# Install with: ansible-galaxy collection install -r config/requirements.yml
+# Priority order (tries in sequence):
 #   1. Private Automation Hub (if configured via ~/.aap-demo/pah-config.yml)
 #   2. console.redhat.com (if token present in ~/.aap-demo/galaxy-token)
 #   3. galaxy.ansible.com (community fallback)

--- a/config/requirements.yml
+++ b/config/requirements.yml
@@ -1,0 +1,21 @@
+---
+# Ansible collection requirements for aap-demo
+# Installed automatically during deployment from configured galaxy servers:
+#   1. Private Automation Hub (if configured via ~/.aap-demo/pah-config.yml)
+#   2. console.redhat.com (if token present in ~/.aap-demo/galaxy-token)
+#   3. galaxy.ansible.com (community fallback)
+
+collections:
+  # Red Hat Certified Collections (require authentication to console.redhat.com)
+  - name: ansible.controller
+    version: ">=4.6.0"
+
+  - name: infra.aap_configuration
+    version: ">=2.10.0"
+
+  # Community Collections (available from galaxy.ansible.com)
+  - name: kubernetes.core
+    version: ">=2.4.0"
+
+  - name: community.general
+    version: ">=6.0.0"

--- a/docs/adr/016-console-pah-authentication.md
+++ b/docs/adr/016-console-pah-authentication.md
@@ -1,0 +1,335 @@
+# ADR-016: Console.redhat.com and Private Automation Hub Authentication
+
+**Status**: Accepted
+
+**Date**: 2026-07-08
+
+**Authors**: aap-demo maintainers
+
+## Context
+
+aap-demo deploys Ansible Automation Platform 2.7 to OpenShift Local for development
+and testing. Users frequently need certified and private Ansible collections that are
+**not** published to the public `galaxy.ansible.com`:
+
+- **Certified collections** (e.g. `ansible.controller`, `redhat.rhel_system_roles`) are
+  available from `console.redhat.com` with a valid Red Hat subscription
+- **Private collections** (internal, pre-release, or organization-specific) are
+  published to Private Automation Hub (PAH) instances
+
+Currently, aap-demo has **no authentication mechanism** for either source. Users must:
+
+1. Manually configure `ansible.cfg` with galaxy server entries
+2. Generate and copy offline tokens from console.redhat.com
+3. Manually install collections via `ansible-galaxy collection install` after deployment
+4. Re-authenticate on every cluster recreate
+
+This creates significant friction:
+
+- **Manual overhead**: 5-10 minutes of repetitive authentication and collection installs
+- **Inconsistent environments**: developers use different collection versions depending
+  on when they last installed
+- **Testing gaps**: CI/CD pipelines skip certified collections due to auth complexity
+- **Credential exposure**: tokens pasted into shell commands and config files
+- **Version drift**: manual installs may pull newer patch versions than production uses
+
+Requirements:
+
+- Auto-detect console.redhat.com **offline token** from `~/.aap-demo/galaxy-token`
+- Support PAH authentication via `~/.aap-demo/pah-config.yml`
+- Prioritize collection sources: PAH → console.redhat.com → galaxy.ansible.com
+- Auto-generate `ansible.cfg` with multiple galaxy servers
+- Install collections from `requirements.yml` during `deploy`
+- Clear error messages when tokens are missing or expired
+- Show authenticated sources and available collections in `aap-demo status`
+- Optional skip via `SKIP_COLLECTIONS=true` for environments without auth
+
+## Decision
+
+Implement a **multi-source authentication and collection management system** that:
+
+1. **Detects credentials** from local config files (`~/.aap-demo/galaxy-token`,
+   `~/.aap-demo/pah-config.yml`)
+2. **Auto-generates ansible.cfg** with prioritized galaxy servers
+3. **Installs collections** from `config/requirements.yml` during `deploy`
+4. **Validates authentication** before attempting collection downloads
+5. **Reports source status** in `aap-demo status`
+
+### Credential detection and storage
+
+#### console.redhat.com offline token
+
+File: `~/.aap-demo/galaxy-token` (Windows: `%USERPROFILE%\.aap-demo\galaxy-token`)
+
+Format: Single line containing the offline token from
+https://console.redhat.com/ansible/automation-hub/token
+
+```
+eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI...
+```
+
+Generation:
+
+- User logs into console.redhat.com
+- Navigates to Connect to Hub → Get token
+- Copies offline token to `~/.aap-demo/galaxy-token`
+
+Token is refreshed automatically via OAuth2 device flow when expired.
+
+#### Private Automation Hub (PAH) config
+
+File: `~/.aap-demo/pah-config.yml`
+
+Format:
+
+```yaml
+url: https://pah.example.com/api/galaxy/
+token: your-pah-api-token-here
+verify_ssl: true  # optional, defaults to true
+```
+
+Generation:
+
+- User generates API token from PAH UI (Collections → API Token)
+- Creates `pah-config.yml` with URL and token
+
+### ansible.cfg generation
+
+`includes/collection-install.sh` (bash) and
+`powershell/native/Private/Helpers.ps1` (PowerShell) generate `ansible.cfg`:
+
+```ini
+[galaxy]
+server_list = pah, console_redhat, galaxy
+
+[galaxy_server.pah]
+url=https://pah.example.com/api/galaxy/
+token=<token-from-pah-config>
+
+[galaxy_server.console_redhat]
+url=https://console.redhat.com/api/automation-hub/
+token=<token-from-galaxy-token>
+
+[galaxy_server.galaxy]
+url=https://galaxy.ansible.com/
+```
+
+**Priority order**: PAH → console.redhat.com → galaxy.ansible.com
+
+- `ansible-galaxy collection install` tries servers in `server_list` order
+- First successful download wins
+- Private collections only exist in PAH → PAH must be first
+- Certified collections exist in console.redhat.com → second priority
+- Public collections fallback to galaxy.ansible.com
+
+Missing credentials result in omitted server entries (e.g., no PAH config → only
+console_redhat and galaxy in `server_list`).
+
+### Collection installation flow
+
+During `aap-demo deploy`:
+
+1. Detect credentials from `~/.aap-demo/`
+2. Generate `ansible.cfg` in `~/.aap-demo/ansible.cfg`
+3. Read `config/requirements.yml`:
+
+   ```yaml
+   collections:
+     - name: ansible.controller
+       version: ">=4.5.0"
+     - name: containers.podman
+   ```
+
+4. Run `ansible-galaxy collection install -r config/requirements.yml` with
+   `ANSIBLE_CONFIG=~/.aap-demo/ansible.cfg`
+5. Report installation status:
+   - Success → log collection name and version
+   - Auth failure → clear error with link to token generation
+   - Missing collection → suggest checking PAH or console.redhat.com availability
+   - Network failure → retry once, then warn and continue
+
+Collections install to `~/.ansible/collections` by default (not cluster-bound).
+Cluster recreate does **not** re-download already installed collections unless
+versions change.
+
+### Error handling and user feedback
+
+**Missing token**:
+
+```
+[WARN] console.redhat.com token not found at ~/.aap-demo/galaxy-token
+       Collections from console.redhat.com will not be available.
+       Generate token: https://console.redhat.com/ansible/automation-hub/token
+```
+
+**Expired token**:
+
+```
+[ERROR] console.redhat.com token expired. Attempting refresh...
+[INFO] Token refreshed successfully.
+```
+
+**PAH unreachable**:
+
+```
+[WARN] Private Automation Hub at https://pah.example.com unreachable.
+       Skipping PAH collections. Check VPN connection or pah-config.yml URL.
+```
+
+**Collection not found**:
+
+```
+[ERROR] Collection 'internal.custom_collection' not found in:
+        - PAH (https://pah.example.com)
+        - console.redhat.com
+        - galaxy.ansible.com
+        Ensure collection is published to PAH or check requirements.yml spelling.
+```
+
+### Status reporting
+
+`aap-demo status` output includes:
+
+```
+Collection Sources:
+  Private Automation Hub: ✓ Connected (https://pah.example.com)
+  console.redhat.com: ✓ Authenticated
+  galaxy.ansible.com: ✓ Available
+
+Installed Collections:
+  ansible.controller 4.5.1 (from console.redhat.com)
+  containers.podman 1.11.0 (from galaxy.ansible.com)
+  internal.custom_collection 2.3.0 (from PAH)
+```
+
+When `SKIP_COLLECTIONS=true` is set:
+
+```
+Collection Sources: Skipped (SKIP_COLLECTIONS=true)
+```
+
+### Opt-out behavior
+
+Set `SKIP_COLLECTIONS=true` to bypass all collection authentication and installation:
+
+```bash
+export SKIP_COLLECTIONS=true
+aap-demo deploy
+```
+
+Use cases:
+
+- Air-gapped environments
+- CI/CD pipelines with pre-cached collections
+- Debugging cluster deployment without collection overhead
+
+### Implementation files
+
+| File | Responsibility |
+|------|----------------|
+| `includes/collection-install.sh` | Bash implementation (Linux/macOS) |
+| `powershell/native/Private/Helpers.ps1` | PowerShell implementation (Windows) |
+| `config/requirements.yml` | Default collection manifest |
+| `~/.aap-demo/galaxy-token` | console.redhat.com offline token |
+| `~/.aap-demo/pah-config.yml` | PAH URL and API token |
+| `~/.aap-demo/ansible.cfg` | Generated multi-source galaxy config |
+
+## Consequences
+
+### Positive
+
+- **Automation**: Zero-touch collection installation after initial credential setup
+- **Consistency**: All developers use the same collection versions from `requirements.yml`
+- **Reproducibility**: Cluster recreate restores authenticated sources automatically
+- **Testing**: CI/CD can authenticate to console.redhat.com and PAH via file-based creds
+- **Security**: Tokens stored in user home directory, not committed to git
+- **Transparency**: `status` command shows exactly which sources are authenticated
+- **Source priority**: Private collections shadow certified collections (PAH first)
+- **Graceful degradation**: Missing PAH or console.redhat.com falls back to
+  galaxy.ansible.com for public collections
+
+### Negative
+
+- **Credential management burden**: Users must manually generate and store tokens
+  - console.redhat.com token generation requires Red Hat SSO login
+  - PAH token requires PAH admin or self-service token creation
+  - Token expiry requires manual refresh (OAuth2 refresh mitigates for console.redhat.com)
+- **Token security**: Plaintext tokens in `~/.aap-demo/` rely on filesystem permissions
+  - Mitigation: Files created with `0600` permissions (user read/write only)
+  - Risk: Local malware or shared machines may expose tokens
+- **Version drift in requirements.yml**: `>=4.5.0` may install different patch versions
+  on different days
+  - Mitigation: Pin exact versions (`==4.5.1`) when reproducibility is critical
+- **Network dependency**: Collection install fails if PAH or console.redhat.com are
+  unreachable at deploy time
+  - Mitigation: Retry logic + fallback to cached collections in `~/.ansible/collections`
+- **Windows credential store gap**: Tokens not integrated with Windows Credential Manager
+  - Future work: Optional keyring integration via PowerShell `CredentialManager` module
+
+### Neutral
+
+- Collection install is orthogonal to AAP deployment (AAP itself runs without collections)
+- `ansible-galaxy` CLI is already a dependency (ships with Ansible)
+- Token rotation frequency depends on console.redhat.com and PAH policies (not
+  controlled by aap-demo)
+- Galaxy server priority order (PAH → console → galaxy) is the same priority used
+  in production AAP deployments
+
+## Alternatives Considered
+
+### Manual ansible.cfg only (no auto-generation)
+
+Rejected: High user friction; every developer must hand-edit `ansible.cfg` and
+remember to update tokens after expiry. Does not solve version drift or consistency.
+
+### AAP UI-based collection configuration only
+
+Rejected: AAP UI requires post-deployment manual clicks; defeats automation goal.
+Also does not help CLI users (`ansible-navigator`, `ansible-playbook`) outside AAP.
+
+### Different priority order (console.redhat.com first, PAH second)
+
+Rejected: Breaks common use case where private collections **shadow** certified
+collections (e.g., `ansible.controller` with internal patches must override
+console.redhat.com version). PAH must be first.
+
+### Reverse priority order (galaxy.ansible.com first)
+
+Rejected: Would always download public versions even when certified or private
+versions exist. Defeats the purpose of PAH and console.redhat.com.
+
+### Store tokens in environment variables instead of files
+
+Rejected: Environment variables are less persistent (shell session scoped) and
+harder to manage across `create`, `deploy`, `status` commands. Files allow
+one-time setup.
+
+### Keyring integration for credential storage
+
+Considered but deferred: Would improve security on Windows (Credential Manager),
+macOS (Keychain), and Linux (Secret Service API). However:
+
+- Adds complexity (platform-specific keyring libraries)
+- Not all environments have keyring available (headless CI/CD)
+- File-based tokens are simpler for initial implementation
+
+Future enhancement: Optional keyring backend when `~/.aap-demo/use-keyring` exists.
+
+### Embed tokens in aap-demo config file
+
+Rejected: Config file may be committed to version control or shared in screenshots.
+Separate credential files reduce accidental exposure.
+
+### Collection caching to avoid re-download on recreate
+
+Already implemented: `ansible-galaxy` caches to `~/.ansible/collections`. Cluster
+recreate does not trigger re-download unless collection versions change in
+`requirements.yml`.
+
+## References
+
+- Issue #36: [Add console.redhat.com and PAH authentication](https://github.com/chadalen/aap-demo/issues/36)
+- [console.redhat.com Automation Hub](https://console.redhat.com/ansible/automation-hub/)
+- [Private Automation Hub documentation](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.7/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/)
+- [ansible-galaxy collection install](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html#ansible-galaxy-collection-install)
+- [ansible.cfg galaxy_server configuration](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#galaxy-server-list)

--- a/docs/adr/016-console-pah-authentication.md
+++ b/docs/adr/016-console-pah-authentication.md
@@ -97,7 +97,7 @@ Generation:
 
 ### ansible.cfg generation
 
-`includes/collection-install.sh` (bash) and
+`aap-demo.sh` (bash functions: detect_galaxy_credentials, generate_ansible_cfg, install_collections, configure_pah_remotes) and
 `powershell/native/Private/Helpers.ps1` (PowerShell) generate `ansible.cfg`:
 
 ```ini
@@ -270,7 +270,7 @@ Use cases:
 
 | File | Responsibility |
 |------|----------------|
-| `includes/collection-install.sh` | Bash implementation (Linux/macOS) |
+| `aap-demo.sh` (inline functions) | Bash implementation (Linux/macOS) |
 | `powershell/native/Private/Helpers.ps1` | PowerShell implementation (Windows) |
 | `config/requirements.yml` | Default collection manifest |
 | `~/.aap-demo/galaxy-token` | console.redhat.com offline token |

--- a/docs/adr/016-console-pah-authentication.md
+++ b/docs/adr/016-console-pah-authentication.md
@@ -50,10 +50,16 @@ Implement a **multi-source authentication and collection management system** tha
 
 1. **Detects credentials** from local config files (`~/.aap-demo/galaxy-token`,
    `~/.aap-demo/pah-config.yml`)
-2. **Auto-generates ansible.cfg** with prioritized galaxy servers
-3. **Installs collections** from `config/requirements.yml` during `deploy`
-4. **Validates authentication** before attempting collection downloads
-5. **Reports source status** in `aap-demo status`
+2. **Configures AAP's integrated Private Automation Hub** with console.redhat.com
+   and external PAH remotes
+3. **Syncs certified collections** into local PAH from console.redhat.com
+4. **Auto-generates ansible.cfg** with prioritized galaxy servers for local use
+5. **Validates authentication** before attempting collection downloads
+6. **Reports source status** in `aap-demo status`
+
+**Key insight**: AAP 2.7 includes an integrated Private Automation Hub instance.
+Rather than configuring Controller to pull from external sources, we configure
+PAH to **sync** from console.redhat.com, then Controller uses the local PAH.
 
 ### Credential detection and storage
 
@@ -129,9 +135,13 @@ console_redhat and galaxy in `server_list`).
 
 During `aap-demo deploy`:
 
-1. Detect credentials from `~/.aap-demo/`
-2. Generate `ansible.cfg` in `~/.aap-demo/ansible.cfg`
-3. Read `config/requirements.yml`:
+1. **Detect credentials** from `~/.aap-demo/`
+2. **Configure AAP PAH remotes** via Pulp API:
+   - Update `rh-certified` remote with offline token from `galaxy-token`
+   - Trigger background sync of certified collections
+   - Create `external-pah` remote if `pah-config.yml` exists
+3. **Generate ansible.cfg** in `~/.aap-demo/ansible.cfg` for local dev use
+4. **Install collections locally** (optional) from `config/requirements.yml`:
 
    ```yaml
    collections:
@@ -140,17 +150,29 @@ During `aap-demo deploy`:
      - name: containers.podman
    ```
 
-4. Run `ansible-galaxy collection install -r config/requirements.yml` with
-   `ANSIBLE_CONFIG=~/.aap-demo/ansible.cfg`
-5. Report installation status:
-   - Success → log collection name and version
-   - Auth failure → clear error with link to token generation
-   - Missing collection → suggest checking PAH or console.redhat.com availability
-   - Network failure → retry once, then warn and continue
+#### PAH Remote Configuration
 
-Collections install to `~/.ansible/collections` by default (not cluster-bound).
-Cluster recreate does **not** re-download already installed collections unless
-versions change.
+Uses Pulp API (`/api/galaxy/pulp/api/v3/`) to configure collection sources:
+
+```bash
+# Update rh-certified remote token
+PATCH /remotes/ansible/collection/{uuid}/
+{
+  "token": "<offline-token-from-galaxy-token>"
+}
+
+# Sync repository
+POST /repositories/ansible/ansible/{uuid}/sync/
+{
+  "mirror": false
+}
+```
+
+Collections sync into PAH's `rh-certified` repository. Controller jobs then
+pull from local PAH (`https://aap.../api/galaxy/content/rh-certified/`), not
+external console.redhat.com.
+
+Local `ansible.cfg` generation remains for CLI/dev use outside Controller.
 
 ### Error handling and user feedback
 

--- a/docs/adr/016-console-pah-authentication.md
+++ b/docs/adr/016-console-pah-authentication.md
@@ -97,7 +97,8 @@ Generation:
 
 ### ansible.cfg generation
 
-`aap-demo.sh` (bash functions: detect_galaxy_credentials, generate_ansible_cfg, install_collections, configure_pah_remotes) and
+`aap-demo.sh` (bash functions: detect_galaxy_credentials, generate_ansible_cfg, install_collections,
+configure_pah_remotes) and
 `powershell/native/Private/Helpers.ps1` (PowerShell) generate `ansible.cfg`:
 
 ```ini

--- a/docs/adr/016-console-pah-authentication.md
+++ b/docs/adr/016-console-pah-authentication.md
@@ -70,10 +70,6 @@ File: `~/.aap-demo/galaxy-token` (Windows: `%USERPROFILE%\.aap-demo\galaxy-token
 Format: Single line containing the offline token from
 https://console.redhat.com/ansible/automation-hub/token
 
-```
-eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI...
-```
-
 Generation:
 
 - User logs into console.redhat.com
@@ -136,12 +132,21 @@ console_redhat and galaxy in `server_list`).
 During `aap-demo deploy`:
 
 1. **Detect credentials** from `~/.aap-demo/`
-2. **Configure AAP PAH remotes** via Pulp API:
-   - Update `rh-certified` remote with offline token from `galaxy-token`
-   - Trigger background sync of certified collections
-   - Create `external-pah` remote if `pah-config.yml` exists
-3. **Generate ansible.cfg** in `~/.aap-demo/ansible.cfg` for local dev use
-4. **Install collections locally** (optional) from `config/requirements.yml`:
+2. **Validate tokens** (format and presence checks)
+3. **Generate ansible.cfg** for local CLI use with prioritized galaxy servers
+4. **Install collections locally** (optional) from `config/requirements.yml`
+
+After deployment, configure AAP's integrated PAH:
+
+```bash
+aap-demo setup-pah
+```
+
+This command:
+
+- Updates `rh-certified` remote with offline token from `galaxy-token`
+- Triggers background sync of certified collections into local PAH
+- Creates `rh-validated` remote for validated content
 
    ```yaml
    collections:
@@ -152,13 +157,29 @@ During `aap-demo deploy`:
 
 #### PAH Remote Configuration
 
-Uses Pulp API (`/api/galaxy/pulp/api/v3/`) to configure collection sources:
+Uses Pulp API (`/api/galaxy/pulp/api/v3/`) to configure two collection remotes:
+
+**rh-certified**: Red Hat Certified Content Collections
+
+- Pre-configured in AAP 2.7
+- Updated with offline token from `~/.aap-demo/galaxy-token`
+- Syncs from `https://console.redhat.com/api/automation-hub/`
+- Repository: `rh-certified`
+
+**rh-validated**: Red Hat Validated Content Collections
+
+- Created by `setup-pah` if not present
+- Uses same offline token as rh-certified
+- Syncs from `https://console.redhat.com/api/automation-hub/v3/plugin/ansible/content/validated/`
+- Repository: `validated`
+
+API example:
 
 ```bash
-# Update rh-certified remote token
+# Update remote token
 PATCH /remotes/ansible/collection/{uuid}/
 {
-  "token": "<offline-token-from-galaxy-token>"
+  "token": "YOUR_OFFLINE_TOKEN"
 }
 
 # Sync repository
@@ -168,9 +189,9 @@ POST /repositories/ansible/ansible/{uuid}/sync/
 }
 ```
 
-Collections sync into PAH's `rh-certified` repository. Controller jobs then
-pull from local PAH (`https://aap.../api/galaxy/content/rh-certified/`), not
-external console.redhat.com.
+Collections sync into PAH's local repositories. Controller jobs then pull from
+local PAH (`https://aap.../api/galaxy/content/rh-certified/`), not external
+console.redhat.com.
 
 Local `ansible.cfg` generation remains for CLI/dev use outside Controller.
 

--- a/docs/collection-authentication.md
+++ b/docs/collection-authentication.md
@@ -1,0 +1,299 @@
+# Collection Authentication for aap-demo
+
+This guide explains how to configure authentication for downloading Ansible collections from Red Hat's certified content sources and Private Automation Hub (PAH).
+
+## Overview
+
+aap-demo supports multiple collection sources with automatic priority-based selection:
+
+1. **Private Automation Hub** (PAH) — your organization's private collections
+2. **console.redhat.com** — Red Hat certified collections
+3. **galaxy.ansible.com** — community collections (fallback)
+
+Authentication is optional but recommended for accessing certified collections like `ansible.controller` and `infra.aap_configuration`.
+
+## Getting a console.redhat.com Token
+
+Red Hat Automation Hub offline tokens allow CLI access to certified collections.
+
+### Steps
+
+1. Log in to [Red Hat Hybrid Cloud Console](https://console.redhat.com)
+2. Navigate to **Ansible** → **Automation Hub** → **Connect to Hub**
+3. Click **Load token**
+4. Copy the **Offline Token** (long base64 string, ~1500 characters)
+5. Save to `~/.aap-demo/galaxy-token`:
+
+   ```bash
+   echo "YOUR_OFFLINE_TOKEN_HERE" > ~/.aap-demo/galaxy-token
+   chmod 600 ~/.aap-demo/galaxy-token
+   ```
+
+### Token Scope
+
+Offline tokens provide access to:
+
+- Red Hat Certified Content Collections
+- Red Hat Ansible Automation Platform collections
+- Execution environments
+
+Tokens are tied to your Red Hat account and subscription entitlements.
+
+## Configuring Private Automation Hub (PAH)
+
+If your organization runs a Private Automation Hub, you can prioritize it over console.redhat.com.
+
+### Configuration File Format
+
+Create `~/.aap-demo/pah-config.yml`:
+
+```yaml
+# Token-based authentication (recommended)
+url: https://pah.example.com
+token: YOUR_PAH_TOKEN_HERE
+```
+
+Or username/password authentication:
+
+```yaml
+# Username/password authentication
+url: https://pah.example.com
+username: your-username
+password: your-password
+```
+
+### Getting a PAH Token
+
+Token generation varies by PAH version:
+
+**AAP 2.4+:**
+
+1. Log into PAH web UI
+2. Navigate to **User Preferences** → **API Token**
+3. Click **Load token** or **Generate new token**
+4. Copy and save to `pah-config.yml`
+
+**Earlier versions:** Use username/password in config file.
+
+## Collection Source Priority
+
+aap-demo uses the first available source:
+
+| Priority | Source | Credential Required | Collections Available |
+|----------|--------|---------------------|----------------------|
+| 1 | Private Automation Hub | PAH token/credentials | Your organization's collections |
+| 2 | console.redhat.com | Offline token | Red Hat Certified |
+| 3 | galaxy.ansible.com | None | Community |
+
+### Example Scenarios
+
+**Scenario 1: No authentication configured**
+
+- Downloads from `galaxy.ansible.com` only
+- Community collections install successfully
+- Certified collections (`ansible.controller`, `infra.aap_configuration`) fail
+
+**Scenario 2: console.redhat.com token configured**
+
+- Downloads certified collections from console.redhat.com
+- Falls back to galaxy.ansible.com for community-only collections
+- Recommended for most users
+
+**Scenario 3: PAH + console.redhat.com both configured**
+
+- Tries PAH first (for private collections)
+- Falls back to console.redhat.com (for certified collections)
+- Uses galaxy.ansible.com for community collections
+- Recommended for enterprise deployments
+
+## Deployment Workflow
+
+When you run `aap-demo deploy`, the tool automatically:
+
+1. **Detects credentials**: Checks `~/.aap-demo/galaxy-token` and `~/.aap-demo/pah-config.yml`
+2. **Validates authentication**: Verifies token formats and configuration
+3. **Generates ansible.cfg**: Creates galaxy server configuration with detected sources
+4. **Installs collections**: Runs `ansible-galaxy collection install -r config/requirements.yml`
+
+### Requirements File
+
+Default collections in `config/requirements.yml`:
+
+```yaml
+collections:
+  # Red Hat Certified (require console.redhat.com authentication)
+  - name: ansible.controller
+    version: ">=4.6.0"
+  - name: infra.aap_configuration
+    version: ">=2.10.0"
+
+  # Community (available without authentication)
+  - name: kubernetes.core
+    version: ">=2.4.0"
+  - name: community.general
+    version: ">=6.0.0"
+```
+
+You can customize by editing this file or creating your own.
+
+## Skipping Collection Installation
+
+To deploy AAP without installing collections:
+
+```bash
+SKIP_COLLECTIONS=true aap-demo deploy
+```
+
+Useful for:
+
+- Testing deployment without waiting for collection downloads
+- Using pre-installed collections
+- Troubleshooting authentication issues
+
+## Checking Collection Status
+
+### View Configured Sources
+
+```bash
+aap-demo status
+```
+
+Shows:
+
+- Which galaxy servers are configured
+- Whether console.redhat.com token is present
+- Number of installed certified collections
+
+Example output:
+
+```
+Collection Sources:
+-------------------
+  Red Hat Certified:   console.redhat.com (authenticated)
+  Community:           galaxy.ansible.com
+  Installed:           4 certified collections
+```
+
+### Diagnose Collection Issues
+
+```bash
+aap-demo diagnose
+```
+
+Validates:
+
+- `ansible.cfg` galaxy server configuration
+- Credential file existence
+- Required collection installation
+
+Example output:
+
+```
+Collection Sources:
+  ✓ ansible.cfg exists
+  ✓ Galaxy server configuration present
+  ✓ console.redhat.com token present
+  ✓ Collection ansible.controller installed
+  ✓ Collection infra.aap_configuration installed
+```
+
+## Troubleshooting
+
+### Error: "Failed to install collections"
+
+**Cause**: Authentication failure or network issue.
+
+**Solutions**:
+
+1. **Verify token format**:
+
+   ```bash
+   wc -c ~/.aap-demo/galaxy-token
+   # Should show ~1500 characters for offline token
+   ```
+
+2. **Test connectivity**:
+
+   ```bash
+   curl -H "Authorization: Bearer $(cat ~/.aap-demo/galaxy-token)" \
+     https://console.redhat.com/api/automation-hub/v3/collections/
+   ```
+
+3. **Check subscription access**:
+   - Log into https://console.redhat.com
+   - Verify active Red Hat Ansible Automation Platform subscription
+
+4. **Skip collections temporarily**:
+
+   ```bash
+   SKIP_COLLECTIONS=true aap-demo deploy
+   ```
+
+### Error: "Invalid galaxy token format (too short)"
+
+**Cause**: Token file contains a refresh token instead of an offline token, or is corrupted.
+
+**Solution**: Return to console.redhat.com and copy the **Offline Token** (not the Refresh Token). Offline tokens are ~1500 characters.
+
+### Warning: "Collection ansible.controller not found"
+
+**Cause**: Collection requires Red Hat Certified content access.
+
+**Solutions**:
+
+1. **Configure console.redhat.com token** (see above)
+2. **Use community alternative**: Edit `config/requirements.yml` to use `awx.awx` instead of `ansible.controller`
+
+### PAH Connection Failures
+
+**Cause**: PAH URL unreachable or credentials invalid.
+
+**Solutions**:
+
+1. **Verify URL**: Test PAH accessibility:
+
+   ```bash
+   curl https://pah.example.com/api/galaxy/
+   ```
+
+2. **Check token/credentials**: Log into PAH web UI with same credentials
+
+3. **Remove PAH config temporarily**:
+
+   ```bash
+   mv ~/.aap-demo/pah-config.yml ~/.aap-demo/pah-config.yml.bak
+   aap-demo deploy
+   ```
+
+## Environment Variables
+
+Override default file locations:
+
+```bash
+GALAXY_TOKEN_FILE=~/custom/path/token aap-demo deploy
+PAH_CONFIG_FILE=~/custom/path/pah.yml aap-demo deploy
+SKIP_COLLECTIONS=true aap-demo deploy
+```
+
+## Security Considerations
+
+**Token Storage**: Tokens are stored in plaintext files. Protect with file permissions:
+
+```bash
+chmod 600 ~/.aap-demo/galaxy-token
+chmod 600 ~/.aap-demo/pah-config.yml
+```
+
+**Token Rotation**: Offline tokens don't expire automatically, but should be rotated periodically:
+
+1. Generate new token from console.redhat.com
+2. Update `~/.aap-demo/galaxy-token`
+3. No redeployment needed — new collections will use new token
+
+**Future Enhancement**: Keyring integration for encrypted credential storage (tracked in future ADR).
+
+## References
+
+- [Red Hat Automation Hub Documentation](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/)
+- [Ansible Galaxy CLI Documentation](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html)
+- [ADR-016: Console.redhat.com and PAH Authentication](../adr/016-console-pah-authentication.md)

--- a/docs/collection-authentication.md
+++ b/docs/collection-authentication.md
@@ -1,6 +1,6 @@
 # Collection Authentication for aap-demo
 
-This guide explains how to configure authentication for downloading Ansible collections from Red Hat's certified content sources and Private Automation Hub (PAH).
+This guide explains how to configure authentication for downloading collections from Red Hat sources and Private Hub.
 
 ## Overview
 
@@ -87,19 +87,19 @@ aap-demo uses the first available source:
 
 ### Example Scenarios
 
-**Scenario 1: No authentication configured**
+#### Scenario 1: No authentication configured**
 
 - Downloads from `galaxy.ansible.com` only
 - Community collections install successfully
 - Certified collections (`ansible.controller`, `infra.aap_configuration`) fail
 
-**Scenario 2: console.redhat.com token configured**
+#### Scenario 2: console.redhat.com token configured**
 
 - Downloads certified collections from console.redhat.com
 - Falls back to galaxy.ansible.com for community-only collections
 - Recommended for most users
 
-**Scenario 3: PAH + console.redhat.com both configured**
+#### Scenario 3: PAH + console.redhat.com both configured**
 
 - Tries PAH first (for private collections)
 - Falls back to console.redhat.com (for certified collections)
@@ -233,7 +233,7 @@ Collection Sources:
 
 **Cause**: Token file contains a refresh token instead of an offline token, or is corrupted.
 
-**Solution**: Return to console.redhat.com and copy the **Offline Token** (not the Refresh Token). Offline tokens are ~1500 characters.
+**Solution**: Return to console.redhat.com and copy the **Offline Token** (not the Refresh Token). They are ~1500 characters.
 
 ### Warning: "Collection ansible.controller not found"
 

--- a/powershell/aap-demo.ps1
+++ b/powershell/aap-demo.ps1
@@ -236,6 +236,12 @@ try {
 
     'setup' { Invoke-AapDemoSetup }
 
+    'setup-pah' {
+      $params = @{}
+      if ($cli.Namespace) { $params.Namespace = $cli.Namespace }
+      Invoke-AapDemoSetupPah @params
+    }
+
     'ssh' { Invoke-AapDemoSsh }
 
     'kubeconfig' { Invoke-AapDemoKubeconfig }

--- a/powershell/native/AapDemo.psm1
+++ b/powershell/native/AapDemo.psm1
@@ -22,6 +22,8 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 
 . (Join-Path $PrivateDir 'Commands.ps1')
 
+. (Join-Path $PrivateDir 'Collections.ps1')
+
 
 
 Export-ModuleMember -Function @(
@@ -71,6 +73,8 @@ Export-ModuleMember -Function @(
   'Invoke-AapDemoRedeployAll'
 
   'Get-AapDemoHelp'
+
+  'Invoke-AapDemoSetupPah'
 
 )
 

--- a/powershell/native/Private/Collections.ps1
+++ b/powershell/native/Private/Collections.ps1
@@ -231,6 +231,11 @@ function Join-AapPulpUrl {
   )
 
   if ($Href -match '^https?://') { return $Href }
+  if ($Href -match '^/api/galaxy/') {
+    if ($ApiBase -match '^(https?://[^/]+)') {
+      return "$($Matches[1])$Href"
+    }
+  }
   return "$ApiBase$Href"
 }
 
@@ -257,8 +262,11 @@ function Invoke-AapPulpCurl {
     'PATCH' { $curlArgs += '-X', 'PATCH' }
   }
 
+  $bodyFile = $null
   if ($Body) {
-    $curlArgs += '-H', 'Content-Type: application/json', '-d', $Body
+    $bodyFile = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($bodyFile, $Body, [System.Text.UTF8Encoding]::new($false))
+    $curlArgs += '-H', 'Content-Type: application/json', '--data-binary', "@$bodyFile"
   }
 
   $curlArgs += $Url
@@ -270,6 +278,9 @@ function Invoke-AapPulpCurl {
     $exitCode = $LASTEXITCODE
   } finally {
     $ErrorActionPreference = $previousEap
+    if ($bodyFile -and (Test-Path -LiteralPath $bodyFile)) {
+      Remove-Item -LiteralPath $bodyFile -Force -ErrorAction SilentlyContinue
+    }
   }
 
   $httpCode = 0
@@ -294,7 +305,7 @@ function Format-AapPulpErrorDetail {
   )
 
   if ($HttpCode -in 502, 503, 504) {
-    return "Hub returned HTTP $HttpCode (temporary upstream error - hub may be busy; re-run: aap-demo setup-pah)"
+    return "Hub returned HTTP $HttpCode (gateway or upstream error; re-run: aap-demo setup-pah)"
   }
 
   if ($ResponseBody -and $ResponseBody -notmatch '__HTTP_CODE__') {
@@ -314,6 +325,34 @@ function Format-AapPulpErrorDetail {
   return 'No response from hub API'
 }
 
+function Invoke-AapPulpMutatingWithRetry {
+  param(
+    [Parameter(Mandatory)][string]$Url,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [ValidateSet('POST', 'PATCH')]
+    [string]$Method = 'POST',
+    [Parameter(Mandatory)][string]$Body,
+    [int]$MaxAttempts = 6,
+    [int]$DelaySeconds = 8,
+    [int]$TimeoutSeconds = 60
+  )
+
+  $result = $null
+  for ($i = 1; $i -le $MaxAttempts; $i++) {
+    $result = Invoke-AapPulpCurl -Url $Url -AdminPassword $AdminPassword -Method $Method `
+      -Body $Body -TimeoutSeconds $TimeoutSeconds
+    if ($result.Ok) { return $result }
+    if ($Method -eq 'POST' -and $result.HttpCode -eq 400 -and $result.Body -match 'unique|already exists|must be unique') {
+      return $result
+    }
+    if ($result.HttpCode -notin 502, 503, 504) { return $result }
+    if ($i -lt $MaxAttempts) {
+      Start-Sleep -Seconds $DelaySeconds
+    }
+  }
+  return $result
+}
+
 function Invoke-AapPulpPostWithRetry {
   param(
     [Parameter(Mandatory)][string]$Url,
@@ -324,20 +363,8 @@ function Invoke-AapPulpPostWithRetry {
     [int]$TimeoutSeconds = 60
   )
 
-  $result = $null
-  for ($i = 1; $i -le $MaxAttempts; $i++) {
-    $result = Invoke-AapPulpCurl -Url $Url -AdminPassword $AdminPassword -Method 'POST' `
-      -Body $Body -TimeoutSeconds $TimeoutSeconds
-    if ($result.Ok) { return $result }
-    if ($result.HttpCode -eq 400 -and $result.Body -match 'unique|already exists|must be unique') {
-      return $result
-    }
-    if ($result.HttpCode -notin 502, 503, 504) { return $result }
-    if ($i -lt $MaxAttempts) {
-      Start-Sleep -Seconds $DelaySeconds
-    }
-  }
-  return $result
+  return Invoke-AapPulpMutatingWithRetry -Url $Url -AdminPassword $AdminPassword -Method 'POST' `
+    -Body $Body -MaxAttempts $MaxAttempts -DelaySeconds $DelaySeconds -TimeoutSeconds $TimeoutSeconds
 }
 
 function Invoke-AapPulpRequest {
@@ -351,9 +378,14 @@ function Invoke-AapPulpRequest {
 
   $result = Invoke-AapPulpCurl -Url $Url -AdminPassword $AdminPassword -Method $Method -Body $Body
   if ($result.ExitCode -ne 0 -and [string]::IsNullOrWhiteSpace($result.Body)) {
-    return $null
+    return [PSCustomObject]@{
+      Body     = $null
+      HttpCode = $result.HttpCode
+      ExitCode = $result.ExitCode
+      Ok       = $false
+    }
   }
-  return $result.Body
+  return $result
 }
 
 function Get-AapPulpApiAvailability {
@@ -416,6 +448,8 @@ function Write-AapPulpCreateFailureHint {
     [Parameter(Mandatory)][string]$AdminPassword,
     [Parameter(Mandatory)][string]$Namespace,
     [Parameter(Mandatory)][string]$AapRoute,
+    [ValidateSet('create', 'update', 'link', 'sync')]
+    [string]$Operation = 'create',
     [int]$HttpCode = 0,
     [AllowNull()][string]$ResponseBody = $null
   )
@@ -431,7 +465,13 @@ function Write-AapPulpCreateFailureHint {
     return
   }
 
-  Write-Host '    Pulp API is reachable; remote create failed' -ForegroundColor Yellow
+  $operationLabel = switch ($Operation) {
+    'update' { 'remote update failed' }
+    'link'   { 'repository link failed' }
+    'sync'   { 'repository sync failed' }
+    default  { 'remote create failed' }
+  }
+  Write-Host "    Pulp API is reachable; $operationLabel" -ForegroundColor Yellow
   $detail = Format-AapPulpErrorDetail -HttpCode $HttpCode -ResponseBody $ResponseBody
   Write-Host "    $detail"
 }
@@ -445,8 +485,9 @@ function Get-AapPulpResourceHref {
   )
 
   $url = if ($Name) { "${ResourceUrl}?name=${Name}" } else { $ResourceUrl }
-  $raw = Invoke-AapPulpRequest -Url $url -AdminPassword $AdminPassword
-  return Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $raw)
+  $result = Invoke-AapPulpRequest -Url $url -AdminPassword $AdminPassword
+  if (-not $result.Ok) { return $null }
+  return Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $result.Body)
 }
 
 function Wait-AapPulpTask {
@@ -459,13 +500,62 @@ function Wait-AapPulpTask {
   for ($i = 1; $i -le 10; $i++) {
     Start-Sleep -Seconds 1
     $taskUrl = Join-AapPulpUrl -ApiBase $ApiBase -Href $TaskHref
-    $raw = Invoke-AapPulpRequest -Url $taskUrl -AdminPassword $AdminPassword
-    $task = ConvertFrom-AapPulpJson -Raw $raw
+    $result = Invoke-AapPulpRequest -Url $taskUrl -AdminPassword $AdminPassword
+    if (-not $result.Ok) { continue }
+    $task = ConvertFrom-AapPulpJson -Raw $result.Body
     if ($task -and [string]$task.state -eq 'completed') {
       return $true
     }
   }
   return $false
+}
+
+function Update-AapPulpRemoteToken {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$RemoteHref,
+    [Parameter(Mandatory)][string]$Token
+  )
+
+  $patchBody = (@{ token = $Token } | ConvertTo-Json -Compress)
+  $patchUrl = Join-AapPulpUrl -ApiBase $ApiBase -Href $RemoteHref
+  $patchResult = Invoke-AapPulpMutatingWithRetry -Url $patchUrl -AdminPassword $AdminPassword `
+    -Method 'PATCH' -Body $patchBody
+  if (-not $patchResult.Ok) {
+    return $patchResult
+  }
+
+  $patchData = ConvertFrom-AapPulpJson -Raw $patchResult.Body
+  if ($patchData -and $patchData.task) {
+    Wait-AapPulpTask -ApiBase $ApiBase -AdminPassword $AdminPassword -TaskHref ([string]$patchData.task) | Out-Null
+  }
+  return $patchResult
+}
+
+function Set-AapPulpCollectionRemote {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$RemotesUrl,
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string]$RemoteUrl,
+    [Parameter(Mandatory)][string]$Token
+  )
+
+  $href = Get-AapPulpResourceHref -AdminPassword $AdminPassword -ResourceUrl $RemotesUrl -Name $Name
+  if ($href) {
+    return Update-AapPulpRemoteToken -ApiBase $ApiBase -AdminPassword $AdminPassword `
+      -RemoteHref $href -Token $Token
+  }
+
+  $createBody = (@{
+      name           = $Name
+      url            = $RemoteUrl
+      token          = $Token
+      tls_validation = $true
+    } | ConvertTo-Json -Compress)
+  return Invoke-AapPulpPostWithRetry -Url $RemotesUrl -AdminPassword $AdminPassword -Body $createBody
 }
 
 function Set-AapPahRemotes {
@@ -502,93 +592,64 @@ function Set-AapPahRemotes {
   }
 
   if ($Credentials.GalaxyToken) {
-    Write-Host -NoNewline '  Configuring rh-certified remote... '
-    $certifiedRemote = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
-      -ResourceUrl $remotesUrl -Name 'rh-certified'
-    $certifiedCreateResult = $null
+    $certifiedRemote = $null
+    $validatedRemote = $null
 
-    if ($certifiedRemote) {
-      $patchBody = (@{ token = $Credentials.GalaxyToken } | ConvertTo-Json -Compress)
-      $patchUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRemote
-      $patchRaw = Invoke-AapPulpRequest -Url $patchUrl -AdminPassword $adminPass -Method 'PATCH' -Body $patchBody
-      $patchData = ConvertFrom-AapPulpJson -Raw $patchRaw
-      if ($patchData -and $patchData.task) {
-        Wait-AapPulpTask -ApiBase $apiBase -AdminPassword $adminPass -TaskHref ([string]$patchData.task) | Out-Null
-      }
+    Write-Host -NoNewline '  Configuring rh-certified remote... '
+    $certifiedResult = Set-AapPulpCollectionRemote -ApiBase $apiBase -AdminPassword $adminPass `
+      -RemotesUrl $remotesUrl -Name 'rh-certified' `
+      -RemoteUrl 'https://console.redhat.com/api/automation-hub/content/published/' `
+      -Token $Credentials.GalaxyToken
+    $certifiedRemote = Get-AapPulpResourceHref -AdminPassword $adminPass -ResourceUrl $remotesUrl -Name 'rh-certified'
+    if (-not $certifiedRemote) {
+      $certifiedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $certifiedResult.Body)
+    }
+    if ($certifiedResult.Ok -and $certifiedRemote) {
       Write-Host 'OK' -ForegroundColor Green
     } else {
-      $createBody = (@{
-          name           = 'rh-certified'
-          url            = 'https://console.redhat.com/api/automation-hub/content/published/'
-          token          = $Credentials.GalaxyToken
-          tls_validation = $true
-        } | ConvertTo-Json -Compress)
-      $certifiedCreateResult = Invoke-AapPulpPostWithRetry -Url $remotesUrl -AdminPassword $adminPass -Body $createBody
-      $certifiedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $certifiedCreateResult.Body)
-
-      if ($certifiedRemote) {
-        Write-Host 'OK' -ForegroundColor Green
-      } else {
-        Write-Host 'WARN (create failed)' -ForegroundColor Yellow
-        Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
-          -Namespace $Namespace -AapRoute $aapRoute -HttpCode $certifiedCreateResult.HttpCode `
-          -ResponseBody $certifiedCreateResult.Body
-      }
-    }
-
-    if ($certifiedRemote) {
-      $certifiedRepo = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
-        -ResourceUrl $reposUrl -Name 'rh-certified'
-      if ($certifiedRepo) {
-        $linkBody = (@{ remote = $certifiedRemote } | ConvertTo-Json -Compress)
-        $linkUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepo
-        Invoke-AapPulpRequest -Url $linkUrl -AdminPassword $adminPass -Method 'PATCH' -Body $linkBody | Out-Null
-      }
-    }
-
-    Write-Host -NoNewline '  Syncing rh-certified... '
-    $certifiedRepo = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
-      -ResourceUrl $reposUrl -Name 'rh-certified'
-    if ($certifiedRepo) {
-      $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepo).TrimEnd('/') + 'sync/'
-      Invoke-AapPulpRequest -Url $syncUrl -AdminPassword $adminPass -Method 'POST' -Body '{"mirror":false}' | Out-Null
-      Write-Host 'OK (background)' -ForegroundColor Green
-    } else {
-      Write-Host 'WARN (repository not found)' -ForegroundColor Yellow
+      Write-Host 'WARN (configure failed)' -ForegroundColor Yellow
+      Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+        -Namespace $Namespace -AapRoute $aapRoute -Operation $(if ($certifiedRemote) { 'update' } else { 'create' }) `
+        -HttpCode $certifiedResult.HttpCode -ResponseBody $certifiedResult.Body
     }
 
     Write-Host -NoNewline '  Configuring rh-validated remote... '
-    $validatedRemote = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
-      -ResourceUrl $remotesUrl -Name 'rh-validated'
-    $validatedCreateResult = $null
-
-    if ($validatedRemote) {
-      $patchBody = (@{ token = $Credentials.GalaxyToken } | ConvertTo-Json -Compress)
-      $patchUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRemote
-      $patchRaw = Invoke-AapPulpRequest -Url $patchUrl -AdminPassword $adminPass -Method 'PATCH' -Body $patchBody
-      $patchData = ConvertFrom-AapPulpJson -Raw $patchRaw
-      if ($patchData -and $patchData.task) {
-        Wait-AapPulpTask -ApiBase $apiBase -AdminPassword $adminPass -TaskHref ([string]$patchData.task) | Out-Null
-      }
+    $validatedResult = Set-AapPulpCollectionRemote -ApiBase $apiBase -AdminPassword $adminPass `
+      -RemotesUrl $remotesUrl -Name 'rh-validated' `
+      -RemoteUrl 'https://console.redhat.com/api/automation-hub/content/validated/' `
+      -Token $Credentials.GalaxyToken
+    $validatedRemote = Get-AapPulpResourceHref -AdminPassword $adminPass -ResourceUrl $remotesUrl -Name 'rh-validated'
+    if (-not $validatedRemote) {
+      $validatedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $validatedResult.Body)
+    }
+    if ($validatedResult.Ok -and $validatedRemote) {
       Write-Host 'OK' -ForegroundColor Green
     } else {
-      $createBody = (@{
-          name           = 'rh-validated'
-          url            = 'https://console.redhat.com/api/automation-hub/content/validated/'
-          token          = $Credentials.GalaxyToken
-          tls_validation = $true
-        } | ConvertTo-Json -Compress)
-      $validatedCreateResult = Invoke-AapPulpCurl -Url $remotesUrl -AdminPassword $adminPass `
-        -Method 'POST' -Body $createBody
-      $validatedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $validatedCreateResult.Body)
+      Write-Host 'WARN (configure failed)' -ForegroundColor Yellow
+      Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+        -Namespace $Namespace -AapRoute $aapRoute -Operation $(if ($validatedRemote) { 'update' } else { 'create' }) `
+        -HttpCode $validatedResult.HttpCode -ResponseBody $validatedResult.Body
+    }
 
-      if ($validatedRemote) {
-        Write-Host 'OK' -ForegroundColor Green
+    if ($certifiedRemote) {
+      Write-Host -NoNewline '  Linking rh-certified remote to repository... '
+      $certifiedRepoHref = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+        -ResourceUrl $reposUrl -Name 'rh-certified'
+      if ($certifiedRepoHref) {
+        $linkBody = (@{ remote = $certifiedRemote } | ConvertTo-Json -Compress)
+        $linkUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepoHref
+        $linkResult = Invoke-AapPulpMutatingWithRetry -Url $linkUrl -AdminPassword $adminPass `
+          -Method 'PATCH' -Body $linkBody
+        if ($linkResult.Ok) {
+          Write-Host 'OK' -ForegroundColor Green
+        } else {
+          Write-Host 'WARN (link failed)' -ForegroundColor Yellow
+          Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+            -Namespace $Namespace -AapRoute $aapRoute -Operation 'link' `
+            -HttpCode $linkResult.HttpCode -ResponseBody $linkResult.Body
+        }
       } else {
-        Write-Host 'WARN (create failed)' -ForegroundColor Yellow
-        Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
-          -Namespace $Namespace -AapRoute $aapRoute -HttpCode $validatedCreateResult.HttpCode `
-          -ResponseBody $validatedCreateResult.Body
+        Write-Host 'WARN (repository not found)' -ForegroundColor Yellow
       }
     }
 
@@ -599,13 +660,56 @@ function Set-AapPahRemotes {
       if ($validatedRepoHref) {
         $linkBody = (@{ remote = $validatedRemote } | ConvertTo-Json -Compress)
         $linkUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRepoHref
-        Invoke-AapPulpRequest -Url $linkUrl -AdminPassword $adminPass -Method 'PATCH' -Body $linkBody | Out-Null
-        Write-Host 'OK' -ForegroundColor Green
+        $linkResult = Invoke-AapPulpMutatingWithRetry -Url $linkUrl -AdminPassword $adminPass `
+          -Method 'PATCH' -Body $linkBody
+        if ($linkResult.Ok) {
+          Write-Host 'OK' -ForegroundColor Green
+        } else {
+          Write-Host 'WARN (link failed)' -ForegroundColor Yellow
+          Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+            -Namespace $Namespace -AapRoute $aapRoute -Operation 'link' `
+            -HttpCode $linkResult.HttpCode -ResponseBody $linkResult.Body
+        }
+      } else {
+        Write-Host 'WARN (validated repository not found)' -ForegroundColor Yellow
+      }
+    }
 
-        Write-Host -NoNewline '  Syncing validated... '
-        $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRepoHref).TrimEnd('/') + 'sync/'
-        Invoke-AapPulpRequest -Url $syncUrl -AdminPassword $adminPass -Method 'POST' -Body '{"mirror":false}' | Out-Null
+    Write-Host -NoNewline '  Syncing rh-certified... '
+    $certifiedRepoHref = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+      -ResourceUrl $reposUrl -Name 'rh-certified'
+    if ($certifiedRepoHref) {
+      $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepoHref).TrimEnd('/') + '/sync/'
+      $syncResult = Invoke-AapPulpMutatingWithRetry -Url $syncUrl -AdminPassword $adminPass `
+        -Method 'POST' -Body '{"mirror":false}'
+      if ($syncResult.Ok) {
         Write-Host 'OK (background)' -ForegroundColor Green
+      } else {
+        Write-Host 'WARN (sync failed)' -ForegroundColor Yellow
+        Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+          -Namespace $Namespace -AapRoute $aapRoute -Operation 'sync' `
+          -HttpCode $syncResult.HttpCode -ResponseBody $syncResult.Body
+      }
+    } else {
+      Write-Host 'WARN (repository not found)' -ForegroundColor Yellow
+    }
+
+    if ($validatedRemote) {
+      Write-Host -NoNewline '  Syncing validated... '
+      $validatedRepoHref = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+        -ResourceUrl $reposUrl -Name 'validated'
+      if ($validatedRepoHref) {
+        $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRepoHref).TrimEnd('/') + '/sync/'
+        $syncResult = Invoke-AapPulpMutatingWithRetry -Url $syncUrl -AdminPassword $adminPass `
+          -Method 'POST' -Body '{"mirror":false}'
+        if ($syncResult.Ok) {
+          Write-Host 'OK (background)' -ForegroundColor Green
+        } else {
+          Write-Host 'WARN (sync failed)' -ForegroundColor Yellow
+          Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+            -Namespace $Namespace -AapRoute $aapRoute -Operation 'sync' `
+            -HttpCode $syncResult.HttpCode -ResponseBody $syncResult.Body
+        }
       } else {
         Write-Host 'WARN (validated repository not found)' -ForegroundColor Yellow
       }
@@ -614,19 +718,24 @@ function Set-AapPahRemotes {
     Write-AapWarn 'No galaxy token found, skipping console.redhat.com remotes'
   }
 
-  if ($Credentials.PahUrl -and $Credentials.PahToken) {
-    Write-Host -NoNewline '  Configuring Private Automation Hub remote... '
-    $pahBody = (@{
-        name           = 'external-pah'
-        url            = $Credentials.PahUrl
-        token          = $Credentials.PahToken
-        tls_validation = $true
-      } | ConvertTo-Json -Compress)
-    $createRaw = Invoke-AapPulpRequest -Url $remotesUrl -AdminPassword $adminPass -Method 'POST' -Body $pahBody
-    if ($createRaw -match 'pulp_href') {
-      Write-Host 'OK' -ForegroundColor Green
-    } else {
-      Write-Host 'WARN (may already exist or invalid config)' -ForegroundColor Yellow
+  if ($Credentials.PahUrl) {
+    if (-not (Test-AapPahConfigFormat -Credentials $Credentials)) {
+      Write-AapWarn 'Invalid PAH config, skipping external Private Automation Hub remote'
+    } elseif ($Credentials.PahToken) {
+      Write-Host -NoNewline '  Configuring Private Automation Hub remote... '
+      $pahBody = (@{
+          name           = 'external-pah'
+          url            = $Credentials.PahUrl
+          token          = $Credentials.PahToken
+          tls_validation = $true
+        } | ConvertTo-Json -Compress)
+      $createResult = Invoke-AapPulpMutatingWithRetry -Url $remotesUrl -AdminPassword $adminPass `
+        -Method 'POST' -Body $pahBody
+      if ($createResult.Ok -and $createResult.Body -match 'pulp_href') {
+        Write-Host 'OK' -ForegroundColor Green
+      } else {
+        Write-Host 'WARN (may already exist or invalid config)' -ForegroundColor Yellow
+      }
     }
   }
 
@@ -711,9 +820,6 @@ function Invoke-AapDemoSetupPah {
   Write-Host ''
 
   $creds = Get-AapGalaxyCredentials
-  if (-not (Test-AapPahConfigFormat -Credentials $creds)) {
-    throw 'Invalid PAH config'
-  }
 
   $crc = Get-AapCrcStatus
   if ([string]$crc.crcStatus -ne 'Running') {

--- a/powershell/native/Private/Collections.ps1
+++ b/powershell/native/Private/Collections.ps1
@@ -1,0 +1,732 @@
+# Collection authentication and integrated PAH remote configuration (Windows).
+
+Set-StrictMode -Version Latest
+
+function Get-AapGalaxyTokenFilePath {
+  if ($env:GALAXY_TOKEN_FILE) { return $env:GALAXY_TOKEN_FILE }
+  return Join-Path $Script:AapDemoConfigDir 'galaxy-token'
+}
+
+function Get-AapPahConfigFilePath {
+  if ($env:PAH_CONFIG_FILE) { return $env:PAH_CONFIG_FILE }
+  return Join-Path $Script:AapDemoConfigDir 'pah-config.yml'
+}
+
+function Get-AapYamlScalar {
+  param(
+    [Parameter(Mandatory)][string[]]$Lines,
+    [Parameter(Mandatory)][string]$Key
+  )
+
+  foreach ($line in $Lines) {
+    if ($line -match ('^\s*' + [regex]::Escape($Key) + '\s*:\s*(.+)$')) {
+      return $Matches[1].Trim().Trim('"').Trim("'")
+    }
+  }
+  return $null
+}
+
+function Get-AapGalaxyCredentials {
+  $creds = [PSCustomObject]@{
+    GalaxyToken = $null
+    PahUrl      = $null
+    PahToken    = $null
+    PahUser     = $null
+    PahPass     = $null
+  }
+
+  $tokenFile = Get-AapGalaxyTokenFilePath
+  if (Test-Path -LiteralPath $tokenFile) {
+    $creds.GalaxyToken = (Get-Content -LiteralPath $tokenFile -Raw).Trim()
+  }
+
+  $pahFile = Get-AapPahConfigFilePath
+  if (Test-Path -LiteralPath $pahFile) {
+    $lines = Get-Content -LiteralPath $pahFile
+    $creds.PahUrl = Get-AapYamlScalar -Lines $lines -Key 'url'
+    $creds.PahToken = Get-AapYamlScalar -Lines $lines -Key 'token'
+    $creds.PahUser = Get-AapYamlScalar -Lines $lines -Key 'username'
+    $creds.PahPass = Get-AapYamlScalar -Lines $lines -Key 'password'
+  }
+
+  return $creds
+}
+
+function Test-AapGalaxyTokenFormat {
+  param(
+    [AllowNull()][string]$Token,
+    [switch]$Brief
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    return $true
+  }
+
+  if ($Token.Length -lt 100) {
+    if ($Brief) {
+      Write-AapWarn "Invalid galaxy token format (too short: $($Token.Length) chars)"
+    } else {
+      Write-AapErr "Invalid galaxy token format (too short: $($Token.Length) chars)"
+      Write-Host ''
+      Write-Host 'Quick setup:'
+      Write-Host '  aap-demo setup-pah    # Opens browser and prompts for token'
+      Write-Host ''
+      Write-Host 'Documentation: docs/collection-authentication.md'
+    }
+    return $false
+  }
+
+  return $true
+}
+
+function Test-AapPahConfigFormat {
+  param([Parameter(Mandatory)]$Credentials)
+
+  if ([string]::IsNullOrWhiteSpace($Credentials.PahUrl)) {
+    return $true
+  }
+
+  if ($Credentials.PahUrl -notmatch '^https?://') {
+    Write-AapErr "Invalid PAH URL format: $($Credentials.PahUrl)"
+    Write-Host '  URL must start with http:// or https://'
+    return $false
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Credentials.PahToken) -and
+      [string]::IsNullOrWhiteSpace($Credentials.PahUser)) {
+    Write-AapErr 'PAH config missing authentication'
+    Write-Host "  Provide either 'token' or 'username'/'password' in $((Get-AapPahConfigFilePath))"
+    return $false
+  }
+
+  return $true
+}
+
+function Test-AapInteractivePrompt {
+  if ($env:QUIET -eq 'true') { return $false }
+  try {
+    if (-not [Environment]::UserInteractive) { return $false }
+    if ($Host.Name -ne 'ConsoleHost') { return $false }
+    if ([Console]::IsInputRedirected) { return $false }
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Save-AapGalaxyTokenFile {
+  param([Parameter(Mandatory)][string]$Token)
+
+  $tokenFile = Get-AapGalaxyTokenFilePath
+  $tokenDir = Split-Path -Parent $tokenFile
+  New-Item -ItemType Directory -Force -Path $tokenDir | Out-Null
+  Set-Content -LiteralPath $tokenFile -Value $Token.Trim() -NoNewline -Encoding ascii
+
+  try {
+    $acl = Get-Acl -LiteralPath $tokenFile
+    $acl.SetAccessRuleProtection($true, $false)
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+      $identity, 'FullControl', 'Allow')
+    $acl.SetAccessRule($rule)
+    Set-Acl -LiteralPath $tokenFile -AclObject $acl
+  } catch {
+    Write-AapWarn 'Could not restrict token file permissions'
+  }
+}
+
+function Open-AapGalaxyTokenPage {
+  param([Parameter(Mandatory)][string]$TokenUrl)
+
+  try {
+    Start-Process $TokenUrl | Out-Null
+    Write-Host 'Opening browser to Red Hat Automation Hub...'
+  } catch {
+    Write-Host 'Visit this URL in your browser:'
+    Write-Host "  $TokenUrl"
+  }
+}
+
+function Initialize-AapGalaxyToken {
+  $tokenFile = Get-AapGalaxyTokenFilePath
+  $tokenUrl = 'https://console.redhat.com/ansible/automation-hub/token'
+
+  if (Test-Path -LiteralPath $tokenFile) {
+    $existing = (Get-Content -LiteralPath $tokenFile -Raw).Trim()
+    if (Test-AapGalaxyTokenFormat -Token $existing) {
+      if (-not [string]::IsNullOrWhiteSpace($existing)) {
+        return $existing
+      }
+    } elseif (Test-AapInteractivePrompt) {
+      Write-AapWarn "Existing token at $tokenFile is invalid"
+      $replace = Read-Host 'Replace token? [y/N]'
+      if ($replace -notmatch '^[Yy]') {
+        throw 'Invalid galaxy token'
+      }
+    } else {
+      throw 'Invalid galaxy token'
+    }
+  }
+
+  if (-not (Test-AapInteractivePrompt)) {
+    Open-AapGalaxyTokenPage -TokenUrl $tokenUrl
+    Write-Host ''
+    Write-Host 'Run aap-demo setup-pah in an interactive PowerShell window to paste your token.'
+    Write-Host 'Documentation: docs/collection-authentication.md'
+    return $null
+  }
+
+  Open-AapGalaxyTokenPage -TokenUrl $tokenUrl
+  Write-Host ''
+  Write-Host 'Paste your Offline Token from the browser page.'
+  Write-Host 'Press Enter on an empty line to cancel.'
+  Write-Host ''
+
+  while ($true) {
+    $token = Read-Host 'Offline Token'
+    if ([string]::IsNullOrWhiteSpace($token)) {
+      throw 'Token entry cancelled'
+    }
+
+    $token = $token.Trim()
+    if (Test-AapGalaxyTokenFormat -Token $token -Brief) {
+      Save-AapGalaxyTokenFile -Token $token
+      Write-AapStep "Token saved to $tokenFile"
+      return $token
+    }
+
+    Write-Host 'Paste the full Offline Token (~1500 characters) and try again.'
+    Write-Host ''
+  }
+}
+
+function ConvertFrom-AapPulpJson {
+  param([AllowNull()][string]$Raw)
+
+  if ([string]::IsNullOrWhiteSpace($Raw)) { return $null }
+  try {
+    return ($Raw | ConvertFrom-Json)
+  } catch {
+    return $null
+  }
+}
+
+function Get-AapPulpFirstHref {
+  param($Data)
+
+  if (-not $Data) { return $null }
+  if ($Data.PSObject.Properties['results'] -and $Data.results -and @($Data.results).Count -gt 0) {
+    return [string]$Data.results[0].pulp_href
+  }
+  if ($Data.PSObject.Properties['pulp_href'] -and $Data.pulp_href) {
+    return [string]$Data.pulp_href
+  }
+  return $null
+}
+
+function Join-AapPulpUrl {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$Href
+  )
+
+  if ($Href -match '^https?://') { return $Href }
+  return "$ApiBase$Href"
+}
+
+function Invoke-AapPulpCurl {
+  param(
+    [Parameter(Mandatory)][string]$Url,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [ValidateSet('GET', 'POST', 'PATCH')]
+    [string]$Method = 'GET',
+    [string]$Body = $null,
+    [int]$TimeoutSeconds = 10
+  )
+
+  Set-AapIngressCaEnvFromSaved
+
+  $curlArgs = @(
+    '--ssl-no-revoke', '-sS', "--max-time", "$TimeoutSeconds",
+    '-u', "admin:$AdminPassword",
+    '-w', "`n__HTTP_CODE__:%{http_code}"
+  )
+
+  switch ($Method) {
+    'POST' { $curlArgs += '-X', 'POST' }
+    'PATCH' { $curlArgs += '-X', 'PATCH' }
+  }
+
+  if ($Body) {
+    $curlArgs += '-H', 'Content-Type: application/json', '-d', $Body
+  }
+
+  $curlArgs += $Url
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $output = (& curl.exe @curlArgs 2>&1 | Out-String).Trim()
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousEap
+  }
+
+  $httpCode = 0
+  $body = $output
+  if ($output -match '__HTTP_CODE__:(?<code>\d+)\s*$') {
+    $httpCode = [int]$Matches['code']
+    $body = ($output -replace '(?s)\n?__HTTP_CODE__:\d+\s*$', '').Trim()
+  }
+
+  return [PSCustomObject]@{
+    Body     = $body
+    HttpCode = $httpCode
+    ExitCode = $exitCode
+    Ok       = ($httpCode -ge 200 -and $httpCode -lt 300)
+  }
+}
+
+function Format-AapPulpErrorDetail {
+  param(
+    [int]$HttpCode,
+    [AllowNull()][string]$ResponseBody
+  )
+
+  if ($HttpCode -in 502, 503, 504) {
+    return "Hub returned HTTP $HttpCode (temporary upstream error - hub may be busy; re-run: aap-demo setup-pah)"
+  }
+
+  if ($ResponseBody -and $ResponseBody -notmatch '__HTTP_CODE__') {
+    $err = ConvertFrom-AapPulpJson -Raw $ResponseBody
+    if ($err -and $err.detail) {
+      return [string]$err.detail
+    }
+    if ($ResponseBody.Length -le 200) {
+      return $ResponseBody
+    }
+  }
+
+  if ($HttpCode -gt 0) {
+    return "Request failed (HTTP $HttpCode)"
+  }
+
+  return 'No response from hub API'
+}
+
+function Invoke-AapPulpPostWithRetry {
+  param(
+    [Parameter(Mandatory)][string]$Url,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$Body,
+    [int]$MaxAttempts = 6,
+    [int]$DelaySeconds = 8,
+    [int]$TimeoutSeconds = 60
+  )
+
+  $result = $null
+  for ($i = 1; $i -le $MaxAttempts; $i++) {
+    $result = Invoke-AapPulpCurl -Url $Url -AdminPassword $AdminPassword -Method 'POST' `
+      -Body $Body -TimeoutSeconds $TimeoutSeconds
+    if ($result.Ok) { return $result }
+    if ($result.HttpCode -eq 400 -and $result.Body -match 'unique|already exists|must be unique') {
+      return $result
+    }
+    if ($result.HttpCode -notin 502, 503, 504) { return $result }
+    if ($i -lt $MaxAttempts) {
+      Start-Sleep -Seconds $DelaySeconds
+    }
+  }
+  return $result
+}
+
+function Invoke-AapPulpRequest {
+  param(
+    [Parameter(Mandatory)][string]$Url,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [ValidateSet('GET', 'POST', 'PATCH')]
+    [string]$Method = 'GET',
+    [string]$Body = $null
+  )
+
+  $result = Invoke-AapPulpCurl -Url $Url -AdminPassword $AdminPassword -Method $Method -Body $Body
+  if ($result.ExitCode -ne 0 -and [string]::IsNullOrWhiteSpace($result.Body)) {
+    return $null
+  }
+  return $result.Body
+}
+
+function Get-AapPulpApiAvailability {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$Namespace,
+    [Parameter(Mandatory)][string]$AapRoute
+  )
+
+  $statusUrl = "$ApiBase/status/"
+  $result = Invoke-AapPulpCurl -Url $statusUrl -AdminPassword $AdminPassword
+  $json = ConvertFrom-AapPulpJson -Raw $result.Body
+
+  if ($result.Ok -and $json) {
+    return [PSCustomObject]@{
+      Available = $true
+      Reason    = 'Pulp API responding'
+      HttpCode  = $result.HttpCode
+      ApiUrl    = "https://${AapRoute}/api/galaxy/pulp/api/v3/"
+    }
+  }
+
+  $reason = switch ($true) {
+    (-not (Get-AapAapSuccessful -Namespace $Namespace)) {
+      'AAP deployment not complete - run: aap-demo watch'
+    }
+    ($result.HttpCode -eq 401) {
+      'Authentication failed - admin credentials may not be ready yet'
+    }
+    ($result.HttpCode -in 502, 503, 504) {
+      'Hub is still starting (gateway returned an upstream error)'
+    }
+    ($result.HttpCode -eq 404) {
+      'Pulp API endpoint not found - hub component may not be deployed yet'
+    }
+    ($result.HttpCode -eq 0 -or $result.ExitCode -in 7, 28) {
+      'Cannot connect to hub API - hub pod may still be starting'
+    }
+    default {
+      if ($result.Body -and $result.Body.Length -lt 200) {
+        "Unexpected response (HTTP $($result.HttpCode)): $($result.Body)"
+      } else {
+        "Unexpected response (HTTP $($result.HttpCode))"
+      }
+    }
+  }
+
+  return [PSCustomObject]@{
+    Available = $false
+    Reason    = $reason
+    HttpCode  = $result.HttpCode
+    ApiUrl    = "https://${AapRoute}/api/galaxy/pulp/api/v3/"
+  }
+}
+
+function Write-AapPulpCreateFailureHint {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$Namespace,
+    [Parameter(Mandatory)][string]$AapRoute,
+    [int]$HttpCode = 0,
+    [AllowNull()][string]$ResponseBody = $null
+  )
+
+  $availability = Get-AapPulpApiAvailability -ApiBase $ApiBase -AdminPassword $AdminPassword `
+    -Namespace $Namespace -AapRoute $AapRoute
+
+  Write-Host ''
+  if (-not $availability.Available) {
+    Write-AapWarn "AAP galaxy API not available at $($availability.ApiUrl)"
+    Write-Host "    $($availability.Reason)"
+    Write-Host '    Re-run when ready: aap-demo setup-pah'
+    return
+  }
+
+  Write-Host '    Pulp API is reachable; remote create failed' -ForegroundColor Yellow
+  $detail = Format-AapPulpErrorDetail -HttpCode $HttpCode -ResponseBody $ResponseBody
+  Write-Host "    $detail"
+}
+
+function Get-AapPulpResourceHref {
+  param(
+    [string]$ApiBase = '',
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$ResourceUrl,
+    [string]$Name = $null
+  )
+
+  $url = if ($Name) { "${ResourceUrl}?name=${Name}" } else { $ResourceUrl }
+  $raw = Invoke-AapPulpRequest -Url $url -AdminPassword $AdminPassword
+  return Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $raw)
+}
+
+function Wait-AapPulpTask {
+  param(
+    [Parameter(Mandatory)][string]$ApiBase,
+    [Parameter(Mandatory)][string]$AdminPassword,
+    [Parameter(Mandatory)][string]$TaskHref
+  )
+
+  for ($i = 1; $i -le 10; $i++) {
+    Start-Sleep -Seconds 1
+    $taskUrl = Join-AapPulpUrl -ApiBase $ApiBase -Href $TaskHref
+    $raw = Invoke-AapPulpRequest -Url $taskUrl -AdminPassword $AdminPassword
+    $task = ConvertFrom-AapPulpJson -Raw $raw
+    if ($task -and [string]$task.state -eq 'completed') {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Set-AapPahRemotes {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Namespace,
+    [Parameter(Mandatory)]$Credentials
+  )
+
+  Write-Host 'Configuring Private Automation Hub remotes...'
+
+  $routeResult = Invoke-AapOcCapture @('get', 'route', 'aap', '-n', $Namespace, '-o', 'jsonpath={.spec.host}')
+  $aapRoute = if ($routeResult.ExitCode -eq 0) { $routeResult.Output.Trim() } else { '' }
+  if (-not $aapRoute) {
+    throw 'AAP route not found'
+  }
+
+  $adminPass = Get-AapAdminPassword -Namespace $Namespace
+  if (-not $adminPass) {
+    throw 'Admin password not found'
+  }
+
+  $apiBase = "https://$aapRoute/api/galaxy/pulp/api/v3"
+  $remotesUrl = "$apiBase/remotes/ansible/collection/"
+  $reposUrl = "$apiBase/repositories/ansible/ansible/"
+
+  $apiAvailability = Get-AapPulpApiAvailability -ApiBase $apiBase -AdminPassword $adminPass `
+    -Namespace $Namespace -AapRoute $aapRoute
+  if (-not $apiAvailability.Available) {
+    Write-AapErr "AAP galaxy API not available at $($apiAvailability.ApiUrl)"
+    Write-Host "  $($apiAvailability.Reason)"
+    Write-Host '  Re-run when ready: aap-demo setup-pah'
+    throw 'AAP galaxy API not available'
+  }
+
+  if ($Credentials.GalaxyToken) {
+    Write-Host -NoNewline '  Configuring rh-certified remote... '
+    $certifiedRemote = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+      -ResourceUrl $remotesUrl -Name 'rh-certified'
+    $certifiedCreateResult = $null
+
+    if ($certifiedRemote) {
+      $patchBody = (@{ token = $Credentials.GalaxyToken } | ConvertTo-Json -Compress)
+      $patchUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRemote
+      $patchRaw = Invoke-AapPulpRequest -Url $patchUrl -AdminPassword $adminPass -Method 'PATCH' -Body $patchBody
+      $patchData = ConvertFrom-AapPulpJson -Raw $patchRaw
+      if ($patchData -and $patchData.task) {
+        Wait-AapPulpTask -ApiBase $apiBase -AdminPassword $adminPass -TaskHref ([string]$patchData.task) | Out-Null
+      }
+      Write-Host 'OK' -ForegroundColor Green
+    } else {
+      $createBody = (@{
+          name           = 'rh-certified'
+          url            = 'https://console.redhat.com/api/automation-hub/content/published/'
+          token          = $Credentials.GalaxyToken
+          tls_validation = $true
+        } | ConvertTo-Json -Compress)
+      $certifiedCreateResult = Invoke-AapPulpPostWithRetry -Url $remotesUrl -AdminPassword $adminPass -Body $createBody
+      $certifiedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $certifiedCreateResult.Body)
+
+      if ($certifiedRemote) {
+        Write-Host 'OK' -ForegroundColor Green
+      } else {
+        Write-Host 'WARN (create failed)' -ForegroundColor Yellow
+        Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+          -Namespace $Namespace -AapRoute $aapRoute -HttpCode $certifiedCreateResult.HttpCode `
+          -ResponseBody $certifiedCreateResult.Body
+      }
+    }
+
+    if ($certifiedRemote) {
+      $certifiedRepo = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+        -ResourceUrl $reposUrl -Name 'rh-certified'
+      if ($certifiedRepo) {
+        $linkBody = (@{ remote = $certifiedRemote } | ConvertTo-Json -Compress)
+        $linkUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepo
+        Invoke-AapPulpRequest -Url $linkUrl -AdminPassword $adminPass -Method 'PATCH' -Body $linkBody | Out-Null
+      }
+    }
+
+    Write-Host -NoNewline '  Syncing rh-certified... '
+    $certifiedRepo = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+      -ResourceUrl $reposUrl -Name 'rh-certified'
+    if ($certifiedRepo) {
+      $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $certifiedRepo).TrimEnd('/') + 'sync/'
+      Invoke-AapPulpRequest -Url $syncUrl -AdminPassword $adminPass -Method 'POST' -Body '{"mirror":false}' | Out-Null
+      Write-Host 'OK (background)' -ForegroundColor Green
+    } else {
+      Write-Host 'WARN (repository not found)' -ForegroundColor Yellow
+    }
+
+    Write-Host -NoNewline '  Configuring rh-validated remote... '
+    $validatedRemote = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+      -ResourceUrl $remotesUrl -Name 'rh-validated'
+    $validatedCreateResult = $null
+
+    if ($validatedRemote) {
+      $patchBody = (@{ token = $Credentials.GalaxyToken } | ConvertTo-Json -Compress)
+      $patchUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRemote
+      $patchRaw = Invoke-AapPulpRequest -Url $patchUrl -AdminPassword $adminPass -Method 'PATCH' -Body $patchBody
+      $patchData = ConvertFrom-AapPulpJson -Raw $patchRaw
+      if ($patchData -and $patchData.task) {
+        Wait-AapPulpTask -ApiBase $apiBase -AdminPassword $adminPass -TaskHref ([string]$patchData.task) | Out-Null
+      }
+      Write-Host 'OK' -ForegroundColor Green
+    } else {
+      $createBody = (@{
+          name           = 'rh-validated'
+          url            = 'https://console.redhat.com/api/automation-hub/content/validated/'
+          token          = $Credentials.GalaxyToken
+          tls_validation = $true
+        } | ConvertTo-Json -Compress)
+      $validatedCreateResult = Invoke-AapPulpCurl -Url $remotesUrl -AdminPassword $adminPass `
+        -Method 'POST' -Body $createBody
+      $validatedRemote = Get-AapPulpFirstHref -Data (ConvertFrom-AapPulpJson -Raw $validatedCreateResult.Body)
+
+      if ($validatedRemote) {
+        Write-Host 'OK' -ForegroundColor Green
+      } else {
+        Write-Host 'WARN (create failed)' -ForegroundColor Yellow
+        Write-AapPulpCreateFailureHint -ApiBase $apiBase -AdminPassword $adminPass `
+          -Namespace $Namespace -AapRoute $aapRoute -HttpCode $validatedCreateResult.HttpCode `
+          -ResponseBody $validatedCreateResult.Body
+      }
+    }
+
+    if ($validatedRemote) {
+      Write-Host -NoNewline '  Linking validated remote to repository... '
+      $validatedRepoHref = Get-AapPulpResourceHref -ApiBase $apiBase -AdminPassword $adminPass `
+        -ResourceUrl $reposUrl -Name 'validated'
+      if ($validatedRepoHref) {
+        $linkBody = (@{ remote = $validatedRemote } | ConvertTo-Json -Compress)
+        $linkUrl = Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRepoHref
+        Invoke-AapPulpRequest -Url $linkUrl -AdminPassword $adminPass -Method 'PATCH' -Body $linkBody | Out-Null
+        Write-Host 'OK' -ForegroundColor Green
+
+        Write-Host -NoNewline '  Syncing validated... '
+        $syncUrl = (Join-AapPulpUrl -ApiBase $apiBase -Href $validatedRepoHref).TrimEnd('/') + 'sync/'
+        Invoke-AapPulpRequest -Url $syncUrl -AdminPassword $adminPass -Method 'POST' -Body '{"mirror":false}' | Out-Null
+        Write-Host 'OK (background)' -ForegroundColor Green
+      } else {
+        Write-Host 'WARN (validated repository not found)' -ForegroundColor Yellow
+      }
+    }
+  } else {
+    Write-AapWarn 'No galaxy token found, skipping console.redhat.com remotes'
+  }
+
+  if ($Credentials.PahUrl -and $Credentials.PahToken) {
+    Write-Host -NoNewline '  Configuring Private Automation Hub remote... '
+    $pahBody = (@{
+        name           = 'external-pah'
+        url            = $Credentials.PahUrl
+        token          = $Credentials.PahToken
+        tls_validation = $true
+      } | ConvertTo-Json -Compress)
+    $createRaw = Invoke-AapPulpRequest -Url $remotesUrl -AdminPassword $adminPass -Method 'POST' -Body $pahBody
+    if ($createRaw -match 'pulp_href') {
+      Write-Host 'OK' -ForegroundColor Green
+    } else {
+      Write-Host 'WARN (may already exist or invalid config)' -ForegroundColor Yellow
+    }
+  }
+
+  Write-AapStep 'PAH configuration complete'
+}
+
+function Write-AapSetupPahReminder {
+  Write-Host ''
+  Write-Host 'To configure Private Automation Hub remotes:'
+  Write-Host '  aap-demo setup-pah'
+  Write-Host ''
+}
+
+function Write-AapCollectionSourcesStatus {
+  $creds = Get-AapGalaxyCredentials
+
+  Write-Host ''
+  Write-Host 'Collection Sources:'
+  Write-Host '-------------------'
+
+  if ($creds.PahUrl) {
+    Write-Host ("  {0,-20} {1}" -f 'Private Hub:', $creds.PahUrl)
+  }
+
+  if ($creds.GalaxyToken) {
+    Write-Host ("  {0,-20} {1}" -f 'Red Hat Certified:', 'console.redhat.com (authenticated)')
+  } else {
+    Write-Host ("  {0,-20} {1}" -f 'Red Hat Certified:', 'Not configured')
+  }
+
+  Write-Host ("  {0,-20} {1}" -f 'Community:', 'galaxy.ansible.com')
+}
+
+function Write-AapCollectionSourcesDiagnose {
+  param(
+    [scriptblock]$WritePass,
+    [scriptblock]$WriteInfo
+  )
+
+  Write-Host 'Collection Sources:'
+
+  $tokenFile = Get-AapGalaxyTokenFilePath
+  if (Test-Path -LiteralPath $tokenFile) {
+    & $WritePass 'console.redhat.com token present'
+  } else {
+    & $WriteInfo 'console.redhat.com token not configured'
+    & $WriteInfo 'Get token from: https://console.redhat.com/ansible/automation-hub/token'
+    & $WriteInfo 'Then run: aap-demo setup-pah'
+  }
+
+  $pahFile = Get-AapPahConfigFilePath
+  if (Test-Path -LiteralPath $pahFile) {
+    & $WritePass 'Private Automation Hub config present'
+    $creds = Get-AapGalaxyCredentials
+    if (-not (Test-AapPahConfigFormat -Credentials $creds)) {
+      & $WriteInfo 'Fix pah-config.yml before running setup-pah'
+    }
+  } else {
+    & $WriteInfo 'Private Automation Hub not configured (optional)'
+  }
+
+  Write-Host ''
+}
+
+function Invoke-AapDemoSetupPah {
+  [CmdletBinding()]
+  param(
+    [string]$Namespace = $Script:AapDemoDefaultNamespace
+  )
+
+  Write-Host ''
+  Write-Host 'Setting up Private Automation Hub...'
+  Write-Host ''
+
+  $galaxyToken = Initialize-AapGalaxyToken
+  if (-not $galaxyToken) {
+    return
+  }
+
+  $tokenFile = Get-AapGalaxyTokenFilePath
+  Write-AapStep "Galaxy token configured at $tokenFile"
+  Write-Host ''
+
+  $creds = Get-AapGalaxyCredentials
+  if (-not (Test-AapPahConfigFormat -Credentials $creds)) {
+    throw 'Invalid PAH config'
+  }
+
+  $crc = Get-AapCrcStatus
+  if ([string]$crc.crcStatus -ne 'Running') {
+    throw 'Cluster is not running - run: aap-demo deploy'
+  }
+
+  Initialize-AapKubeEnvironment
+  Set-AapIngressCaEnvFromSaved
+
+  if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
+    throw 'oc cannot connect to cluster'
+  }
+
+  Write-Host 'Configuring AAP Private Automation Hub remotes...'
+  Set-AapPahRemotes -Namespace $Namespace -Credentials $creds
+}

--- a/powershell/native/Private/Deploy.ps1
+++ b/powershell/native/Private/Deploy.ps1
@@ -86,6 +86,7 @@ function Invoke-AapDemoDeploy {
       Write-AapStep ('AAP instance ''{0}'' already exists in {1} - watching progress' -f $existingName, $Namespace)
       Write-Host ''
       Invoke-AapDemoWatch -Namespace $Namespace
+      Write-AapSetupPahReminder
       return
     }
   }
@@ -138,7 +139,7 @@ function Invoke-AapDemoDeploy {
   Write-Host ''
   Write-Host '  Monitor: aap-demo watch'
   Write-Host '  Or:      aap-demo status'
-  Write-Host ''
+  Write-AapSetupPahReminder
 }
 
 function Initialize-AapNamespace {

--- a/powershell/native/Private/Diagnose.ps1
+++ b/powershell/native/Private/Diagnose.ps1
@@ -274,6 +274,14 @@ function Invoke-AapDemoDiagnose {
   }
   Write-Host ''
 
+  Write-AapCollectionSourcesDiagnose -WritePass {
+    param($Message)
+    Write-AapDiagPass $Message
+  } -WriteInfo {
+    param($Message)
+    Write-AapDiagInfo $Message
+  }
+
   # DNS
   Write-Host 'DNS:'
   $dnsResult = Invoke-AapOcCapture @('get', 'pods', '-n', 'openshift-dns', '--no-headers')

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -117,6 +117,8 @@ function Invoke-AapDemoStatus {
   }
   if (-not $foundCred) { Write-Host '  (no admin password secret found yet)' }
 
+  Write-AapCollectionSourcesStatus
+
   $savedAddons = @(Get-AapAddonsList)
   Write-Host ''
   Write-Host 'Addons:'
@@ -156,6 +158,7 @@ DEPLOY:
     redeploy-all    Destroy cluster and full redeploy
     clean           Remove AAP namespace and resources
     watch           Monitor AAP deployment progress
+    setup-pah       Configure integrated PAH remotes (console.redhat.com token)
 
 STATUS:
     status          Show cluster and AAP status
@@ -173,5 +176,6 @@ ADDONS:
 NOTES:
     Requires oc and crc on PATH. OpenShift Local needs Hyper-V.
     Pull secret: %USERPROFILE%\.aap-demo\pull-secret.txt
+    Galaxy token: %USERPROFILE%\.aap-demo\galaxy-token (for setup-pah)
 '@
 }

--- a/powershell/native/Private/Watch.ps1
+++ b/powershell/native/Private/Watch.ps1
@@ -123,6 +123,7 @@ function Invoke-AapDemoWatch {
         Write-Host "Password: (run: oc get secret -n $Namespace aap-admin-password -o jsonpath='{.data.password}')"
       }
       Write-Host ''
+      Write-AapSetupPahReminder
       return
     }
 


### PR DESCRIPTION
## Summary

Adds automatic authentication and collection management for Red Hat Certified Content and Private Automation Hub.

## Changes

**Authentication:**
- Detects console.redhat.com offline token from `~/.aap-demo/galaxy-token`
- Supports PAH configuration via `~/.aap-demo/pah-config.yml`
- Validates token format and configuration before use

**Collection Management:**
- Generates `ansible.cfg` with prioritized galaxy servers (PAH → console.redhat.com → galaxy.ansible.com)
- New `setup-pah` command configures AAP's integrated PAH remotes:
  - `rh-certified`: Red Hat Certified Content Collections
  - `rh-validated`: Red Hat Validated Content Collections
- Syncs certified collections into local PAH from console.redhat.com

**Documentation:**
- Comprehensive authentication guide: `docs/collection-authentication.md`
- ADR-016: architecture decision record
- Updated README with authentication overview

**Diagnostics:**
- Extended `diagnose` command with collection source validation
- Shows authenticated sources in `status` output

## Testing

```bash
# Without authentication
aap-demo deploy  # Uses galaxy.ansible.com only

# With console.redhat.com token
echo "TOKEN" > ~/.aap-demo/galaxy-token
aap-demo deploy
aap-demo setup-pah  # Configure PAH remotes

# Check status
aap-demo status     # Shows authenticated sources
aap-demo diagnose   # Validates collection sources
```

## Breaking Changes

None. Authentication is optional. Existing deployments continue working with community collections.

## Related

Closes #36