### PR TITLE
fix: remove literal quotes from SSH key path in CRC_SSH_OPTS

### DIFF
--- a/includes/infra-crc.sh
+++ b/includes/infra-crc.sh
@@ -29,7 +29,7 @@ _detect_crc_ssh_key() {
 
 # Initialize SSH key — callers should check CRC_SSH_KEY before use
 if CRC_SSH_KEY="$(_detect_crc_ssh_key 2>/dev/null)"; then
-  CRC_SSH_OPTS="-i \"${CRC_SSH_KEY}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+  CRC_SSH_OPTS="-i ${CRC_SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 else
   CRC_SSH_KEY=""
   CRC_SSH_OPTS=""


### PR DESCRIPTION
## Summary
- `CRC_SSH_OPTS` on `infra-crc.sh:32` embedded escaped quotes (`\"`) around the SSH key path, which became literal `"` characters in the string
- When `$CRC_SSH_OPTS` is word-split at the `ssh` call site, SSH received a filename wrapped in actual quote chars (e.g. `"/home/user/.crc/machines/crc/id_ed25519"`), couldn't find it, and fell back to password authentication
- This caused `aap-demo status` (and any other command using `infra_exec_cmd`) to prompt for a password instead of using key-based auth

## Test plan
- [ ] Run `aap-demo status` — VM section should display without a password prompt
- [ ] Run `aap-demo ssh` — should connect without prompting for password

🤖 Generated with [Claude Code](https://claude.com/claude-code)