### PR TITLE
docs: fix repo URL in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy AAP to a local MicroShift cluster in minutes.
 ## Install
 
 ```bash
-git clone https://github.com/ansible-automation-platform/aap-demo.git
+git clone https://github.com/RedHatOfficial/aap-demo.git
 cd aap-demo && ./install.sh
 ```
 


### PR DESCRIPTION
## Summary

- Fixed incorrect git clone URL in README install section
- Changed from `ansible-automation-platform/aap-demo` (doesn't exist) to `RedHatOfficial/aap-demo`

## Test plan

- [x] Verify URL works: https://github.com/RedHatOfficial/aap-demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)