### PR TITLE
fix: add setup-pah to welcome help output

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -386,10 +386,12 @@ Addons:
   enable portal    Enable Self-Service Portal (Helm; auto-detects arm64 vs amd64)
                   Requires: AAP 2.6+, Helm 3.10+, registry.redhat.io credentials
   enable mcp-server Enable MCP server for AI assistants
+  enable setup-pah Configure Private Automation Hub remotes and credentials
 
 Examples:
   aap-demo deploy                 # Deploy AAP 2.7
   aap-demo enable portal          # Enable Self-Service Portal (Helm; auto-detects CPU)
+  aap-demo enable setup-pah       # Configure Private Automation Hub
 
 Run 'aap-demo help' for full documentation.
 EOF

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -460,7 +460,7 @@ EXAMPLES:
     aap-demo stop                    # Stop cluster
     aap-demo start                   # Start stopped cluster
     aap-demo ssh                     # SSH into cluster node
-    aap-demo enable console          # Enable web console addon
+    aap-demo enable setup-pah        # Configure Private Automation Hub remotes
 
 REQUIREMENTS:
     - OpenShift Local — https://console.redhat.com/openshift/create/local


### PR DESCRIPTION
## Summary

- Adds `enable setup-pah` to the short welcome help (shown when running `aap-demo` with no args)
- Adds a matching example line so users discover PAH setup without reading full docs

## Test plan

- [ ] Run `aap-demo` with no args — confirm `enable setup-pah` appears in Addons section
- [ ] Run `aap-demo help` — confirm existing full help still intact