### PR TITLE
Replace deprecated kubeval with kubeconform in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -143,16 +143,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install kubeval
+      - name: Install kubeconform
         run: |
-          wget -qO- https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar xz
-          sudo mv kubeval /usr/local/bin/
+          wget -qO- https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
 
       - name: Validate Kubernetes YAMLs
         run: |
           find config/manifests config/crs -name "*.yaml" -o -name "*.yml" | while read -r file; do
             echo "Validating $file"
-            kubeval --ignore-missing-schemas "$file" || true
+            kubeconform -ignore-missing-schemas -summary "$file" || true
           done
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

Replace `instrumenta/kubeval` with `yannh/kubeconform` in the `validate-manifests` CI job.

- `instrumenta/kubeval` has been archived since 2022 and receives no updates
- `yannh/kubeconform` is the actively maintained successor with support for newer Kubernetes schemas
- Drop-in replacement with equivalent CLI flags (`-ignore-missing-schemas`, `-summary`)

## Changes

- `.github/workflows/lint.yaml`: swap kubeval install and invocation for kubeconform

## Verification

- Confirmed `kubeconform-linux-amd64.tar.gz` download URL resolves from `yannh/kubeconform` releases
- Flag mapping verified: `--ignore-missing-schemas` (kubeval) maps to `-ignore-missing-schemas` (kubeconform)
- Added `-summary` flag for clearer validation output