### PR TITLE
fix(apme-eap): ensure Helm is installed and on PATH before deploy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,14 +148,14 @@
         "filename": "addons/apme-eap/README.md",
         "hashed_secret": "e817446c7170e3a1eca4d65d196ae59611ac3a53",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 170
       },
       {
         "type": "Secret Keyword",
         "filename": "addons/apme-eap/README.md",
         "hashed_secret": "4af90ebb9601dde86fa702e345fc4530eb01efb9",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 173
       }
     ],
     "addons/apme-eap/TEST_PLAN.md": [
@@ -252,5 +252,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-07T15:08:18Z"
+  "generated_at": "2026-08-12T18:12:38Z"
 }

--- a/addons/apme-eap/README.md
+++ b/addons/apme-eap/README.md
@@ -29,6 +29,7 @@ authentication.
 
 - `kubectl` or `oc`
 - `python3` (3.8+)
+- `helm` 3.10+ (portal Helm chart — auto-installed via brew/dnf when missing)
 - `skopeo` (host-side plugin OCI push — auto-installed via brew/dnf when missing)
 - AAP deployed (`aap-demo deploy`)
 
@@ -51,7 +52,7 @@ aap-demo enable apme-eap
 
 This will:
 
-1. Check system prerequisites (kubectl, python3, skopeo — installs skopeo if missing)
+1. Check system prerequisites (kubectl, python3, helm, skopeo — installs helm/skopeo if missing)
 2. Create venv with full Ansible + collections (if not exists)
 3. Auto-discover your aap-demo environment (KUBECONFIG, cluster domain, AAP route/credentials)
 4. Generate playbook vars at `~/.aap-demo/apme-eap-vars.yml`
@@ -290,6 +291,28 @@ kubectl get secret -n aap-operator <aap-cr-name> -o jsonpath='{.data.admin_passw
 2. Check port-forward to plugin registry is working
 3. Verify skopeo is installed: `which skopeo`
 4. Check plugin registry pod is running: `kubectl get pods -n apme -l app=plugin-registry`
+
+### Helm not installed
+
+**Symptom**: Playbook fails with `Failed to find required executable 'helm'` or `helm: command not found`
+
+**Solution**: Re-run enable — helm is auto-installed when Homebrew (`brew`) or `dnf` is available:
+
+```bash
+aap-demo enable apme-eap
+```
+
+Or install manually:
+
+```bash
+# macOS
+brew install helm
+
+# RHEL/Fedora
+sudo dnf install helm
+```
+
+Verify: `helm version --short` (requires 3.10+).
 
 ### Helm timeout
 

--- a/addons/apme-eap/deploy.sh
+++ b/addons/apme-eap/deploy.sh
@@ -205,6 +205,65 @@ _ensure_skopeo() {
   info "skopeo installed: $(command -v skopeo)"
 }
 
