### PR TITLE
fix: OLM installation error handling 

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2045,10 +2045,17 @@ cmd_create() {
 
   # Install OLM by default (OpenShift Local doesn't include it, needed for operator dev and latest deploys)
   setup_kubeconfig
-  bash "${SCRIPT_DIR}/addons/olm/deploy.sh" || {
+  echo ""
+  echo "Installing OLM (Operator Lifecycle Manager)..."
+  if ! bash "${SCRIPT_DIR}/addons/olm/deploy.sh"; then
     echo ""
-    printf "  \033[1;33mWARNING: OLM install failed — you can retry with: aap-demo enable olm\033[0m\n"
-  }
+    printf "  \033[1;31mERROR: OLM install failed\033[0m\n"
+    printf "  \033[1;33mYou can retry with: aap-demo enable olm\033[0m\n"
+    printf "  \033[1;33mOr destroy and recreate: aap-demo destroy && aap-demo create\033[0m\n"
+    echo ""
+    # Don't fail cluster creation, but warn that latest deploys won't work
+    printf "  \033[1;33mNote: 'aap-demo deploy latest' requires OLM\033[0m\n"
+  fi
 }
 
 # shellcheck source=includes/galaxy-auth.sh
@@ -2079,7 +2086,12 @@ cmd_deploy() {
   install_ingress_ca_trust
 
   # Install OLM if not present (OpenShift Local doesn't include it)
-  KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}" bash "${SCRIPT_DIR}/addons/olm/deploy.sh"
+  if ! KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}" bash "${SCRIPT_DIR}/addons/olm/deploy.sh"; then
+    printf "\n\033[1;31mERROR: OLM installation failed\033[0m\n"
+    printf "OLM is required for AAP deployments. Please fix OLM before continuing.\n"
+    printf "Try: \033[1maap-demo enable olm\033[0m\n\n"
+    exit 1
+  fi
 
   # anyuid and privileged SCCs granted in setup_namespace() for all SAs in the namespace
   echo ""

--- a/addons/olm/deploy.sh
+++ b/addons/olm/deploy.sh
@@ -126,5 +126,12 @@ else
   if kubectl get crd subscriptions.operators.coreos.com &>/dev/null; then
     kubectl delete catsrc operatorhubio-catalog -n olm 2>/dev/null || true
     echo "OLM CRDs are present — installation likely succeeded despite timeout."
+    exit 0
+  else
+    # Partial installation detected — clean up to avoid broken state
+    echo "ERROR: OLM installation incomplete. Cleaning up..."
+    kubectl delete namespace olm 2>/dev/null || true
+    kubectl delete namespace operators 2>/dev/null || true
+    exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
Fixes silent OLM installation failures that leave the cluster in a broken state (olm namespace exists but no CRDs/operators installed).

## Problem
During cluster creation, OLM installation could fail partially:
- `olm` namespace created but empty
- No OLM CRDs installed
- `aap-demo deploy` would fail with cryptic error: `the server could not find the requested resource (post catalogsources.operators.coreos.com)`

## Changes

### `addons/olm/deploy.sh`
- **Detect partial installations**: If `operator-sdk olm install` fails and CRDs are not created, automatically clean up the partial state (delete `olm` and `operators` namespaces) and exit with error code 1
- **Return proper exit codes**: Previously would exit 0 on partial failures; now only succeeds if CRDs are actually created

### `aap-demo.sh` (create command)
- **Clearer error messages**: Changed from yellow WARNING to red ERROR when OLM fails
- **Better user guidance**: Shows recovery options (`aap-demo enable olm` or `aap-demo destroy && aap-demo create`)
- **Non-fatal for cluster creation**: Allows cluster to be created even if OLM fails, but warns that `latest` deploys won't work

### `aap-demo.sh` (deploy command)
- **Fail fast**: Deploy now exits immediately if OLM installation fails
- **Clear error message**: Shows exactly what's wrong and how to fix it
- **Prevent cascading failures**: Won't attempt to create CatalogSources if OLM isn't ready

## Test Plan
- [x] Verify existing OLM install is detected correctly
- [x] Manual test: partial OLM state is cleaned up on failure
- [ ] Full test: `aap-demo destroy && aap-demo create && aap-demo deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)