### PR TITLE
fix: increase default VM memory to 24GB for EAP addon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ cd aap-demo && ./install.sh
 ## Prerequisites
 
 - **CRC (OpenShift Local)** — [Download](https://console.redhat.com/openshift/create/local)
+- **24GB RAM** — Default VM allocation (override with `CRC_MEMORY=16384 aap-demo create` for 16GB)
 - **Pull secret** (required for all deploys):
 
 ```bash

--- a/docs/FULL-README.md
+++ b/docs/FULL-README.md
@@ -9,8 +9,9 @@ Deploy AAP in minutes on macOS, Linux, or Windows.
 
 #### System Requirements
 
-A typical Microshift and AAP 2.7 environment requires 16GB of RAM, 2 cores, and
+A typical MicroShift and AAP 2.7 environment requires 24GB of RAM, 2 cores, and
 100 GB of storage. We recommend having a total of 32GB RAM available on your system.
+The 24GB default supports AAP plus EAP addons (AO, APME); use `CRC_MEMORY=16384` for 16GB if running AAP alone.
 
 #### MacOS
 
@@ -234,7 +235,7 @@ design, storage, OLM, addons, and cross-platform support).
 
 ```bash
 CRC_CPUS=8                   # VM CPU count (default: 8)
-CRC_MEMORY=16384             # VM memory in MiB (default: 16384)
+CRC_MEMORY=24576             # VM memory in MiB (default: 24576, use 16384 for AAP-only)
 CRC_DISK=100                 # VM disk size in GiB (default: 100)
 CRC_PV_SIZE=70               # Storage reserved for LVMS PVCs in GiB (default: 70, must be < CRC_DISK)
 NAMESPACE=aap-operator       # Target namespace

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -206,7 +206,7 @@ printf "${_GREEN}▸${_NC} CRC preset: ${CURRENT_PRESET}\n"
 # Configure CRC resources
 # ---------------------------------------------------------------------------
 CRC_CPUS="${CRC_CPUS:-${VM_CPUS:-8}}"
-CRC_MEMORY="${CRC_MEMORY:-${VM_MEMORY:-16384}}"
+CRC_MEMORY="${CRC_MEMORY:-${VM_MEMORY:-24576}}"
 CRC_DISK="${CRC_DISK:-${VM_DISK_SIZE:-100}}"
 CRC_PV_SIZE="${CRC_PV_SIZE:-${VM_PV_SIZE:-50}}"
 


### PR DESCRIPTION
## Summary
- Increase default `CRC_MEMORY` from 16GB to 24GB
- AAP base + EAP addons (AO, APME) exceeded 16GB, causing pod scheduling failures
- Document override: `CRC_MEMORY=16384 aap-demo create` for AAP-only deployments

## Changes
- `includes/crc-create.sh`: Default 16384 → 24576
- `README.md`: Add 24GB RAM prerequisite with override example
- `docs/FULL-README.md`: Update system requirements and env var docs

## Test plan
- [ ] `aap-demo destroy && CRC_MEMORY=24576 aap-demo create && aap-demo deploy`
- [ ] `aap-demo enable ao-eap && aap-demo enable apme-eap` — both addons should schedule
- [ ] Verify `CRC_MEMORY=16384` override still works for AAP-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)