+_helm_version_ok() {
+  local helm_version helm_major helm_minor
+  helm_version=$(helm version --short 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+' | sed 's/v//')
+  [ -n "$helm_version" ] || return 1
+  helm_major=$(echo "$helm_version" | cut -d. -f1)
+  helm_minor=$(echo "$helm_version" | cut -d. -f2)
+  # Require helm >= 3.10 (v4+ is also OK)
+  if [ "$helm_major" -gt 3 ]; then
+    return 0
+  fi
+  if [ "$helm_major" -eq 3 ] && [ "$helm_minor" -ge 10 ]; then
+    return 0
+  fi
+  return 1
+}
+
+_ensure_helm() {
+  # Homebrew (macOS) and common install paths — ansible playbook tasks also prepend these
+  export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}"
+
+  if command -v helm &>/dev/null && _helm_version_ok; then
+    info "helm found: $(command -v helm) ($(helm version --short 2>/dev/null || echo 'unknown version'))"
+    return 0
+  fi
+
+  if command -v helm &>/dev/null; then
+    die "Helm 3.10+ required (found: $(helm version --short 2>/dev/null || echo 'unknown')). Upgrade from https://helm.sh/docs/intro/install/"
+  fi
+
+  info "helm not found — installing (required for portal Helm chart deployment)..."
+  case "$(uname -s)" in
+    Darwin)
+      if command -v brew &>/dev/null; then
+        brew install helm
+      else
+        die "helm not found. Install Homebrew, then: brew install helm"
+      fi
+      ;;
+    Linux)
+      if command -v dnf &>/dev/null; then
+        sudo dnf install -y helm
+      else
+        die "helm not found and cannot auto-install. Install Helm 3.10+ from https://helm.sh/docs/intro/install/"
+      fi
+      ;;
+    *)
+      die "helm not found. Install Helm 3.10+ from https://helm.sh/docs/intro/install/"
+      ;;
+  esac
+
+  if ! command -v helm &>/dev/null; then
+    die "helm install completed but helm is still not on PATH"
+  fi
+  if ! _helm_version_ok; then
+    die "Helm 3.10+ required after install (found: $(helm version --short 2>/dev/null || echo 'unknown'))"
+  fi
+  info "helm installed: $(command -v helm) ($(helm version --short 2>/dev/null || echo 'unknown version'))"
+}
+
 check_prerequisites() {
   info "Checking system prerequisites..."
 
@@ -225,6 +284,9 @@ check_prerequisites() {
 
   # Plugin OCI push runs skopeo on the host (outside the cluster)
   _ensure_skopeo
+
+  # Portal/gateway Helm releases use kubernetes.core.helm (requires helm binary on PATH)
+  _ensure_helm
 
   # MicroShift lacks an integrated registry — deploy the in-cluster registry
   # addon so APME can store plugin OCI images for the portal init container.

--- a/addons/apme-eap/playbooks/roles/apme_gateway_helm/tasks/main.yml
+++ b/addons/apme-eap/playbooks/roles/apme_gateway_helm/tasks/main.yml
@@ -62,7 +62,7 @@
     host: "{{ openshift_api_url }}"
     validate_certs: "{{ apme_gateway_helm_validate_certs }}"
   environment:
-    PATH: "/usr/local/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"  # yamllint disable-line rule:line-length
+    PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"  # yamllint disable-line rule:line-length
     HELM_CACHE_HOME: "/tmp/.helm/cache"
     HELM_CONFIG_HOME: "/tmp/.helm/config"
     HELM_DATA_HOME: "/tmp/.helm/data"

--- a/addons/apme-eap/playbooks/roles/portal_helm_install/tasks/main.yml
+++ b/addons/apme-eap/playbooks/roles/portal_helm_install/tasks/main.yml
@@ -29,7 +29,7 @@
     force: "{{ portal_helm_install_force_upgrade | bool }}"
     atomic: "{{ false if portal_helm_install_force_upgrade | bool else true }}"
   environment:
-    PATH: "/usr/local/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
+    PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"  # yamllint disable-line rule:line-length
     HELM_CACHE_HOME: "/tmp/.helm/cache"
     HELM_CONFIG_HOME: "/tmp/.helm/config"
     HELM_DATA_HOME: "/tmp/.helm/data"


### PR DESCRIPTION
## Summary
- Add `_ensure_helm()` to `apme-eap` deploy prerequisites (auto-install via brew/dnf, require Helm 3.10+)
- Include `/opt/homebrew/bin` in Ansible Helm role `PATH` so Homebrew-installed Helm is found on macOS
- Document Helm prerequisite and troubleshooting in the addon README

## Test plan
- [ ] Run `aap-demo enable apme-eap` on macOS with Helm installed via Homebrew
- [ ] Verify prerequisite check reports helm version before playbook runs
- [ ] Confirm `portal_helm_install` role completes without `helm not found` errors
- [ ] Test on Linux with `dnf`-managed Helm install path (if available)


Made with [Cursor](https://cursor.com)