### PR TITLE
fix: isolate aap-demo kubeconfig under ~/.aap-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ git clone https://github.com/RedHatOfficial/aap-demo.git && cd aap-demo && ./ins
 `aap-demo create` provisions the MicroShift VM only. `aap-demo deploy` installs OLM and AAP
 (use `deploy` for the typical path; `create` alone is for cluster-only setup).
 
+Cluster credentials live at `~/.aap-demo/kubeconfig.microshift` and are **not** merged into
+`~/.kube/config`. If you relied on the old default kubeconfig behavior, run:
+
+```bash
+export KUBECONFIG=~/.aap-demo/kubeconfig.microshift
+# or: aap-demo kubeconfig   # refresh file and print export command
+```
+
 ## Status
 
 ```bash

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -37,6 +37,9 @@ while [ -L "$SOURCE" ]; do
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
+# shellcheck source=includes/aap-demo-paths.sh
+source "${SCRIPT_DIR}/includes/aap-demo-paths.sh"
+
 # KUBECONFIG is set later by setup_kubeconfig() after argument parsing
 
 # AAP version
@@ -257,11 +260,10 @@ setup_kubeconfig() {
     fi
     export KUBECONFIG="$KUBECTL_KUBECONFIG"
   else
-    # Use OpenShift Local kubeconfig — only refresh if current one doesn't work
-    if [ -f "$HOME/.crc/machines/crc/kubeconfig" ]; then
-      export KUBECONFIG="$HOME/.crc/machines/crc/kubeconfig"
-    fi
-    # Test if kubeconfig works, refresh from VM if not
+    mkdir -p "$AAP_DEMO_DIR"
+    KUBECONFIG="$(aap_demo_resolve_kubeconfig)"
+    export KUBECONFIG
+    # Refresh from cluster if current kubeconfig doesn't work
     if ! kubectl cluster-info &>/dev/null 2>&1; then
       # Ensure infra backend is loaded to set CRC_SSH_KEY
       _infra_ensure_backend 2>/dev/null || true
@@ -270,11 +272,12 @@ setup_kubeconfig() {
           -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
           -o ConnectTimeout=2 -o BatchMode=yes \
           core@127.0.0.1 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' \
-          >"$HOME/.crc/machines/crc/kubeconfig.tmp" 2>/dev/null; then
-          mv "$HOME/.crc/machines/crc/kubeconfig.tmp" "$HOME/.crc/machines/crc/kubeconfig"
-          export KUBECONFIG="$HOME/.crc/machines/crc/kubeconfig"
+          >"${AAP_DEMO_KUBECONFIG}.tmp" 2>/dev/null; then
+          mv "${AAP_DEMO_KUBECONFIG}.tmp" "$AAP_DEMO_KUBECONFIG"
+          chmod 600 "$AAP_DEMO_KUBECONFIG"
+          export KUBECONFIG="$AAP_DEMO_KUBECONFIG"
         else
-          rm -f "$HOME/.crc/machines/crc/kubeconfig.tmp"
+          rm -f "${AAP_DEMO_KUBECONFIG}.tmp"
         fi
       fi
     fi
@@ -415,7 +418,7 @@ USAGE:
     aap-demo [OPTIONS] <COMMAND>
 
 OPTIONS:
-    --kubeconfig=FILE   Path to kubeconfig file (default: ~/.kube/config)
+    --kubeconfig=FILE   Path to kubeconfig file (default: ~/.aap-demo/kubeconfig.microshift)
     --context=NAME      kubectl context to use (default: current context)
     NAMESPACE=<name>    Kubernetes namespace (default: aap-operator)
     QUIET=true          Suppress disclaimer
@@ -503,7 +506,7 @@ determine_pull_secret() {
 
 cmd_repair() {
   NAMESPACE="${NAMESPACE:-aap-operator}"
-  export KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
+  export KUBECONFIG="${KUBECONFIG:-$(aap_demo_resolve_kubeconfig)}"
 
   echo "Running repair..."
   echo ""
@@ -973,7 +976,7 @@ cmd_diagnose() {
     _check_fail "kubectl cannot connect to cluster"
     echo ""
     echo "Cannot proceed without cluster connectivity."
-    echo "  Check KUBECONFIG: ${KUBECONFIG:-~/.kube/config}"
+    echo "  Check KUBECONFIG: ${KUBECONFIG:-$AAP_DEMO_KUBECONFIG}"
     return 1
   fi
   echo ""
@@ -1540,12 +1543,6 @@ cmd_kubeconfig() {
   }
   trap cleanup_temp_files EXIT
 
-  # Skip ~/.kube in CI (permission issues)
-  SKIP_KUBE_DIR=false
-  if [ "${CI:-false}" = "true" ] || [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
-    SKIP_KUBE_DIR=true
-  fi
-
   # Check cluster is reachable
   local cluster_name
   cluster_name=$(infra_get_name 2>/dev/null || echo "")
@@ -1598,64 +1595,17 @@ cmd_kubeconfig() {
   fi
   KUBECONFIG="$TEMP_KUBECONFIG" kubectl config use-context "$ctx_name" >/dev/null 2>&1
 
-  mv "$TEMP_KUBECONFIG" "$HOME/.crc/machines/crc/kubeconfig"
+  mv "$TEMP_KUBECONFIG" "$AAP_DEMO_KUBECONFIG"
   TEMP_FILES=() # Clear since file was moved successfully
-  chmod 600 "$HOME/.crc/machines/crc/kubeconfig"
-  echo "  ✓ Saved to ~/.crc/machines/crc/kubeconfig"
-
-  # Merge into ~/.kube/config (unless in CI)
-  if [ "$SKIP_KUBE_DIR" = "false" ]; then
-    mkdir -p "$HOME/.kube"
-    chmod 700 "$HOME/.kube"
-
-    if [ -f "$HOME/.kube/config" ]; then
-      # Remove old aap-demo entries first (prevents stale certs after repair)
-      echo "  Removing old aap-demo entries..."
-      KUBECONFIG="$HOME/.kube/config" kubectl config delete-context "$ctx_name" 2>/dev/null || true
-      KUBECONFIG="$HOME/.kube/config" kubectl config delete-cluster "$ctx_name" 2>/dev/null || true
-      KUBECONFIG="$HOME/.kube/config" kubectl config delete-user "$ctx_name" 2>/dev/null || true
-      # Also clean legacy names
-      KUBECONFIG="$HOME/.kube/config" kubectl config delete-context microshift 2>/dev/null || true
-      KUBECONFIG="$HOME/.kube/config" kubectl config delete-cluster microshift 2>/dev/null || true
-
-      # Merge into existing config
-      echo "  Merging into existing ~/.kube/config..."
-      TEMP_MERGED=$(mktemp)
-      TEMP_FILES+=("$TEMP_MERGED")
-      chmod 600 "$TEMP_MERGED"
-
-      if ! KUBECONFIG="$HOME/.kube/config:$HOME/.crc/machines/crc/kubeconfig" kubectl config view --flatten >"$TEMP_MERGED" 2>/dev/null; then
-        echo "  ERROR: Failed to merge kubeconfigs"
-        exit 1
-      fi
-
-      if ! KUBECONFIG="$TEMP_MERGED" kubectl config view >/dev/null 2>&1; then
-        echo "  ERROR: Merged kubeconfig is invalid"
-        exit 1
-      fi
-
-      mv "$TEMP_MERGED" "$HOME/.kube/config"
-      TEMP_FILES=()
-      chmod 600 "$HOME/.kube/config"
-      echo "  ✓ Merged context into ~/.kube/config"
-    else
-      cp "$HOME/.crc/machines/crc/kubeconfig" "$HOME/.kube/config"
-      chmod 600 "$HOME/.kube/config"
-      echo "  ✓ Created ~/.kube/config"
-    fi
-
-    # Set aap-demo as current context
-    if KUBECONFIG="$HOME/.kube/config" kubectl config use-context "$ctx_name" >/dev/null 2>&1; then
-      echo "  ✓ Current context set to $ctx_name"
-    else
-      echo "  WARNING: Could not set context to $ctx_name"
-    fi
-  fi
+  chmod 600 "$AAP_DEMO_KUBECONFIG"
+  echo "  ✓ Saved to $AAP_DEMO_KUBECONFIG"
+  export KUBECONFIG="$AAP_DEMO_KUBECONFIG"
 
   trap - EXIT
   echo ""
   echo "  kubectl now connects to OpenShift Local cluster."
   echo "  Context: $ctx_name"
+  echo "  export KUBECONFIG=$AAP_DEMO_KUBECONFIG"
 }
 
 cmd_status() {
@@ -2026,7 +1976,7 @@ cmd_deploy() {
   fi
 
   # Install OLM if not present (OpenShift Local doesn't include it)
-  if ! KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}" bash "${SCRIPT_DIR}/addons/olm/deploy.sh"; then
+  if ! KUBECONFIG="${KUBECONFIG:-$(aap_demo_resolve_kubeconfig)}" bash "${SCRIPT_DIR}/addons/olm/deploy.sh"; then
     printf "\n\033[1;31mERROR: OLM installation failed\033[0m\n"
     printf "OLM is required for AAP deployments. Please fix OLM before continuing.\n"
     printf "Try: \033[1maap-demo enable olm\033[0m\n\n"
@@ -2501,7 +2451,7 @@ _patch_gateway_capability() {
 
 watch_aap() {
   NAMESPACE="${NAMESPACE:-aap-operator}"
-  export KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
+  export KUBECONFIG="${KUBECONFIG:-$(aap_demo_resolve_kubeconfig)}"
 
   TIMEOUT=3600 # 60 minutes
   INTERVAL=10  # seconds between refreshes

--- a/addons/ao-eap/deploy.sh
+++ b/addons/ao-eap/deploy.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../includes/aap-demo-paths.sh
+source "${SCRIPT_DIR}/../../includes/aap-demo-paths.sh"
+KUBECONFIG_PATH="$(aap_demo_resolve_kubeconfig "${KUBECONFIG:-}")"
+export KUBECONFIG="$KUBECONFIG_PATH"
+
 # Deploy Automation Orchestrator Early Access to aap-demo
 #
 # Automates the full 10-step AO EAP install using aapctl CLI.
@@ -25,7 +31,6 @@ if echo "$_CATALOG_OP_ARGS" | grep -q '"openshift-marketplace"'; then
 else
   MARKETPLACE_NAMESPACE="olm"
 fi
-KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.aap-demo/kubeconfig.microshift}"
 if [ -z "${AO_STORAGE_CLASS:-}" ]; then
   if kubectl get sc nfs-local-rwx &>/dev/null 2>&1; then
     STORAGE_CLASS="nfs-local-rwx"

--- a/addons/ao-eap/deploy.sh
+++ b/addons/ao-eap/deploy.sh
@@ -25,7 +25,7 @@ if echo "$_CATALOG_OP_ARGS" | grep -q '"openshift-marketplace"'; then
 else
   MARKETPLACE_NAMESPACE="olm"
 fi
-KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
+KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.aap-demo/kubeconfig.microshift}"
 if [ -z "${AO_STORAGE_CLASS:-}" ]; then
   if kubectl get sc nfs-local-rwx &>/dev/null 2>&1; then
     STORAGE_CLASS="nfs-local-rwx"

--- a/addons/apme-eap/deploy.sh
+++ b/addons/apme-eap/deploy.sh
@@ -7,6 +7,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../includes/aap-demo-paths.sh
+source "${SCRIPT_DIR}/../../includes/aap-demo-paths.sh"
 ACTION="${1:-deploy}"
 NAMESPACE="apme"
 VARS_FILE="$HOME/.aap-demo/apme-eap-vars.yml"
@@ -328,11 +330,12 @@ discover_environment() {
 
   # 1. KUBECONFIG
   if [ -z "${KUBECONFIG:-}" ]; then
-    if [ -f "$HOME/.crc/machines/crc/kubeconfig" ]; then
-      export KUBECONFIG="$HOME/.crc/machines/crc/kubeconfig"
+    KUBECONFIG="$(aap_demo_resolve_kubeconfig)"
+    export KUBECONFIG
+    if [ -f "$KUBECONFIG" ]; then
       info "Using KUBECONFIG: $KUBECONFIG"
     else
-      warn "KUBECONFIG not set and default CRC kubeconfig not found"
+      warn "KUBECONFIG not set and aap-demo kubeconfig not found at $AAP_DEMO_KUBECONFIG"
     fi
   fi
 
@@ -726,7 +729,7 @@ deploy() {
   info "(pod status updates every 30s during helm installs)"
 
   # Set environment for kubernetes.core modules
-  export K8S_AUTH_KUBECONFIG="${KUBECONFIG:-${HOME}/.crc/machines/crc/kubeconfig}"
+  export K8S_AUTH_KUBECONFIG="${KUBECONFIG:-$(aap_demo_resolve_kubeconfig)}"
   export ANSIBLE_ROLES_PATH="${SCRIPT_DIR}/playbooks/roles"
 
   _pod_watcher "$NAMESPACE" 30 &

--- a/includes/aap-demo-paths.sh
+++ b/includes/aap-demo-paths.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# =============================================================================
+# aap-demo-paths.sh — Shared path constants for aap-demo
+# =============================================================================
+
+# Guard against double-sourcing
+if [ -n "$_AAP_DEMO_PATHS_LOADED" ]; then return 0; fi
+_AAP_DEMO_PATHS_LOADED=1
+
+AAP_DEMO_DIR="${AAP_DEMO_DIR:-$HOME/.aap-demo}"
+AAP_DEMO_KUBECONFIG="${AAP_DEMO_KUBECONFIG:-$AAP_DEMO_DIR/kubeconfig.microshift}"
+
+# Resolve the kubeconfig path aap-demo should use (read-only discovery).
+aap_demo_resolve_kubeconfig() {
+  if [ -n "${1:-}" ]; then
+    echo "$1"
+    return 0
+  fi
+  if [ -f "$AAP_DEMO_KUBECONFIG" ]; then
+    echo "$AAP_DEMO_KUBECONFIG"
+  elif [ -f "$AAP_DEMO_DIR/kubeconfig" ]; then
+    echo "$AAP_DEMO_DIR/kubeconfig"
+  elif [ -f "$HOME/.crc/machines/crc/kubeconfig" ]; then
+    echo "$HOME/.crc/machines/crc/kubeconfig"
+  else
+    echo "$AAP_DEMO_KUBECONFIG"
+  fi
+}

--- a/includes/aap-demo-paths.sh
+++ b/includes/aap-demo-paths.sh
@@ -4,13 +4,14 @@
 # =============================================================================
 
 # Guard against double-sourcing
-if [ -n "$_AAP_DEMO_PATHS_LOADED" ]; then return 0; fi
+if [ -n "${_AAP_DEMO_PATHS_LOADED:-}" ]; then return 0; fi
 _AAP_DEMO_PATHS_LOADED=1
 
 AAP_DEMO_DIR="${AAP_DEMO_DIR:-$HOME/.aap-demo}"
 AAP_DEMO_KUBECONFIG="${AAP_DEMO_KUBECONFIG:-$AAP_DEMO_DIR/kubeconfig.microshift}"
 
-# Resolve the kubeconfig path aap-demo should use (read-only discovery).
+# Resolve kubeconfig path (read-only discovery). Returns the write target even when
+# missing; callers that read the file must still test -f/-s before use.
 aap_demo_resolve_kubeconfig() {
   if [ -n "${1:-}" ]; then
     echo "$1"

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -11,6 +11,9 @@ set -eo pipefail
 
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
+# shellcheck source=includes/aap-demo-paths.sh
+source "${SCRIPT_DIR}/includes/aap-demo-paths.sh"
+
 # Source CRC infra backend (sets CRC_SSH_KEY, CRC_SSH_OPTS)
 # shellcheck source=includes/infra-crc.sh
 source "${SCRIPT_DIR}/includes/infra-crc.sh"
@@ -66,7 +69,7 @@ configure_coredns() {
 
   printf "${_GREEN}▸${_NC} Configuring CoreDNS for in-cluster route resolution...\n"
 
-  export KUBECONFIG="${KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
+  export KUBECONFIG="${KUBECONFIG:-$(aap_demo_resolve_kubeconfig)}"
 
   route_domain="apps.crc.testing"
   current_domain=$(ssh -p 2222 $crc_ssh_opts core@127.0.0.1 'grep -h baseDomain /etc/microshift/config.d/99-aap-demo-dns.yaml /etc/microshift/config.yaml 2>/dev/null | head -1' 2>/dev/null | awk '{print $2}' || true)
@@ -410,7 +413,9 @@ if [ "$_api_ready" = false ]; then
 fi
 
 # Refresh kubeconfig
-ssh -p 2222 "${CRC_SSH_OPTS[@]}" core@127.0.0.1 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' >~/.crc/machines/crc/kubeconfig 2>/dev/null || true
+mkdir -p "$AAP_DEMO_DIR"
+ssh -p 2222 "${CRC_SSH_OPTS[@]}" core@127.0.0.1 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' >"$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
+chmod 600 "$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
 echo "  ✓ nip.io baseDomain configured (data wiped)"
 
 # ---------------------------------------------------------------------------
@@ -425,17 +430,17 @@ echo "  ✓ nip.io baseDomain configured (data wiped)"
 printf "${_GREEN}▸${_NC} Configuring kubeconfig...\n"
 
 eval "$(crc oc-env 2>/dev/null)"
-mkdir -p "$HOME/.aap-demo"
+mkdir -p "$AAP_DEMO_DIR"
 
-cp ~/.crc/machines/crc/kubeconfig "$HOME/.aap-demo/kubeconfig.microshift" 2>/dev/null
-
-# Set as default kubeconfig (simple copy, no merge)
-# The CRC kubeconfig uses localhost:6443 which is fast and reliable
-mkdir -p "$HOME/.kube"
-cp "$HOME/.crc/machines/crc/kubeconfig" "$HOME/.kube/config"
-chmod 600 "$HOME/.kube/config"
-
-echo "  ✓ KUBECONFIG merged into ~/.kube/config"
+# Save cluster credentials under ~/.aap-demo (never touch ~/.kube/config)
+if [ -f "$AAP_DEMO_KUBECONFIG" ]; then
+  echo "  ✓ Kubeconfig saved to $AAP_DEMO_KUBECONFIG"
+else
+  ssh -p 2222 "${CRC_SSH_OPTS[@]}" core@127.0.0.1 \
+    'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' >"$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
+  chmod 600 "$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
+  echo "  ✓ Kubeconfig saved to $AAP_DEMO_KUBECONFIG"
+fi
 
 # ---------------------------------------------------------------------------
 # Register podman connection
@@ -450,7 +455,8 @@ echo "  podman --connection aap-demo build ."
 # Install metrics-server (enables oc adm top, kubectl top)
 # ---------------------------------------------------------------------------
 printf "${_GREEN}▸${_NC} Installing metrics-server...\n"
-export KUBECONFIG="$HOME/.crc/machines/crc/kubeconfig"
+KUBECONFIG="$(aap_demo_resolve_kubeconfig)"
+export KUBECONFIG
 if kubectl get deployment metrics-server -n kube-system &>/dev/null; then
   echo "  Already installed"
 else
@@ -585,7 +591,7 @@ fi
 echo ""
 echo "  Routes:     *.apps.127.0.0.1.nip.io"
 
-echo "  Kubeconfig: export KUBECONFIG=~/.crc/machines/crc/kubeconfig"
+echo "  Kubeconfig: export KUBECONFIG=$AAP_DEMO_KUBECONFIG"
 echo "  SSH:        aap-demo ssh"
 echo ""
 echo "  Next: aap-demo deploy    # Deploy AAP"

--- a/includes/crc-create.sh
+++ b/includes/crc-create.sh
@@ -433,13 +433,18 @@ eval "$(crc oc-env 2>/dev/null)"
 mkdir -p "$AAP_DEMO_DIR"
 
 # Save cluster credentials under ~/.aap-demo (never touch ~/.kube/config)
-if [ -f "$AAP_DEMO_KUBECONFIG" ]; then
-  echo "  ✓ Kubeconfig saved to $AAP_DEMO_KUBECONFIG"
-else
+if [ ! -s "$AAP_DEMO_KUBECONFIG" ]; then
   ssh -p 2222 "${CRC_SSH_OPTS[@]}" core@127.0.0.1 \
     'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' >"$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
   chmod 600 "$AAP_DEMO_KUBECONFIG" 2>/dev/null || true
+fi
+
+if [ -s "$AAP_DEMO_KUBECONFIG" ]; then
   echo "  ✓ Kubeconfig saved to $AAP_DEMO_KUBECONFIG"
+else
+  printf "  ${_RED}ERROR: Failed to save kubeconfig to $AAP_DEMO_KUBECONFIG${_NC}\n"
+  echo "  Try: aap-demo kubeconfig"
+  exit 1
 fi
 
 # ---------------------------------------------------------------------------

--- a/includes/infra-crc.sh
+++ b/includes/infra-crc.sh
@@ -104,6 +104,7 @@ _infra_crc_get_state() {
 _infra_crc_get_kubeconfig() {
   local dest="$1"
   _crc_exec sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig >"$dest" 2>/dev/null \
+    || cp "${AAP_DEMO_KUBECONFIG:-$HOME/.aap-demo/kubeconfig.microshift}" "$dest" 2>/dev/null \
     || cp ~/.crc/machines/crc/kubeconfig "$dest" 2>/dev/null
 }
 

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -79,11 +79,11 @@ function Invoke-AapDemoCreate {
       Start-Sleep -Seconds 5
     }
 
-    $kubeDir = Join-Path $env:USERPROFILE '.crc\machines\crc'
-    New-Item -ItemType Directory -Force -Path $kubeDir | Out-Null
+    $aapKube = Join-Path $Script:AapDemoConfigDir 'kubeconfig.microshift'
+    New-Item -ItemType Directory -Force -Path $Script:AapDemoConfigDir | Out-Null
     Invoke-AapCrcSsh 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' |
-      Set-Content -LiteralPath (Join-Path $kubeDir 'kubeconfig') -Encoding ascii
-    $env:KUBECONFIG = Join-Path $kubeDir 'kubeconfig'
+      Set-Content -LiteralPath $aapKube -Encoding ascii
+    $env:KUBECONFIG = $aapKube
 
     Write-AapStep 'Installing metrics-server...'
     if ((Invoke-AapOcQuiet @('get', 'deployment', 'metrics-server', '-n', 'kube-system')) -ne 0) {

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -211,9 +211,13 @@ function Get-AapKubeconfigPath {
   if ($env:KUBECONFIG -and (Test-Path -LiteralPath $env:KUBECONFIG)) {
     return $env:KUBECONFIG
   }
+  $aapKube = Join-Path $Script:AapDemoConfigDir 'kubeconfig.microshift'
+  if (Test-Path -LiteralPath $aapKube) { return $aapKube }
+  $legacyKube = Join-Path $Script:AapDemoConfigDir 'kubeconfig'
+  if (Test-Path -LiteralPath $legacyKube) { return $legacyKube }
   $crcKube = Join-Path $env:USERPROFILE '.crc\machines\crc\kubeconfig'
   if (Test-Path -LiteralPath $crcKube) { return $crcKube }
-  return $null
+  return $aapKube
 }
 
 function Initialize-AapKubeEnvironment {
@@ -1258,11 +1262,11 @@ function Sync-AapKubeconfig {
       'config', 'use-context', $ctxName
     ) | Out-Null
 
-    $crcDir = Split-Path -Parent $crcKube
-    New-Item -ItemType Directory -Force -Path $crcDir | Out-Null
-    Move-Item -LiteralPath $tempKube -Destination $crcKube -Force
+    $aapKube = Join-Path $Script:AapDemoConfigDir 'kubeconfig.microshift'
+    New-Item -ItemType Directory -Force -Path $Script:AapDemoConfigDir | Out-Null
+    Move-Item -LiteralPath $tempKube -Destination $aapKube -Force
     if (-not $Quiet) {
-      Write-AapStep 'Saved to ~/.crc/machines/crc/kubeconfig'
+      Write-AapStep "Saved to $aapKube"
     }
     $tempKube = $null
   } finally {
@@ -1271,46 +1275,10 @@ function Sync-AapKubeconfig {
     }
   }
 
-  $userKubeDir = Join-Path $env:USERPROFILE '.kube'
-  $userKube = Join-Path $userKubeDir 'config'
-  New-Item -ItemType Directory -Force -Path $userKubeDir | Out-Null
-
-  if (Test-Path -LiteralPath $userKube) {
-    if (-not $Quiet) {
-      Write-Host '  Removing stale OpenShift Local kubeconfig entries...'
-    }
-    Remove-AapStaleCrcKubeEntries -KubeConfig $userKube
-
-    if (-not $Quiet) {
-      Write-Host '  Merging into existing ~/.kube/config...'
-    }
-    $merged = [System.IO.Path]::GetTempFileName()
-    $prev = $env:KUBECONFIG
-    try {
-      $env:KUBECONFIG = "$userKube;$crcKube"
-      $flat = Invoke-AapExternal oc @('config', 'view', '--flatten')
-      if ($flat.ExitCode -ne 0) { throw 'Failed to merge kubeconfigs' }
-      Set-Content -LiteralPath $merged -Value $flat.Output -Encoding ascii
-      Move-Item -LiteralPath $merged -Destination $userKube -Force
-      if (-not $Quiet) {
-        Write-AapStep 'Merged context into ~/.kube/config'
-      }
-    } finally {
-      $env:KUBECONFIG = $prev
-      if (Test-Path -LiteralPath $merged) {
-        Remove-Item -LiteralPath $merged -Force -ErrorAction SilentlyContinue
-      }
-    }
-  } else {
-    Copy-Item -LiteralPath $crcKube -Destination $userKube -Force
-    if (-not $Quiet) {
-      Write-AapStep 'Created ~/.kube/config'
-    }
-  }
-
-  Invoke-AapOcConfig -KubeConfig $userKube -Arguments @('config', 'use-context', $ctxName) | Out-Null
+  $env:KUBECONFIG = Join-Path $Script:AapDemoConfigDir 'kubeconfig.microshift'
   if (-not $Quiet) {
     Write-AapStep "Current context set to $ctxName"
+    Write-Host "  export KUBECONFIG=$($env:KUBECONFIG)"
   }
 }
 


### PR DESCRIPTION
Keep cluster credentials in ~/.aap-demo/kubeconfig.microshift by default so create and kubeconfig sync no longer merge into the user's ~/.kube/config.