### PR TITLE
feat: bring PowerShell CLI and Windows addons to bash parity

### DIFF
--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -1778,7 +1778,15 @@ cmd_status() {
           echo "------------"
           _cred_found=true
         fi
-        printf "  %-20s admin / %s\n" "$ns:" "$ADMIN_PASSWORD"
+        local AAP_URL=""
+        AAP_URL=$(kubectl get route -n "$ns" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
+        echo "AAP ($ns)"
+        if [ -n "$AAP_URL" ]; then
+          echo "  URL:      https://${AAP_URL}"
+        fi
+        echo "  Username: admin"
+        echo "  Password: ${ADMIN_PASSWORD}"
+        echo ""
       fi
     done
     [ "$_cred_found" = "true" ] && echo ""
@@ -1787,20 +1795,31 @@ cmd_status() {
   # Show credentials for Automation Orchestrator (ao addon)
   if echo "$(_addons_list)" | grep -qw "ao" || kubectl get namespace automation-orchestrator &>/dev/null 2>&1; then
     local _ao_ns="automation-orchestrator"
-    local _ao_pw="" _ao_secret=""
+    local _ao_pw="" _ao_secret="" _ao_route=""
+    _ao_route=$(kubectl get routes -n "$_ao_ns" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
     _ao_secret=$(kubectl get secret -n "$_ao_ns" -o name 2>/dev/null | grep -i "admin-password" | head -1 || true)
     if [ -n "$_ao_secret" ]; then
       _ao_pw=$(kubectl get "$_ao_secret" -n "$_ao_ns" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)
     fi
-    if [ -n "$_ao_pw" ]; then
-      if [ "$_cred_found" = "false" ]; then
-        echo "Credentials:"
-        echo "------------"
-      fi
-      printf "  %-20s admin / %s\n" "$_ao_ns:" "$_ao_pw"
-      _cred_found=true
-      echo ""
+    if [ "$_cred_found" = "false" ]; then
+      echo "Credentials:"
+      echo "------------"
     fi
+    echo "Automation Orchestrator (ao-eap)"
+    if [ -n "$_ao_route" ]; then
+      echo "  URL:      https://${_ao_route}"
+    fi
+    echo "  Username: admin"
+    if [ -n "$_ao_pw" ]; then
+      echo "  Password: ${_ao_pw}"
+    else
+      echo "  Password: kubectl get secret -n ${_ao_ns} -o name | grep admin-password"
+    fi
+    if [ -z "$_ao_route" ] && [ -z "$_ao_pw" ]; then
+      echo "  (deployment may still be in progress)"
+    fi
+    _cred_found=true
+    echo ""
   fi
 
   local saved_addons
@@ -2624,6 +2643,71 @@ _addons_remove() {
   _addons_save "$new"
 }
 
+_show_access_entry() {
+  local title="$1" url="$2" username="$3" password="$4" hint="$5"
+  [ -n "$title" ] && echo "$title"
+  [ -n "$url" ] && echo "  URL:      $url"
+  [ -n "$username" ] && echo "  Username: $username"
+  if [ -n "$password" ]; then
+    echo "  Password: $password"
+  elif [ -n "$hint" ]; then
+    echo "  Password: $hint"
+  fi
+  echo ""
+}
+
+_show_addon_access() {
+  local addon="$1"
+  local ns="${NAMESPACE:-aap-operator}"
+  case "$addon" in
+    ao-eap)
+      local ao_ns="automation-orchestrator"
+      kubectl get namespace "$ao_ns" &>/dev/null 2>&1 || return 0
+      echo ""
+      echo "Credentials:"
+      echo "------------"
+      local ao_route="" ao_pw="" ao_secret=""
+      ao_route=$(kubectl get routes -n "$ao_ns" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
+      ao_secret=$(kubectl get secret -n "$ao_ns" -o name 2>/dev/null | grep -i "admin-password" | head -1 || true)
+      if [ -n "$ao_secret" ]; then
+        ao_pw=$(kubectl get "$ao_secret" -n "$ao_ns" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)
+      fi
+      echo "Automation Orchestrator (ao-eap)"
+      if [ -n "$ao_route" ]; then
+        echo "  URL:      https://${ao_route}"
+      fi
+      echo "  Username: admin"
+      if [ -n "$ao_pw" ]; then
+        echo "  Password: ${ao_pw}"
+      else
+        echo "  Password: kubectl get secret -n ${ao_ns} -o name | grep admin-password"
+      fi
+      if [ -z "$ao_route" ] && [ -z "$ao_pw" ]; then
+        echo "  (deployment may still be in progress)"
+      fi
+      echo ""
+      ;;
+    apme-eap)
+      local apme_ns="apme"
+      kubectl get namespace "$apme_ns" &>/dev/null 2>&1 || return 0
+      local apme_route="" aap_pw=""
+      apme_route=$(kubectl get route -n "$apme_ns" redhat-rhaap-portal -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+      [ -z "$apme_route" ] && return 0
+      aap_pw=$(kubectl get secret -n "$ns" aap-admin-password -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)
+      echo ""
+      echo "Credentials:"
+      echo "------------"
+      _show_access_entry "APME Portal (apme-eap)" \
+        "https://${apme_route}" "admin" "$aap_pw" \
+        "Uses AAP OAuth - retrieve AAP admin password from aap-demo status"
+      echo "  Sign in with AAP admin credentials (AAP OAuth)"
+      echo ""
+      ;;
+    portal|mcp-server|setup-pah|local-cache)
+      ;;
+  esac
+}
+
 cmd_enable() {
   local addon="${1:-}"
   shift 2>/dev/null || true
@@ -2687,9 +2771,14 @@ cmd_enable() {
     _addons_add "$addon"
   fi
   bash "$addon_dir/deploy.sh" "$@"
+  local _rc=$?
   if [ "$_skip_addon_save" != true ]; then
     echo "  Saved to config: ADDONS=$(_addons_list | tr ' ' ',')"
   fi
+  if [ "$_rc" -eq 0 ]; then
+    _show_addon_access "$addon"
+  fi
+  return "$_rc"
 }
 
 cmd_disable() {

--- a/aap-demo.sh
+++ b/aap-demo.sh
@@ -2703,7 +2703,7 @@ _show_addon_access() {
       echo "  Sign in with AAP admin credentials (AAP OAuth)"
       echo ""
       ;;
-    portal|mcp-server|setup-pah|local-cache)
+    portal | mcp-server | setup-pah | local-cache)
       ;;
   esac
 }

--- a/addons/ao/deploy.sh
+++ b/addons/ao/deploy.sh
@@ -47,9 +47,9 @@ AO_ACTIVE_INDEX_IMAGE=""
 AO_INDEX_FALLBACK_USED=0
 
 if [ -z "${AO_STORAGE_CLASS:-}" ]; then
-  if kubectl get sc nfs-local-rwx &>/dev/null 2>&1; then
+  if oc get sc nfs-local-rwx &>/dev/null 2>&1; then
     STORAGE_CLASS="nfs-local-rwx"
-  elif kubectl get sc topolvm-provisioner &>/dev/null 2>&1; then
+  elif oc get sc topolvm-provisioner &>/dev/null 2>&1; then
     STORAGE_CLASS="topolvm-provisioner"
   else
     echo "ERROR: No suitable StorageClass found (expected nfs-local-rwx or topolvm-provisioner)"
@@ -90,7 +90,7 @@ short_image_ref() {
 find_catalog_namespace() {
   local _ns
   for _ns in aap-operator openshift-marketplace olm; do
-    if kubectl get catalogsource redhat-operators -n "$_ns" &>/dev/null 2>&1; then
+    if oc get catalogsource redhat-operators -n "$_ns" &>/dev/null 2>&1; then
       echo "$_ns"
       return 0
     fi
@@ -101,9 +101,9 @@ find_catalog_namespace() {
 report_catalog_failure() {
   local _catalog_ns="$1"
   local _status _pod_status _reason
-  _status=$(kubectl get catalogsource redhat-operators -n "$_catalog_ns" \
+  _status=$(oc get catalogsource redhat-operators -n "$_catalog_ns" \
     -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "unknown")
-  _pod_status=$(kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  _pod_status=$(oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "unknown")
   echo "ERROR: CatalogSource not READY after waiting." >&2
   echo "  Namespace: ${_catalog_ns}" >&2
@@ -116,7 +116,7 @@ report_catalog_failure() {
   fi
   if catalog_pod_has_signature_pull_failure "$_catalog_ns"; then
     local _fail_phase
-    _fail_phase=$(kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+    _fail_phase=$(oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
       -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
     if [ "$_fail_phase" = "ImagePullBackOff" ] || [ "$_fail_phase" = "ErrImagePull" ]; then
       echo "" >&2
@@ -130,17 +130,17 @@ report_catalog_failure() {
   echo "  On slower networks or disks this can exceed 10 minutes." >&2
   echo "" >&2
   echo "  Verify AAP catalog is healthy first:" >&2
-  echo "    kubectl get catalogsource redhat-operators -n ${AAP_NAMESPACE}" >&2
-  echo "    kubectl get pods -n ${AAP_NAMESPACE} -l olm.catalogSource=redhat-operators" >&2
+  echo "    oc get catalogsource redhat-operators -n ${AAP_NAMESPACE}" >&2
+  echo "    oc get pods -n ${AAP_NAMESPACE} -l olm.catalogSource=redhat-operators" >&2
   echo "" >&2
   echo "  Then inspect the AO catalog pod and events:" >&2
-  echo "    kubectl describe pod -n ${_catalog_ns} -l olm.catalogSource=redhat-operators" >&2
-  echo "    kubectl get events -n ${_catalog_ns} --sort-by=.lastTimestamp | tail -15" >&2
+  echo "    oc describe pod -n ${_catalog_ns} -l olm.catalogSource=redhat-operators" >&2
+  echo "    oc get events -n ${_catalog_ns} --sort-by=.lastTimestamp | tail -15" >&2
   echo "" >&2
   echo "  Retry with a longer wait or after fixing AAP deploy:" >&2
   echo "    aap-demo deploy" >&2
   echo "    AO_CATALOG_TIMEOUT=900 AO_REFRESH_CATALOG=1 aap-demo enable ao" >&2
-  kubectl describe catalogsource redhat-operators -n "$_catalog_ns" 2>/dev/null | tail -20 >&2
+  oc describe catalogsource redhat-operators -n "$_catalog_ns" 2>/dev/null | tail -20 >&2
   return 1
 }
 
@@ -219,25 +219,22 @@ copy_pull_secret_to_namespace() {
   local _dst_ns="$2"
   local _src_name="$3"
   local _dst_name="${4:-$_src_name}"
-  if ! kubectl get secret "$_src_name" -n "$_src_ns" &>/dev/null; then
+  local _tmp
+  if ! oc get secret "$_src_name" -n "$_src_ns" &>/dev/null; then
     return 1
   fi
-  kubectl get secret "$_src_name" -n "$_src_ns" -o json \
-    | DST_NAME="$_dst_name" DST_NS="$_dst_ns" python3 -c "
-import json, os, sys
-secret = json.load(sys.stdin)
-out = {
-    'apiVersion': 'v1',
-    'kind': 'Secret',
-    'metadata': {
-        'name': os.environ['DST_NAME'],
-        'namespace': os.environ['DST_NS'],
-    },
-    'type': secret.get('type', 'kubernetes.io/dockerconfigjson'),
-    'data': secret.get('data', {}),
-}
-json.dump(out, sys.stdout)
-" | kubectl apply -f - >&2
+  _tmp="$(mktemp)"
+  if ! oc get secret "$_src_name" -n "$_src_ns" \
+    -o jsonpath='{.data.\.dockerconfigjson}' 2>/dev/null | base64 -d >"$_tmp"; then
+    rm -f "$_tmp"
+    return 1
+  fi
+  oc create secret generic "$_dst_name" \
+    --namespace "$_dst_ns" \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=.dockerconfigjson="$_tmp" \
+    --dry-run=client -o yaml | oc apply -f - >&2
+  rm -f "$_tmp"
 }
 
 select_ao_index_image() {
@@ -252,9 +249,9 @@ select_ao_index_image() {
     return 0
   fi
   _aap_ns=$(find_catalog_namespace)
-  _aap_image=$(kubectl get catalogsource redhat-operators -n "$_aap_ns" \
+  _aap_image=$(oc get catalogsource redhat-operators -n "$_aap_ns" \
     -o jsonpath='{.spec.image}' 2>/dev/null || echo "")
-  _aap_state=$(kubectl get catalogsource redhat-operators -n "$_aap_ns" \
+  _aap_state=$(oc get catalogsource redhat-operators -n "$_aap_ns" \
     -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
   if [ -n "$_aap_image" ]; then
     if [ "$_aap_state" = "READY" ]; then
@@ -284,7 +281,7 @@ ensure_ao_catalog_source() {
 
   _src_ns=$(find_catalog_namespace)
   _target_image=$(select_ao_index_image)
-  _current_image=$(kubectl get catalogsource redhat-operators -n "$_catalog_ns" \
+  _current_image=$(oc get catalogsource redhat-operators -n "$_catalog_ns" \
     -o jsonpath='{.spec.image}' 2>/dev/null || echo "")
 
   echo "Creating AO CatalogSource in ${_catalog_ns}..." >&2
@@ -306,11 +303,11 @@ ensure_ao_catalog_source() {
 
   sed -e "s|image: .*|image: ${_target_image}|" \
     -e "s|namespace: aap-operator|namespace: ${_catalog_ns}|" \
-    "$CATALOG_SOURCE_TEMPLATE" | kubectl apply -f - >&2
+    "$CATALOG_SOURCE_TEMPLATE" | oc apply -f - >&2
 
   if [ -n "$REFRESH_CATALOG" ] || { [ -n "$_current_image" ] && [ "$_current_image" != "$_target_image" ]; }; then
     echo "  Restarting catalog pod..." >&2
-    kubectl delete pod -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+    oc delete pod -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
       --wait=false >/dev/null 2>&1 || true
   fi
 
@@ -334,7 +331,7 @@ ensure_ao_catalog_source() {
 
 resolve_cluster_domain() {
   local _host _domain
-  _host=$(kubectl get route -n "$AAP_NAMESPACE" \
+  _host=$(oc get route -n "$AAP_NAMESPACE" \
     -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
   if [ -n "$_host" ]; then
     _domain="${_host#*.}"
@@ -350,7 +347,7 @@ operator_controller_namespace() {
   local _ns
   for _ns in "${OLM_NAMESPACE:-}" "$NAMESPACE"; do
     [ -z "$_ns" ] && continue
-    if kubectl get deployment automation-orchestrator-operator-controller-manager \
+    if oc get deployment automation-orchestrator-operator-controller-manager \
       -n "$_ns" &>/dev/null; then
       echo "$_ns"
       return 0
@@ -362,39 +359,31 @@ operator_controller_namespace() {
 operator_is_available() {
   local _ns
   _ns=$(operator_controller_namespace)
-  kubectl wait --for=condition=Available \
+  oc wait --for=condition=Available \
     deployment/automation-orchestrator-operator-controller-manager \
     -n "$_ns" --timeout=5s &>/dev/null 2>&1
 }
 
 operator_package_in_catalog() {
   local _catalog_ns="$1"
-  kubectl get packagemanifest automation-orchestrator-operator \
+  oc get packagemanifest automation-orchestrator-operator \
     -n "$_catalog_ns" &>/dev/null 2>&1
 }
 
 subscription_has_resolution_failure() {
-  kubectl get subscription automation-orchestrator-operator -n "${OLM_NAMESPACE}" \
-    -o json 2>/dev/null | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(1)
-for cond in data.get("status", {}).get("conditions", []):
-    if cond.get("status") != "True":
-        continue
-    if cond.get("type") == "ResolutionFailed":
-        sys.exit(0)
-    if cond.get("type") == "CatalogSourcesUnhealthy":
-        if cond.get("reason") != "AllCatalogSourcesHealthy":
-            sys.exit(0)
-sys.exit(1)
-' 2>/dev/null
+  local _types _reason
+  _types=$(oc get subscription automation-orchestrator-operator -n "${OLM_NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[?(@.status=="True")]}{.type}{"\n"}{end}' 2>/dev/null || echo "")
+  if echo "$_types" | grep -qx 'ResolutionFailed'; then
+    return 0
+  fi
+  _reason=$(oc get subscription automation-orchestrator-operator -n "${OLM_NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[?(@.type=="CatalogSourcesUnhealthy" && @.status=="True")]}{.reason}{end}' 2>/dev/null || echo "")
+  [ -n "$_reason" ] && [ "$_reason" != "AllCatalogSourcesHealthy" ]
 }
 
 subscription_failure_detail() {
-  kubectl get subscription automation-orchestrator-operator -n "${OLM_NAMESPACE}" \
+  oc get subscription automation-orchestrator-operator -n "${OLM_NAMESPACE}" \
     -o jsonpath='{range .status.conditions[*]}{.type}: {.message}{"\n"}{end}' 2>/dev/null \
     || echo ""
 }
@@ -403,23 +392,23 @@ apply_operator_olm_manifests() {
   sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
     -e "s|__CATALOG_NAMESPACE__|${CATALOG_NAMESPACE}|g" \
     -e "s|__OPERATOR_CHANNEL__|${OPERATOR_CHANNEL}|g" \
-    "${MANIFESTS_DIR}/operator-subscription.yaml" | kubectl apply -f -
+    "${MANIFESTS_DIR}/operator-subscription.yaml" | oc apply -f -
 }
 
 cleanup_ao_olm_state() {
   local _ns
   for _ns in "${OLM_NAMESPACE:-}" "$NAMESPACE" "$AAP_NAMESPACE"; do
     [ -z "$_ns" ] && continue
-    kubectl delete subscription automation-orchestrator-operator -n "$_ns" --wait=false 2>/dev/null || true
-    kubectl delete operatorgroup automation-orchestrator-operator -n "$_ns" --wait=false 2>/dev/null || true
+    oc delete subscription automation-orchestrator-operator -n "$_ns" --wait=false 2>/dev/null || true
+    oc delete operatorgroup automation-orchestrator-operator -n "$_ns" --wait=false 2>/dev/null || true
     if [ "$_ns" = "$AAP_NAMESPACE" ]; then
       continue
     fi
-    kubectl get installplan -n "$_ns" -o name 2>/dev/null \
-      | xargs -r kubectl delete -n "$_ns" --wait=false 2>/dev/null || true
-    kubectl get csv -n "$_ns" -o name 2>/dev/null \
+    oc get installplan -n "$_ns" -o name 2>/dev/null \
+      | xargs -r oc delete -n "$_ns" --wait=false 2>/dev/null || true
+    oc get csv -n "$_ns" -o name 2>/dev/null \
       | grep "automation-orchestrator" \
-      | xargs -r kubectl delete -n "$_ns" --wait=false 2>/dev/null || true
+      | xargs -r oc delete -n "$_ns" --wait=false 2>/dev/null || true
   done
 }
 
@@ -456,7 +445,7 @@ report_subscription_resolution_failure() {
 report_operator_not_in_catalog() {
   local _catalog_ns="$1"
   local _index_image
-  _index_image=$(kubectl get catalogsource redhat-operators -n "$_catalog_ns" \
+  _index_image=$(oc get catalogsource redhat-operators -n "$_catalog_ns" \
     -o jsonpath='{.spec.image}' 2>/dev/null || echo "unknown")
   echo "ERROR: automation-orchestrator-operator is not in catalog redhat-operators (${_catalog_ns})."
   echo ""
@@ -470,8 +459,8 @@ report_operator_not_in_catalog() {
   echo "  (v4.18+). If the package is missing, verify catalog index version and refresh."
   echo ""
   echo "  Verify:"
-  echo "    kubectl get packagemanifest automation-orchestrator-operator -n ${_catalog_ns}"
-  echo "    kubectl get subscription automation-orchestrator-operator -n ${OLM_NAMESPACE:-$CATALOG_NAMESPACE} -o yaml"
+  echo "    oc get packagemanifest automation-orchestrator-operator -n ${_catalog_ns}"
+  echo "    oc get subscription automation-orchestrator-operator -n ${OLM_NAMESPACE:-$CATALOG_NAMESPACE} -o yaml"
   echo ""
   echo "  Clean up a failed attempt:"
   echo "    aap-demo disable ao"
@@ -486,46 +475,46 @@ report_operator_not_in_catalog() {
 
 show_access_info() {
   local AO_ROUTE PASS_SECRET AO_PASSWORD
-  AO_ROUTE=$(kubectl get routes -n "$NAMESPACE" \
+  AO_ROUTE=$(oc get routes -n "$NAMESPACE" \
     -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
-  PASS_SECRET=$(kubectl get secret -n "$NAMESPACE" \
+  PASS_SECRET=$(oc get secret -n "$NAMESPACE" \
     -o name 2>/dev/null | grep -i "admin-password" | head -1 || echo "")
 
   if [ -n "$AO_ROUTE" ]; then
     echo "  URL:      https://${AO_ROUTE}"
   else
-    echo "  URL:      kubectl get routes -n ${NAMESPACE} -o jsonpath='{.items[0].spec.host}'"
+    echo "  URL:      oc get routes -n ${NAMESPACE} -o jsonpath='{.items[0].spec.host}'"
   fi
   echo "  Username: admin"
   if [ -n "$PASS_SECRET" ]; then
     if [ "${CI:-}" != "true" ]; then
-      AO_PASSWORD=$(kubectl get "$PASS_SECRET" -n "$NAMESPACE" \
+      AO_PASSWORD=$(oc get "$PASS_SECRET" -n "$NAMESPACE" \
         -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
       if [ -n "$AO_PASSWORD" ]; then
         echo "  Password: ${AO_PASSWORD}"
       else
-        echo "  Password: kubectl get $PASS_SECRET -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
+        echo "  Password: oc get $PASS_SECRET -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
       fi
     else
-      echo "  Password: kubectl get $PASS_SECRET -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
+      echo "  Password: oc get $PASS_SECRET -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
     fi
   else
-    echo "  Password: kubectl get secret -n $NAMESPACE | grep admin-password"
+    echo "  Password: oc get secret -n $NAMESPACE | grep admin-password"
   fi
-  echo "  Status:   kubectl get pods -n $NAMESPACE"
+  echo "  Status:   oc get pods -n $NAMESPACE"
 }
 
 AO_PULL_SECRET_NAME="${AO_PULL_SECRET_NAME:-automation-orchestrator-pull-secret}"
 
 cnpg_database_crd_available() {
-  kubectl get crd databases.postgresql.cnpg.io &>/dev/null 2>&1
+  oc get crd databases.postgresql.cnpg.io &>/dev/null 2>&1
 }
 
 ensure_cnpg_operator() {
   CNPG_VERSION="${CNPG_VERSION:-1.25.1}"
   CNPG_MANIFEST="https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v${CNPG_VERSION}/cnpg-${CNPG_VERSION}.yaml"
 
-  if kubectl get crd clusters.postgresql.cnpg.io &>/dev/null 2>&1 \
+  if oc get crd clusters.postgresql.cnpg.io &>/dev/null 2>&1 \
     && cnpg_database_crd_available; then
     echo "✓ CloudNativePG operator ready"
     mkdir -p "$(dirname "$AO_STATE_FILE")"
@@ -534,13 +523,13 @@ ensure_cnpg_operator() {
     return 0
   fi
 
-  if kubectl get crd clusters.postgresql.cnpg.io &>/dev/null 2>&1; then
+  if oc get crd clusters.postgresql.cnpg.io &>/dev/null 2>&1; then
     echo "Upgrading CloudNativePG to v${CNPG_VERSION} (Database CRD required)..."
   else
     echo "Installing CloudNativePG operator v${CNPG_VERSION} (dev-only, not Red Hat supported)..."
   fi
 
-  if ! kubectl apply --server-side -f "$CNPG_MANIFEST" 2>&1 | tail -5; then
+  if ! oc apply --server-side -f "$CNPG_MANIFEST" 2>&1 | tail -5; then
     echo "ERROR: Failed to install CloudNativePG from ${CNPG_MANIFEST}"
     exit 1
   fi
@@ -550,13 +539,13 @@ ensure_cnpg_operator() {
   oc adm policy add-scc-to-group privileged "system:serviceaccounts:cnpg-system" 2>/dev/null || true
 
   echo "Waiting for CloudNativePG operator..."
-  kubectl rollout status deployment/cnpg-controller-manager \
+  oc rollout status deployment/cnpg-controller-manager \
     -n cnpg-system --timeout=5m
   echo "✓ CloudNativePG operator running"
 }
 
 postgres_primary_pod() {
-  kubectl get pod -n "$NAMESPACE" -l "cnpg.io/cluster=orchestrator-postgres,role=primary" \
+  oc get pod -n "$NAMESPACE" -l "cnpg.io/cluster=orchestrator-postgres,role=primary" \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null \
     || echo "orchestrator-postgres-1"
 }
@@ -565,7 +554,7 @@ postgres_database_exists() {
   local _db="$1"
   local _pod
   _pod=$(postgres_primary_pod)
-  kubectl exec -n "$NAMESPACE" "$_pod" -- psql -U postgres -tAc \
+  oc exec -n "$NAMESPACE" "$_pod" -- psql -U postgres -tAc \
     "SELECT 1 FROM pg_database WHERE datname='${_db}'" 2>/dev/null | grep -qx 1
 }
 
@@ -577,7 +566,7 @@ ensure_postgres_database() {
   fi
   _pod=$(postgres_primary_pod)
   echo "  Creating PostgreSQL database: ${_db}"
-  kubectl exec -n "$NAMESPACE" "$_pod" -- psql -U postgres -c \
+  oc exec -n "$NAMESPACE" "$_pod" -- psql -U postgres -c \
     "CREATE DATABASE \"${_db}\" OWNER orchestrator" >/dev/null
 }
 
@@ -586,7 +575,7 @@ wait_for_ao_postgres_databases() {
   if cnpg_database_crd_available; then
     for _cr in orchestrator temporal temporal-visibility; do
       for _i in $(seq 1 30); do
-        _applied=$(kubectl get database "$_cr" -n "$NAMESPACE" \
+        _applied=$(oc get database "$_cr" -n "$NAMESPACE" \
           -o jsonpath='{.status.applied}' 2>/dev/null || echo "")
         if [ "$_applied" = "true" ]; then
           break
@@ -611,24 +600,16 @@ wait_for_ao_postgres_databases() {
 
 ensure_ao_pull_secret() {
   local _src_ns="${CATALOG_NAMESPACE:-$AAP_NAMESPACE}"
-  if kubectl get secret "$AO_PULL_SECRET_NAME" -n "$NAMESPACE" &>/dev/null; then
+  if oc get secret "$AO_PULL_SECRET_NAME" -n "$NAMESPACE" &>/dev/null; then
     return 0
   fi
-  if ! kubectl get secret redhat-operators-pull-secret -n "$_src_ns" &>/dev/null; then
+  if ! oc get secret redhat-operators-pull-secret -n "$_src_ns" &>/dev/null; then
     echo "WARNING: redhat-operators-pull-secret not found in ${_src_ns}"
     return 1
   fi
   echo "Copying pull secret into ${NAMESPACE}..."
-  kubectl get secret redhat-operators-pull-secret -n "$_src_ns" -o json \
-    | AO_PULL_SECRET_NAME="$AO_PULL_SECRET_NAME" NAMESPACE="$NAMESPACE" python3 -c "
-import json, os, sys
-secret = json.load(sys.stdin)
-secret['metadata'] = {
-    'name': os.environ['AO_PULL_SECRET_NAME'],
-    'namespace': os.environ['NAMESPACE'],
-}
-json.dump(secret, sys.stdout)
-" | kubectl apply -f -
+  copy_pull_secret_to_namespace "$_src_ns" "$NAMESPACE" \
+    "redhat-operators-pull-secret" "$AO_PULL_SECRET_NAME"
 }
 
 link_ao_pull_secrets_to_operator() {
@@ -638,8 +619,8 @@ link_ao_pull_secrets_to_operator() {
   for _ns in "${OLM_NAMESPACE:-}" "$NAMESPACE"; do
     [ -z "$_ns" ] && continue
     for _sa in automation-orchestrator-operator-controller-manager default; do
-      if kubectl get sa "$_sa" -n "$_ns" &>/dev/null; then
-        kubectl patch sa "$_sa" -n "$_ns" --type=merge \
+      if oc get sa "$_sa" -n "$_ns" &>/dev/null; then
+        oc patch sa "$_sa" -n "$_ns" --type=merge \
           -p "{\"imagePullSecrets\":[{\"name\":\"${AO_PULL_SECRET_NAME}\"}]}" 2>/dev/null || true
       fi
     done
@@ -647,21 +628,21 @@ link_ao_pull_secrets_to_operator() {
 }
 
 deploy_ao_instance() {
-  kubectl delete secret automation-orchestrator-initial-admin-password \
+  oc delete secret automation-orchestrator-initial-admin-password \
     -n "$NAMESPACE" 2>/dev/null || true
 
   echo "Creating AutomationOrchestrator instance (aapctl GitOps CR)..."
   sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
     -e "s|__INGRESS_HOST__|${INGRESS_HOST}|g" \
     -e "s|__PULL_SECRET_NAME__|${AO_PULL_SECRET_NAME}|g" \
-    "${MANIFESTS_DIR}/automationorchestrator-cr.yaml" | kubectl apply -f -
+    "${MANIFESTS_DIR}/automationorchestrator-cr.yaml" | oc apply -f -
 }
 
 cleanup_legacy_ea_resources() {
   local _ns
   for _ns in aap-operator olm openshift-marketplace; do
-    kubectl delete catalogsource cs-automation-orchestrator -n "$_ns" --wait=false 2>/dev/null || true
-    kubectl delete secret ao-registry-pull-secret -n "$_ns" 2>/dev/null || true
+    oc delete catalogsource cs-automation-orchestrator -n "$_ns" --wait=false 2>/dev/null || true
+    oc delete secret ao-registry-pull-secret -n "$_ns" 2>/dev/null || true
   done
 }
 
@@ -673,26 +654,26 @@ if [ "$ACTION" = "--delete" ] || [ "$ACTION" = "delete" ]; then
     aapctl uninstall automation-orchestrator --force --yes 2>/dev/null || true
   fi
 
-  kubectl get automationorchestrator -n "$NAMESPACE" -o name 2>/dev/null \
-    | xargs -r -I{} kubectl patch {} -n "$NAMESPACE" \
+  oc get automationorchestrator -n "$NAMESPACE" -o name 2>/dev/null \
+    | xargs -r -I{} oc patch {} -n "$NAMESPACE" \
       --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' \
       2>/dev/null || true
-  kubectl get automationorchestrators.aap.ansible.com -n "$NAMESPACE" -o name 2>/dev/null \
-    | xargs -r -I{} kubectl patch {} -n "$NAMESPACE" \
+  oc get automationorchestrators.aap.ansible.com -n "$NAMESPACE" -o name 2>/dev/null \
+    | xargs -r -I{} oc patch {} -n "$NAMESPACE" \
       --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' \
       2>/dev/null || true
 
-  kubectl delete automationorchestrator --all -n "$NAMESPACE" --wait=false 2>/dev/null || true
+  oc delete automationorchestrator --all -n "$NAMESPACE" --wait=false 2>/dev/null || true
   OLM_NAMESPACE="$NAMESPACE"
   cleanup_ao_olm_state
 
   cleanup_legacy_ea_resources
 
-  kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  oc delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
 
   echo "  Waiting for namespace to terminate..."
   for _i in $(seq 1 60); do
-    _ao_ns=$(kubectl get namespace "$NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ') || _ao_ns=0
+    _ao_ns=$(oc get namespace "$NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ') || _ao_ns=0
     printf "\r  $(hat) automation-orchestrator: %s    " \
       "$([ "$_ao_ns" -eq 0 ] && echo "gone" || echo "terminating")"
     if [ "$_ao_ns" -eq 0 ]; then
@@ -702,7 +683,7 @@ if [ "$ACTION" = "--delete" ] || [ "$ACTION" = "delete" ]; then
     if [ "$_i" -eq 60 ]; then
       echo ""
       echo "  ⚠ Namespace still terminating after 5 minutes — continuing anyway"
-      echo "  Check: kubectl get namespace $NAMESPACE"
+      echo "  Check: oc get namespace $NAMESPACE"
     fi
     sleep 5
   done
@@ -716,14 +697,14 @@ fi
 
 ao_instance_ready_to_skip() {
   local _degraded _route _reason
-  if ! kubectl get automationorchestrator automation-orchestrator -n "$NAMESPACE" &>/dev/null 2>&1; then
+  if ! oc get automationorchestrator automation-orchestrator -n "$NAMESPACE" &>/dev/null 2>&1; then
     return 0
   fi
-  _degraded=$(kubectl get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
+  _degraded=$(oc get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
     -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.status}{end}' 2>/dev/null || echo "")
-  _reason=$(kubectl get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
+  _reason=$(oc get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
     -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.reason}{end}' 2>/dev/null || echo "")
-  _route=$(kubectl get routes -n "$NAMESPACE" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
+  _route=$(oc get routes -n "$NAMESPACE" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
   if [ "$_degraded" = "True" ]; then
     echo "  Instance is Degraded (${_reason:-unknown}) — continuing install..."
     return 1
@@ -737,11 +718,11 @@ ao_instance_ready_to_skip() {
 
 # --- Skip if already running (unless --force) ---
 if [ -z "$FORCE" ]; then
-  _ao_total=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+  _ao_total=$(oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
     | { grep -v "Completed" || true; } | wc -l | tr -d ' ' || echo "0")
-  _ao_running=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+  _ao_running=$(oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
     | { grep "Running" || true; } | wc -l | tr -d ' ' || echo "0")
-  _sub_channel=$(kubectl get subscription automation-orchestrator-operator -n "$NAMESPACE" \
+  _sub_channel=$(oc get subscription automation-orchestrator-operator -n "$NAMESPACE" \
     -o jsonpath='{.spec.channel}' 2>/dev/null || echo "")
   if [ "${_ao_total:-0}" -gt 2 ] \
     && [ "${_ao_running:-0}" -eq "${_ao_total:-0}" ] \
@@ -758,7 +739,7 @@ fi
 
 # --- Namespace + SCCs ---
 echo "Creating namespace and SCC grants..."
-kubectl create namespace "$NAMESPACE" 2>/dev/null || true
+oc create namespace "$NAMESPACE" 2>/dev/null || true
 oc adm policy add-scc-to-group anyuid "system:serviceaccounts:${NAMESPACE}" 2>/dev/null || true
 oc adm policy add-scc-to-group privileged "system:serviceaccounts:${NAMESPACE}" 2>/dev/null || true
 echo "✓ Namespace ready"
@@ -766,18 +747,18 @@ echo "✓ Namespace ready"
 # --- AO-local catalog (MicroShift cannot resolve CatalogSources across namespaces) ---
 echo "Checking AAP redhat-operators catalog (for index image and pull secret)..."
 _aap_catalog_ns=$(find_catalog_namespace)
-if ! kubectl get catalogsource redhat-operators -n "$_aap_catalog_ns" &>/dev/null; then
+if ! oc get catalogsource redhat-operators -n "$_aap_catalog_ns" &>/dev/null; then
   echo "ERROR: redhat-operators CatalogSource is missing."
   echo "  Run 'aap-demo deploy' first to install OLM and the operator catalog."
   exit 1
 fi
-_aap_catalog_state=$(kubectl get catalogsource redhat-operators -n "$_aap_catalog_ns" \
+_aap_catalog_state=$(oc get catalogsource redhat-operators -n "$_aap_catalog_ns" \
   -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
 if [ "$_aap_catalog_state" != "READY" ]; then
   echo "ERROR: AAP redhat-operators catalog is not READY (state: ${_aap_catalog_state:-unknown})."
   echo "  Fix the AAP catalog before enabling AO:"
   echo "    aap-demo deploy"
-  echo "  Check: kubectl get catalogsource redhat-operators -n ${_aap_catalog_ns}"
+  echo "  Check: oc get catalogsource redhat-operators -n ${_aap_catalog_ns}"
   exit 1
 fi
 if ! CATALOG_NAMESPACE=$(ensure_ao_catalog_source); then
@@ -808,33 +789,33 @@ ensure_cnpg_operator
 echo "Creating PostgreSQL cluster for Automation Orchestrator..."
 
 _legacy_secret=""
-if kubectl get cluster orchestrator-postgres -n "$NAMESPACE" -o jsonpath='{.spec.bootstrap.initdb.secret.name}' 2>/dev/null \
+if oc get cluster orchestrator-postgres -n "$NAMESPACE" -o jsonpath='{.spec.bootstrap.initdb.secret.name}' 2>/dev/null \
   | grep -qx "orchestrator-pg-credentials"; then
   _legacy_secret=1
 fi
-if kubectl get secret orchestrator-pg-credentials -n "$NAMESPACE" &>/dev/null \
-  || kubectl get secret temporal-pg-credentials -n "$NAMESPACE" &>/dev/null; then
+if oc get secret orchestrator-pg-credentials -n "$NAMESPACE" &>/dev/null \
+  || oc get secret temporal-pg-credentials -n "$NAMESPACE" &>/dev/null; then
   _legacy_secret=1
 fi
 
 if [ -n "$FORCE" ] || [ -n "$_legacy_secret" ]; then
   if [ -n "$_legacy_secret" ]; then
     echo "  Recreating postgres to match aapctl secret names..."
-    kubectl delete secret orchestrator-pg-credentials temporal-pg-credentials -n "$NAMESPACE" \
+    oc delete secret orchestrator-pg-credentials temporal-pg-credentials -n "$NAMESPACE" \
       --ignore-not-found 2>/dev/null || true
   fi
-  if kubectl get cluster orchestrator-postgres -n "$NAMESPACE" &>/dev/null \
-    || kubectl get pvc orchestrator-postgres-1 -n "$NAMESPACE" &>/dev/null; then
+  if oc get cluster orchestrator-postgres -n "$NAMESPACE" &>/dev/null \
+    || oc get pvc orchestrator-postgres-1 -n "$NAMESPACE" &>/dev/null; then
     echo "  Resetting postgres cluster for fresh init..."
-    kubectl delete cluster orchestrator-postgres -n "$NAMESPACE" 2>/dev/null || true
-    kubectl wait --for=delete cluster/orchestrator-postgres -n "$NAMESPACE" --timeout=120s 2>/dev/null || true
-    kubectl delete pvc orchestrator-postgres-1 -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
+    oc delete cluster orchestrator-postgres -n "$NAMESPACE" 2>/dev/null || true
+    oc wait --for=delete cluster/orchestrator-postgres -n "$NAMESPACE" --timeout=120s 2>/dev/null || true
+    oc delete pvc orchestrator-postgres-1 -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
   fi
 fi
 
 # Reuse the existing aapctl secret password so we never desync from CNPG.
-if kubectl get secret orchestrator-postgres-secret -n "$NAMESPACE" &>/dev/null; then
-  PG_PASSWORD=$(kubectl get secret orchestrator-postgres-secret -n "$NAMESPACE" \
+if oc get secret orchestrator-postgres-secret -n "$NAMESPACE" &>/dev/null; then
+  PG_PASSWORD=$(oc get secret orchestrator-postgres-secret -n "$NAMESPACE" \
     -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
 fi
 if [ -z "${PG_PASSWORD:-}" ]; then
@@ -842,7 +823,7 @@ if [ -z "${PG_PASSWORD:-}" ]; then
 fi
 PG_HOST="orchestrator-postgres-rw.${NAMESPACE}.svc"
 
-kubectl apply -f - <<EOF
+oc apply -f - <<EOF
 ---
 apiVersion: v1
 kind: Secret
@@ -886,7 +867,7 @@ EOF
 
 sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
   -e "s|__STORAGE_CLASS__|${STORAGE_CLASS}|g" \
-  "${MANIFESTS_DIR}/postgres-cluster.yaml" | kubectl apply -f - || {
+  "${MANIFESTS_DIR}/postgres-cluster.yaml" | oc apply -f - || {
   echo "ERROR: Failed to apply PostgreSQL manifests."
   if ! cnpg_database_crd_available; then
     echo "  CloudNativePG Database CRD is missing. Re-run after CNPG upgrade completes."
@@ -896,7 +877,7 @@ sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
 
 echo "Waiting for PostgreSQL cluster to be ready..."
 for i in $(seq 1 60); do
-  READY=$(kubectl get cluster orchestrator-postgres -n "$NAMESPACE" \
+  READY=$(oc get cluster orchestrator-postgres -n "$NAMESPACE" \
     -o jsonpath='{.status.readyInstances}' 2>/dev/null || echo "0")
   if [ "$READY" = "1" ]; then
     echo "✓ PostgreSQL cluster ready"
@@ -915,27 +896,27 @@ wait_for_ao_postgres_databases
 # --- Operator install (GA OLM subscription) ---
 # AAP already has an OperatorGroup in aap-operator; a second one there
 # makes OLM refuse all subscriptions in that namespace.
-kubectl delete subscription automation-orchestrator-operator -n "$AAP_NAMESPACE" --wait=false 2>/dev/null || true
-kubectl delete operatorgroup automation-orchestrator-operator -n "$AAP_NAMESPACE" --wait=false 2>/dev/null || true
+oc delete subscription automation-orchestrator-operator -n "$AAP_NAMESPACE" --wait=false 2>/dev/null || true
+oc delete operatorgroup automation-orchestrator-operator -n "$AAP_NAMESPACE" --wait=false 2>/dev/null || true
 
 if [ -n "$FORCE" ]; then
   echo "Clearing existing operator OLM state..."
-  kubectl delete automationorchestrator --all -n "$NAMESPACE" --wait=false 2>/dev/null || true
+  oc delete automationorchestrator --all -n "$NAMESPACE" --wait=false 2>/dev/null || true
   cleanup_ao_olm_state
   for _csv_wait in $(seq 1 12); do
     _stuck_csv=""
     for _csv_ns in "$OLM_NAMESPACE" "$NAMESPACE"; do
-      _stuck_csv="${_stuck_csv}$(kubectl get csv -n "$_csv_ns" -o name 2>/dev/null \
+      _stuck_csv="${_stuck_csv}$(oc get csv -n "$_csv_ns" -o name 2>/dev/null \
         | grep "automation-orchestrator" || true)"
     done
     [ -z "$_stuck_csv" ] && break
     if [ "$_csv_wait" -ge 6 ]; then
       echo "  Clearing stuck CSV finalizers..."
       for _csv_ns in "$OLM_NAMESPACE" "$NAMESPACE"; do
-        kubectl get csv -n "$_csv_ns" -o name 2>/dev/null \
+        oc get csv -n "$_csv_ns" -o name 2>/dev/null \
           | grep "automation-orchestrator" \
           | while read -r _csv; do
-            kubectl patch "$_csv" -n "$_csv_ns" --type=json \
+            oc patch "$_csv" -n "$_csv_ns" --type=json \
               -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
           done
       done
@@ -951,23 +932,16 @@ apply_operator_olm_manifests
 echo "Waiting for InstallPlan..."
 _sub_reset=0
 for i in $(seq 1 30); do
-  _pending_ips=$(kubectl get installplan -n "$OLM_NAMESPACE" -o json 2>/dev/null \
-    | python3 -c '
-import json, sys
-data = json.load(sys.stdin)
-for item in data.get("items", []):
-    if not item.get("spec", {}).get("approved", False):
-        print(item["metadata"]["name"])
-' 2>/dev/null || echo "")
+  _pending_ips=$(oc get installplan -n "$OLM_NAMESPACE" -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{"\n"}{end}' 2>/dev/null || echo "")
   if [ -n "$_pending_ips" ]; then
     while read -r _ip; do
       [ -z "$_ip" ] && continue
       echo "  Approving InstallPlan: ${_ip}"
-      kubectl patch installplan "$_ip" -n "$OLM_NAMESPACE" \
+      oc patch installplan "$_ip" -n "$OLM_NAMESPACE" \
         --type merge -p '{"spec":{"approved":true}}'
     done <<<"$_pending_ips"
   fi
-  if kubectl get csv -n "$OLM_NAMESPACE" -o name 2>/dev/null | grep -q "automation-orchestrator"; then
+  if oc get csv -n "$OLM_NAMESPACE" -o name 2>/dev/null | grep -q "automation-orchestrator"; then
     echo "✓ CSV created"
     break
   fi
@@ -1009,15 +983,15 @@ for item in data.get("items", []):
     echo "  Subscription conditions:"
     subscription_failure_detail | sed 's/^/    /'
     echo "  InstallPlans:"
-    kubectl get installplan -n "$OLM_NAMESPACE" 2>/dev/null
+    oc get installplan -n "$OLM_NAMESPACE" 2>/dev/null
     echo ""
     report_subscription_resolution_failure "$CATALOG_NAMESPACE" || true
     exit 1
   fi
-  SUB_STATE=$(kubectl get subscription automation-orchestrator-operator -n "$OLM_NAMESPACE" \
+  SUB_STATE=$(oc get subscription automation-orchestrator-operator -n "$OLM_NAMESPACE" \
     -o jsonpath='{.status.state}' 2>/dev/null || echo "")
   if [ -z "$SUB_STATE" ]; then
-    SUB_STATE=$(kubectl get subscription automation-orchestrator-operator -n "$OLM_NAMESPACE" \
+    SUB_STATE=$(oc get subscription automation-orchestrator-operator -n "$OLM_NAMESPACE" \
       -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || echo "pending")
   fi
   printf "\r  $(hat) subscription: %-15s    " "${SUB_STATE}"
@@ -1026,22 +1000,22 @@ done
 echo ""
 
 echo "Waiting for operator to become available..."
-if ! kubectl wait --for=condition=Available \
+if ! oc wait --for=condition=Available \
   deployment/automation-orchestrator-operator-controller-manager \
   -n "$(operator_controller_namespace)" --timeout=300s 2>/dev/null; then
   echo "ERROR: Operator deployment not Available after 5 minutes."
-  kubectl get pods -n "$OLM_NAMESPACE" 2>/dev/null || true
-  kubectl get pods -n "$NAMESPACE" 2>/dev/null || true
+  oc get pods -n "$OLM_NAMESPACE" 2>/dev/null || true
+  oc get pods -n "$NAMESPACE" 2>/dev/null || true
   exit 1
 fi
 echo "✓ Operator running"
 
 link_ao_pull_secrets_to_operator
-if kubectl get deployment automation-orchestrator-operator-controller-manager \
+if oc get deployment automation-orchestrator-operator-controller-manager \
   -n "$(operator_controller_namespace)" &>/dev/null; then
-  kubectl rollout restart deployment/automation-orchestrator-operator-controller-manager \
+  oc rollout restart deployment/automation-orchestrator-operator-controller-manager \
     -n "$(operator_controller_namespace)" 2>/dev/null || true
-  kubectl rollout status deployment/automation-orchestrator-operator-controller-manager \
+  oc rollout status deployment/automation-orchestrator-operator-controller-manager \
     -n "$(operator_controller_namespace)" --timeout=5m 2>/dev/null || true
 fi
 
@@ -1054,14 +1028,14 @@ _AO_TIMEOUT=1200
 _AO_START=$(date +%s)
 while true; do
   _AO_ELAPSED=$(($(date +%s) - _AO_START))
-  _ao_reason=$(kubectl get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
+  _ao_reason=$(oc get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
     -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.reason}{end}' 2>/dev/null || echo "")
-  _ao_degraded=$(kubectl get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
+  _ao_degraded=$(oc get automationorchestrator automation-orchestrator -n "$NAMESPACE" \
     -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.status}{end}' 2>/dev/null || echo "")
-  _ao_route=$(kubectl get routes -n "$NAMESPACE" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
-  _ao_running=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+  _ao_route=$(oc get routes -n "$NAMESPACE" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
+  _ao_running=$(oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
     | awk '$3=="Running" && $1 !~ /^redhat-operators-/ {c++} END {print c+0}')
-  _ao_problem=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+  _ao_problem=$(oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
     | awk '$3 ~ /CrashLoopBackOff|Error|ImagePullBackOff/ {c++} END {print c+0}')
   printf "\r  running=%s degraded=%s" "${_ao_running}" "${_ao_reason:-none}"
   [ "${_ao_problem:-0}" -gt 0 ] && printf " problems=%s" "$_ao_problem"
@@ -1074,7 +1048,7 @@ while true; do
   if [ "$_AO_ELAPSED" -ge "$_AO_TIMEOUT" ]; then
     echo ""
     echo "  ⚠ Instance not ready after 20 minutes — continuing anyway"
-    echo "  Check: kubectl get automationorchestrator,pods,routes -n $NAMESPACE"
+    echo "  Check: oc get automationorchestrator,pods,routes -n $NAMESPACE"
     break
   fi
   sleep 10

--- a/addons/apme-eap/README.md
+++ b/addons/apme-eap/README.md
@@ -184,25 +184,32 @@ The deploy.sh wrapper automatically discovers:
 
 These are written to `~/.aap-demo/apme-eap-vars.yml` (regenerated on each deploy).
 
-### GitHub Integration (Manual Configuration)
+### GitHub Integration
 
-To enable repository quality scanning, edit the generated vars file:
+By default, only a **GitHub Personal Access Token (PAT)** is required for repository scanning.
+During `aap-demo enable apme-eap`, you will be prompted for a PAT, or you can set `GITHUB_TOKEN`
+before running enable.
 
-```bash
-vim ~/.aap-demo/apme-eap-vars.yml
-```
+**Create a PAT:** https://github.com/settings/tokens/new
 
-Uncomment and fill in the GitHub section:
+- Note: `APME Portal API Access`
+- Scope: `repo` (full control of private repositories)
+
+The PAT is saved to `~/.aap-demo/apme-eap-github-creds.yml` and written into the generated
+vars file on each deploy.
+
+**Token-only mode** enables repository scanning. OAuth sign-in and portal push require a full
+GitHub App — add these to `~/.aap-demo/apme-eap-vars.yml` if needed:
 
 ```yaml
 configure_github_secrets: true
-github_oauth_client_id: "YOUR_OAUTH_CLIENT_ID"
-github_oauth_client_secret: "YOUR_OAUTH_CLIENT_SECRET"
-github_app_id: "YOUR_APP_ID"
-github_app_client_id: "YOUR_APP_CLIENT_ID"
-github_app_client_secret: "YOUR_APP_CLIENT_SECRET"
+github_token: "ghp_..."
+github_oauth_client_id: "..."
+github_oauth_client_secret: "..."
+github_app_id: "..."
+github_app_client_id: "..."
+github_app_client_secret: "..."
 github_app_private_key_path: "/path/to/private-key.pem"
-github_token: "YOUR_PERSONAL_ACCESS_TOKEN"
 ```
 
 Then re-run:
@@ -211,7 +218,7 @@ Then re-run:
 aap-demo enable apme-eap
 ```
 
-For detailed GitHub setup instructions, see the [APME EAP welcome pack documentation](https://drive.google.com/drive/folders/146Yc3TDKgX0l7k1etdJVXZ2NqhBvPuqr).
+For full GitHub App setup, see the [APME EAP welcome pack documentation](https://drive.google.com/drive/folders/146Yc3TDKgX0l7k1etdJVXZ2NqhBvPuqr).
 
 ### Advanced Configuration
 

--- a/addons/apme-eap/README.md
+++ b/addons/apme-eap/README.md
@@ -1,46 +1,48 @@
 # APME Playbook Addon
 
 Deploy Ansible Portal with Ansible Quality (APME) on OpenShift Local (MicroShift) using
-**official APME EAP welcome pack Ansible playbooks** executed locally in an isolated Python
-virtual environment.
+**official APME EAP welcome pack Ansible playbooks**.
 
 > **Preview:** APME is prototype software for the Early Access Program.
 > Confidential — Red Hat associate and NDA partner use only.
 
 ## Overview
 
-This addon uses the **official APME EAP welcome pack playbooks** executed locally via `ansible-playbook`. This implementation:
+This addon uses the **official APME EAP welcome pack playbooks**:
 
-- **Local execution**: Playbooks run in isolated Python venv (no AAP API dependency)
-- **KUBECONFIG authentication**: Uses standard kubeconfig for cluster access
-- Uses structured Ansible roles from the official APME welcome pack
+- **Linux/macOS**: playbooks run locally in an isolated Python venv (`ansible-playbook`)
+- **Windows (Git Bash / PowerShell)**: playbooks run as **AAP Controller jobs** via REST API — no local Python required
+- **KUBECONFIG / in-cluster token**: cluster access from your workstation or from AAP execution environments
 - Auto-discovers aap-demo environment (no manual configuration)
 - Maintains alignment with upstream APME deployment patterns
 
 **Architecture:** Bash wrapper (`deploy.sh`) handles environment discovery and generates vars
-file, then invokes official APME playbooks via `ansible-playbook` with KUBECONFIG-based
-authentication.
+file, then either invokes `ansible-playbook` locally or registers a Git SCM project in AAP and
+launches `addons/apme-eap/playbooks/deploy_apme_portal.yml` as a job.
 
 ## Quick Start
 
 ### Prerequisites
 
-**System requirements:**
+**System requirements (all platforms):**
 
 - `kubectl` or `oc`
-- `python3` (3.8+)
-- `helm` 3.10+ (portal Helm chart — auto-installed via brew/dnf when missing)
 - AAP deployed (`aap-demo deploy`)
 
-The addon deploys a **pre-built portal hub image** (`quay.io/cferman/portal-hub-eap:latest`)
-with APME plugins baked in at build time. Deploy does **not** push OCI plugin archives,
-run `install-dynamic-plugins`, or require `skopeo` or the in-cluster registry addon.
+**Linux/macOS (local execution):**
 
-**Ansible installation** (auto-installed in venv):
+- `python3` (3.8+)
+- `helm` 3.10+ (portal Helm chart — auto-installed via brew/dnf when missing)
 
-- A venv is created at `~/.aap-demo/apme-eap-venv` with full Ansible suite + collections
-- Includes kubernetes.core, community.okd, and other required collections
-- The playbooks run locally using KUBECONFIG authentication (~150 MB venv)
+**Windows (AAP job execution — default on Git Bash):**
+
+- `jq` (`winget install jqlang.jq`)
+- `curl` (included with Git for Windows)
+- Git clone with `origin` remote (AAP syncs playbooks from Git), or set `APME_PROJECT_SCM_URL`
+- No `python3` or local `ansible-playbook` required
+
+Set `APME_FORCE_LOCAL=1` to use the Linux/macOS venv path on Windows (requires Python + helm).
+Set `APME_USE_AAP=1` on Linux/macOS to run via AAP jobs instead of a local venv.
 
 ### No Manual Configuration Required! 🎉
 
@@ -77,20 +79,19 @@ aap-demo enable apme-eap
 
 This will:
 
-1. Check system prerequisites (kubectl, python3, helm — installs helm if missing)
-2. Create venv with full Ansible + collections (if not exists)
-3. Auto-discover your aap-demo environment (KUBECONFIG, cluster domain, AAP route/credentials)
-4. Run **setup-pah** when `~/.aap-demo/galaxy-token` or `pah-config.yml` exists (configures AAP hub remotes)
-5. Generate playbook vars at `~/.aap-demo/apme-eap-vars.yml`
-6. Run `playbooks/deploy_apme_portal.yml` with pre-built `portal-hub-eap` container image
+1. Check prerequisites (`kubectl`; on Linux/macOS also `python3` + `helm`)
+2. Auto-discover your aap-demo environment (KUBECONFIG, cluster domain, AAP route/credentials)
+3. Run **setup-pah** when `~/.aap-demo/galaxy-token` or `pah-config.yml` exists (configures AAP hub remotes)
+4. Generate playbook vars at `~/.aap-demo/apme-eap-vars.yml`
+5. **Linux/macOS**: create venv at `~/.aap-demo/apme-eap-venv` and run `ansible-playbook` locally
+6. **Windows**: register/update an AAP project (Git SCM), job template, and launch the deployment job
 7. Seed APME galaxy servers from AAP (+ external PAH when configured) and enable PAH catalog sync
 
-**Authentication:** The playbooks use KUBECONFIG (client certificate auth) to interact with
-the cluster. The `K8S_AUTH_KUBECONFIG` environment variable is set automatically by the
-wrapper script.
+**Authentication:** Local runs use KUBECONFIG. AAP jobs use an in-cluster service account token
+and `https://kubernetes.default.svc:443` (configured automatically).
 
-**First run** takes longer (~2-3 minutes) to set up the virtual environment and install
-Ansible collections. Subsequent runs reuse the existing venv and are faster.
+**First run** on Linux/macOS takes longer (~2-3 minutes) to set up the virtual environment.
+Windows runs depend on AAP project sync and job runtime; progress is visible in the AAP UI.
 
 ### Check Status
 
@@ -154,7 +155,8 @@ Environment auto-discovery:
 Generate vars file:
   ~/.aap-demo/apme-eap-vars.yml
     ↓
-ansible-playbook playbooks/deploy_apme_portal.yml
+Linux/macOS: ansible-playbook playbooks/deploy_apme_portal.yml
+Windows:     AAP project sync → job template launch → monitor job
     ↓
 Roles execute in sequence:
   1. openshift_apme_setup
@@ -239,6 +241,8 @@ Edit `~/.aap-demo/apme-eap-vars.yml` to customize:
 ```
 addons/apme-eap/
 ├── deploy.sh                     # Bash wrapper (addon contract)
+├── lib/
+│   └── aap-deploy.sh             # AAP REST API helpers (Windows / APME_USE_AAP)
 ├── defaults.yml                  # Default configuration
 ├── requirements.yml              # Ansible collection dependencies
 ├── README.md                     # This file
@@ -301,7 +305,7 @@ extensions). Registering only the extensions factory leaves `plugin.apme.api` un
 **Solution**: Redeploy with current `apme-eap` playbooks (values template includes both
 factories). Hard-refresh the browser after redeploy.
 
-### Python venv creation fails
+### Python venv creation fails (Linux/macOS)
 
 **Symptom**: `python3 not found` or venv module errors
 
@@ -314,6 +318,16 @@ brew install python3
 # Verify
 python3 --version  # Should be 3.8 or later
 ```
+
+Or use AAP job execution without Python: `APME_USE_AAP=1 aap-demo enable apme-eap`
+
+### Windows: AAP project sync uses remote Git
+
+**Symptom**: Job runs old playbook content or missing local changes
+
+**Solution**: Commit and push your branch, or set `APME_PROJECT_SCM_URL` / `APME_PROJECT_SCM_BRANCH`
+to a remote that contains your playbooks. For local-only testing on Windows, use
+`APME_FORCE_LOCAL=1` with Python and helm installed.
 
 ### Ansible collection missing
 

--- a/addons/apme-eap/defaults.yml
+++ b/addons/apme-eap/defaults.yml
@@ -27,7 +27,7 @@ aap_apme_prerequisites_oauth_application_name: "APME Portal OAuth"
 # GitHub secrets configuration
 configure_github_secrets: false
 
-# Portal hub image (APME plugins baked in at build time — no deploy-time plugin loading)
+# Portal hub image (APME plugins baked in at build time - no deploy-time plugin loading)
 portal_hub_image: "quay.io/cferman/portal-hub-eap:latest"
 
 # setup-pah / Automation Hub integration (see ~/.aap-demo/galaxy-token and pah-config.yml)

--- a/addons/apme-eap/deploy.sh
+++ b/addons/apme-eap/deploy.sh
@@ -587,7 +587,7 @@ generate_vars_file() {
 EOF
   chmod 600 "$VARS_FILE"
   cat >>"$VARS_FILE" <<EOF
-# Do not edit directly — regenerated on each deploy
+# Do not edit directly - regenerated on each deploy
 # Generated at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 
 # OpenShift (discovered from aap-demo environment)

--- a/addons/apme-eap/deploy.sh
+++ b/addons/apme-eap/deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # APME Playbook Addon - Deploy Ansible Portal with Ansible Quality (APME)
-# Uses official APME EAP welcome pack playbooks executed locally in isolated venv
+# Linux/macOS: local ansible-playbook in isolated venv
+# Windows (Git Bash): playbooks run as AAP Controller jobs (no local Python)
 #
 # ADDON_REQUIRES_AAP=true
 
@@ -30,9 +31,31 @@ die() {
   exit 1
 }
 
+_use_aap_execution() {
+  if [ "${APME_FORCE_LOCAL:-}" = "1" ]; then
+    return 1
+  fi
+  if [ "${APME_USE_AAP:-}" = "1" ]; then
+    return 0
+  fi
+  if [ "${APME_USE_AAP:-}" = "0" ]; then
+    return 1
+  fi
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 _load_github_creds_from_file() {
   local creds_file="$1"
   [ -f "$creds_file" ] || return 1
+
+  if _load_github_creds_from_file_legacy "$creds_file"; then
+    return 0
+  fi
 
   if ! python3 -c "import yaml" 2>/dev/null; then
     return 2
@@ -238,24 +261,31 @@ _ensure_helm() {
 check_prerequisites() {
   info "Checking system prerequisites..."
 
-  # Check kubectl
   if ! command -v kubectl &>/dev/null; then
     die "kubectl not found. Please install kubectl or oc."
   fi
 
-  # Check cluster connectivity
   if ! kubectl cluster-info &>/dev/null; then
     die "kubectl not connected to a cluster. Run 'aap-demo create' first."
   fi
 
-  # Check python3
+  if _use_aap_execution; then
+    info "Windows/AAP execution mode — playbooks run in AAP (no local Python required)"
+    if ! command -v jq &>/dev/null; then
+      die "jq is required. Install: winget install jqlang.jq"
+    fi
+    if ! command -v curl &>/dev/null; then
+      die "curl is required for AAP API access"
+    fi
+    info "Prerequisites check complete"
+    return 0
+  fi
+
   if ! command -v python3 &>/dev/null; then
-    die "python3 not found. Please install Python 3.8 or later."
+    die "python3 not found. Please install Python 3.8 or later (or set APME_USE_AAP=1 on Linux/macOS)."
   fi
 
   info "Using pre-built portal hub (${PORTAL_HUB_IMAGE})"
-
-  # Portal/gateway Helm releases use kubernetes.core.helm (requires helm binary on PATH)
   _ensure_helm
 
   info "Prerequisites check complete"
@@ -330,6 +360,7 @@ discover_environment() {
   if [ -z "$AAP_PASSWORD" ]; then
     die "Could not retrieve AAP admin password from secret"
   fi
+  export AAP_PASSWORD
   info "AAP admin password retrieved"
 
   # 7. Architecture
@@ -678,8 +709,36 @@ EOF
 # Deployment
 # ---------------------------------------------------------------------------
 
-deploy() {
-  info "Deploying APME using official welcome pack playbooks..."
+deploy_via_aap() {
+  # shellcheck source=lib/aap-deploy.sh
+  source "${SCRIPT_DIR}/lib/aap-deploy.sh"
+
+  export AAP_PASSWORD AAP_USERNAME="${AAP_USERNAME:-admin}"
+  export AAP_NAMESPACE="${AAP_NAMESPACE:-aap-operator}"
+
+  if [ -n "${GITHUB_APP_PRIVATE_KEY_PATH:-}" ] && [ -f "${GITHUB_APP_PRIVATE_KEY_PATH}" ]; then
+    warn "Full GitHub App mode uses a local private key path that is not available inside AAP."
+    warn "Use token-only GitHub mode on Windows, or set APME_FORCE_LOCAL=1 with Python installed."
+  fi
+
+  info "Deploying APME via AAP Controller job..."
+  info "(pod status updates every 30s while the job runs)"
+
+  _pod_watcher "$NAMESPACE" 30 &
+  _watcher_pid=$!
+  trap '_stop_pod_watcher' EXIT
+
+  apme_deploy_via_aap "$VARS_FILE" "${SCRIPT_DIR}/defaults.yml"
+
+  _stop_pod_watcher
+  trap - EXIT
+
+  info "APME deployment completed successfully"
+  show_routes
+}
+
+deploy_local() {
+  info "Deploying APME using official welcome pack playbooks (local execution)..."
   info "(pod status updates every 30s during helm installs)"
 
   # Set environment for kubernetes.core modules
@@ -690,8 +749,6 @@ deploy() {
   _watcher_pid=$!
   trap '_stop_pod_watcher' EXIT
 
-  # Run main deployment playbook directly
-  # Note: Load defaults first, then vars file so user config takes precedence
   ansible-playbook "${SCRIPT_DIR}/playbooks/deploy_apme_portal.yml" \
     -e "@${SCRIPT_DIR}/defaults.yml" \
     -e "@${VARS_FILE}"
@@ -793,12 +850,16 @@ cleanup() {
 case "$ACTION" in
   deploy | --deploy)
     check_prerequisites
-    detect_architecture
+    ARCH=$(detect_architecture)
     discover_environment
     prompt_github_token
     generate_vars_file
-    setup_venv
-    deploy
+    if _use_aap_execution; then
+      deploy_via_aap
+    else
+      setup_venv
+      deploy_local
+    fi
     ;;
 
   --delete | delete | remove)
@@ -807,9 +868,14 @@ case "$ACTION" in
 
   *)
     echo "Usage: $0 [deploy|--delete [--purge-creds]]"
-    echo "  deploy              - Deploy APME using official welcome pack playbooks (local execution)"
+    echo "  deploy              - Deploy APME (local ansible-playbook on Linux/macOS; AAP job on Windows)"
     echo "  --delete            - Remove APME namespace and resources (preserve GitHub creds by default)"
     echo "  --delete --purge-creds - Also remove ~/.aap-demo/apme-eap-github-creds.yml and private key"
+    echo ""
+    echo "Environment:"
+    echo "  APME_USE_AAP=1       - Run playbooks as AAP Controller jobs (no local Python)"
+    echo "  APME_FORCE_LOCAL=1   - Force local venv execution even on Windows"
+    echo "  APME_PROJECT_SCM_URL - Git URL for AAP project (default: origin remote)"
     exit 1
     ;;
 esac

--- a/addons/apme-eap/deploy.sh
+++ b/addons/apme-eap/deploy.sh
@@ -373,89 +373,44 @@ discover_environment() {
 # ---------------------------------------------------------------------------
 
 prompt_github_token() {
-  # Allow users to optionally provide GitHub App credentials for APME integration
-  # Follows the pattern from setup-pah and portal addons
+  # Optional GitHub PAT for repository scanning (token-only mode).
 
-  # Check saved credentials file from a previous deploy
   if [ -f "$GITHUB_CREDS_FILE" ]; then
     if _load_github_creds_from_file "$GITHUB_CREDS_FILE" || _load_github_creds_from_file_legacy "$GITHUB_CREDS_FILE"; then
       if [ -n "${GITHUB_TOKEN:-}" ]; then
-        info "GitHub credentials found in $GITHUB_CREDS_FILE — reusing"
+        info "GitHub PAT found in $GITHUB_CREDS_FILE - reusing"
         return 0
       fi
     fi
   fi
 
-  # Check environment variables - any token skips the prompt
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    info "Using GitHub credentials from environment variables"
-    # Default OAuth vars to App client credentials if not explicitly set
-    GITHUB_OAUTH_CLIENT_ID="${GITHUB_OAUTH_CLIENT_ID:-${GITHUB_APP_CLIENT_ID:-}}"
-    GITHUB_OAUTH_CLIENT_SECRET="${GITHUB_OAUTH_CLIENT_SECRET:-${GITHUB_APP_CLIENT_SECRET:-}}"
+    info "Using GitHub PAT from environment variable GITHUB_TOKEN"
     return 0
   fi
 
-  # Skip prompt if QUIET mode or non-interactive
   if [ "${QUIET:-false}" = "true" ] || [ ! -t 0 ]; then
-    info "Skipping GitHub configuration (use GITHUB_TOKEN=... to provide, add GITHUB_APP_ID=... for full integration)"
+    info "Skipping GitHub configuration (set GITHUB_TOKEN=... to enable repository scanning)"
     return 0
   fi
 
   echo ""
   info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  info "GitHub App Configuration (Optional)"
+  info "GitHub Integration (Optional)"
   info ""
-  info "APME integrates with GitHub for repository scanning, quality analysis,"
-  info "and code push operations directly from the portal."
+  info "APME can scan repositories using a GitHub Personal Access Token (PAT)."
+  info "OAuth sign-in and portal push require a full GitHub App setup in $VARS_FILE."
   info ""
-  info "Setup Instructions:"
-  info ""
-  info "STEP 1: Create GitHub App (https://github.com/settings/apps/new)"
-  info "  GitHub App name: apme-portal-local"
-  info "  Homepage URL: https://redhat-rhaap-portal-apme.apps.127.0.0.1.nip.io"
-  info "  Callback URL: https://redhat-rhaap-portal-apme.apps.127.0.0.1.nip.io/api/auth/github/handler/frame"
-  info "  Webhook: Uncheck 'Active'"
-  info "  Repository permissions (REQUIRED):"
-  info "    • Contents: Read and write"
-  info "    • Pull requests: Read and write"
-  info "    • Metadata: Read-only (automatically selected)"
-  info "  Where can this app be installed?: Any account"
-  info ""
-  info "STEP 2: Generate client secret (in your new GitHub App settings)"
-  info "  Navigate to: General → Client secrets"
-  info "  Click: 'Generate a new client secret'"
-  info "  Copy the secret immediately (you won't see it again!)"
-  info ""
-  info "STEP 3: Generate private key (in your GitHub App settings)"
-  info "  Navigate to: General → Private keys"
-  info "  Click: 'Generate a private key'"
-  info "  Save the downloaded .pem file to: ~/.aap-demo/apme-github-app.pem"
-  info ""
-  info "STEP 4: Install the app on your account/organization"
-  info "  Click: 'Install App' (left sidebar)"
-  info "  Select: Your account or organization"
-  info "  Repository access:"
-  info "    • All repositories (recommended for testing), OR"
-  info "    • Only select repositories (choose specific repos)"
-  info "  Click: 'Install'"
-  info ""
-  info "STEP 5: Create Personal Access Token (https://github.com/settings/tokens/new)"
+  info "Create a PAT: https://github.com/settings/tokens/new"
   info "  Note: APME Portal API Access"
   info "  Expiration: 90 days (or your preference)"
-  info "  Scopes (REQUIRED):"
-  info "    ☑ repo (Full control of private repositories)"
-  info "      ☑ repo:status"
-  info "      ☑ repo_deployment"
-  info "      ☑ public_repo"
-  info "      ☑ repo:invite"
-  info "      ☑ security_events"
-  info "  Click: 'Generate token' and copy it (starts with ghp_)"
+  info "  Scopes (REQUIRED): repo (full control of private repositories)"
   info ""
-  info "You can skip this and configure later by editing: $VARS_FILE"
+  info "Skip now and configure later by editing: $VARS_FILE"
   info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
 
-  read -r -p "Do you want to configure GitHub integration now? [y/N]: " configure_choice
+  read -r -p "Configure GitHub PAT now? [y/N]: " configure_choice
 
   if [[ ! "$configure_choice" =~ ^[Yy]$ ]]; then
     info "Skipping GitHub integration. You can configure it later."
@@ -463,102 +418,24 @@ prompt_github_token() {
   fi
 
   echo ""
-  info "Enter GitHub App credentials:"
-  info "  (Visit your GitHub App settings: https://github.com/settings/apps/<your-app-name>)"
-  echo ""
-
-  # GitHub App ID
-  info "1. GitHub App ID"
-  info "   Location: General → About → App ID (numeric, e.g., 123456)"
-  read -r -p "   Enter App ID: " github_app_id_input
-  if [ -z "$github_app_id_input" ]; then
-    warn "App ID required for GitHub integration. Skipping."
-    return 0
-  fi
-
-  # GitHub App Client ID
-  echo ""
-  info "2. GitHub App Client ID"
-  info "   Location: General → About → Client ID (starts with Iv1. or Iv23.)"
-  read -r -p "   Enter Client ID: " github_app_client_id_input
-  if [ -z "$github_app_client_id_input" ]; then
-    warn "App Client ID required. Skipping."
-    return 0
-  fi
-
-  # GitHub App Client Secret
-  echo ""
-  info "3. GitHub App Client Secret"
-  info "   Location: General → Client secrets → Generate/copy the secret"
-  info "   (If you don't have one, click 'Generate a new client secret')"
-  read -r -s -p "   Enter Client Secret (hidden): " github_app_client_secret_input
-  echo ""
-  if [ -z "$github_app_client_secret_input" ]; then
-    warn "App Client Secret required. Skipping."
-    return 0
-  fi
-
-  # GitHub App Private Key Path
-  echo ""
-  info "4. GitHub App Private Key"
-  info "   Location: General → Private keys → Generate/download .pem file"
-  info "   (If you don't have one, click 'Generate a private key' - file will download)"
-  info "   Move the downloaded .pem file to: $HOME/.aap-demo/apme-github-app.pem"
-  read -r -p "   Private key path [~/.aap-demo/apme-github-app.pem]: " github_app_private_key_input
-  github_app_private_key_input="${github_app_private_key_input:-$HOME/.aap-demo/apme-github-app.pem}"
-
-  # Expand ~ to full path
-  github_app_private_key_input="${github_app_private_key_input/#\~/$HOME}"
-
-  if [ ! -f "$github_app_private_key_input" ]; then
-    warn "Private key file not found: $github_app_private_key_input"
-    warn "Download the .pem file from GitHub App settings and move it to the path above."
-    warn "Then re-run deployment or edit: $VARS_FILE"
-    return 0
-  fi
-
-  # GitHub Personal Access Token
-  echo ""
-  info "5. GitHub Personal Access Token (PAT)"
-  info "   Location: https://github.com/settings/tokens/new"
-  info "   - Note: 'APME Portal API Access'"
-  info "   - Expiration: 90 days (or your preference)"
-  info "   - Scopes: Check 'repo' (full control of private repositories)"
-  info "   - Generate token and copy it (starts with ghp_)"
-  read -r -s -p "   Enter Personal Access Token (hidden): " github_token_input
+  read -r -s -p "Enter GitHub Personal Access Token (hidden): " github_token_input
   echo ""
   if [ -z "$github_token_input" ]; then
-    warn "Personal Access Token required. Skipping."
+    warn "PAT not provided. Skipping GitHub integration."
     return 0
   fi
 
-  GITHUB_APP_ID="$github_app_id_input"
-  GITHUB_APP_CLIENT_ID="$github_app_client_id_input"
-  GITHUB_APP_CLIENT_SECRET="$github_app_client_secret_input"
-  GITHUB_APP_PRIVATE_KEY_PATH="$github_app_private_key_input"
   GITHUB_TOKEN="$github_token_input"
 
-  GITHUB_OAUTH_CLIENT_ID="$github_app_client_id_input"
-  GITHUB_OAUTH_CLIENT_SECRET="$github_app_client_secret_input"
-
-  # Save credentials so future deploys skip the prompt
   mkdir -p "$(dirname "$GITHUB_CREDS_FILE")"
   cat >"$GITHUB_CREDS_FILE" <<CREDS
 ---
-# GitHub credentials for APME portal (persisted across deploys)
+# GitHub PAT for APME portal (persisted across deploys)
 github_token: "${GITHUB_TOKEN}"
-github_app_id: "${GITHUB_APP_ID}"
-github_app_client_id: "${GITHUB_APP_CLIENT_ID}"
-github_app_client_secret: "${GITHUB_APP_CLIENT_SECRET}"
-github_app_private_key_path: "${GITHUB_APP_PRIVATE_KEY_PATH}"
-github_oauth_client_id: "${GITHUB_OAUTH_CLIENT_ID}"
-github_oauth_client_secret: "${GITHUB_OAUTH_CLIENT_SECRET}"
 CREDS
   chmod 600 "$GITHUB_CREDS_FILE"
 
-  info "✓ GitHub App configured (saved to $GITHUB_CREDS_FILE)"
-  info "  App ID: $GITHUB_APP_ID"
-  info "  Private Key: $GITHUB_APP_PRIVATE_KEY_PATH"
+  info "GitHub PAT saved to $GITHUB_CREDS_FILE"
 
   return 0
 }
@@ -716,9 +593,9 @@ deploy_via_aap() {
   export AAP_PASSWORD AAP_USERNAME="${AAP_USERNAME:-admin}"
   export AAP_NAMESPACE="${AAP_NAMESPACE:-aap-operator}"
 
-  if [ -n "${GITHUB_APP_PRIVATE_KEY_PATH:-}" ] && [ -f "${GITHUB_APP_PRIVATE_KEY_PATH}" ]; then
+  if [ -n "${GITHUB_APP_PRIVATE_KEY_PATH:-}" ] && [ -f "${GITHUB_APP_PRIVATE_KEY_PATH}" ] && [ -n "${GITHUB_APP_ID:-}" ]; then
     warn "Full GitHub App mode uses a local private key path that is not available inside AAP."
-    warn "Use token-only GitHub mode on Windows, or set APME_FORCE_LOCAL=1 with Python installed."
+    warn "Use PAT-only mode (default) or set APME_FORCE_LOCAL=1 with Python installed."
   fi
 
   info "Deploying APME via AAP Controller job..."

--- a/addons/apme-eap/lib/aap-deploy.sh
+++ b/addons/apme-eap/lib/aap-deploy.sh
@@ -382,7 +382,6 @@ apme_deploy_via_aap() {
   fi
 
   extra_vars_file=$(mktemp)
-  trap 'rm -f "$extra_vars_file"' RETURN
   apme_build_extra_vars "$vars_file" "$defaults_file" >"$extra_vars_file"
   apme_sanitize_extra_vars_file "$extra_vars_file"
 
@@ -395,4 +394,5 @@ apme_deploy_via_aap() {
   _apme_info "Launching APME deployment job in AAP (no local Python required)..."
   job_id=$(apme_launch_job "$template_id")
   apme_monitor_job "$job_id" 120
+  rm -f "$extra_vars_file"
 }

--- a/addons/apme-eap/lib/aap-deploy.sh
+++ b/addons/apme-eap/lib/aap-deploy.sh
@@ -109,7 +109,7 @@ apme_build_extra_vars() {
 openshift_api_url: "https://kubernetes.default.svc:443"
 openshift_validate_certs: false
 openshift_token: "${cluster_token}"
-aap_host: "${internal_aap}"
+aap_api_host: "${internal_aap}"
 aap_validate_certs: false
 EOF
   }

--- a/addons/apme-eap/lib/aap-deploy.sh
+++ b/addons/apme-eap/lib/aap-deploy.sh
@@ -316,6 +316,17 @@ apme_monitor_job() {
         ;;
       failed | error | canceled)
         echo ""
+        _apme_warn "Last failed task(s):"
+        kubectl exec -n "${AAP_NAMESPACE:-aap-operator}" deploy/aap-controller-web -- bash -c "awx-manage shell -c \"
+from awx.main.models import Job
+j = Job.objects.get(id=${job_id})
+for ev in j.job_events.filter(event='runner_on_failed').order_by('-id')[:3]:
+    out = (ev.stdout or ev.msg or '').strip()
+    if out:
+        print(ev.task)
+        for line in out.splitlines()[-8:]:
+            print('  ', line)
+\"" 2>/dev/null || true
         die "APME deployment job failed (ID: ${job_id}). View: ${AAP_UI_URL}/#/jobs/playbook/${job_id}/output"
         ;;
     esac

--- a/addons/apme-eap/lib/aap-deploy.sh
+++ b/addons/apme-eap/lib/aap-deploy.sh
@@ -115,6 +115,15 @@ EOF
   }
 }
 
+# Strip non-ASCII bytes so Controller API JSON stays valid UTF-8 on Windows/Git Bash.
+apme_sanitize_extra_vars_file() {
+  local file="$1"
+  local tmp="${file}.san"
+
+  sed -e 's/—/-/g' -e 's/–/-/g' "$file" | tr -cd '\11\12\15\40-\176' >"$tmp"
+  mv "$tmp" "$file"
+}
+
 apme_ensure_project() {
   local org_id="$1"
   local project_id payload result
@@ -232,13 +241,13 @@ apme_ensure_execution_environment() {
 }
 
 apme_ensure_job_template() {
-  local org_id="$1" project_id="$2" ee_id="$3" extra_vars="$4"
+  local org_id="$1" project_id="$2" ee_id="$3" extra_vars_file="$4"
   local template_id payload result
 
   payload=$(jq -n \
     --arg name "$APME_TEMPLATE_NAME" \
     --arg desc "Deploy APME portal via aap-demo apme-eap addon" \
-    --arg extra_vars "$extra_vars" \
+    --rawfile extra_vars "$extra_vars_file" \
     --arg playbook "$APME_PLAYBOOK" \
     --argjson project_id "$project_id" \
     --argjson ee_id "$ee_id" \
@@ -274,7 +283,7 @@ apme_ensure_job_template() {
           --argjson ee_id "$ee_id" \
           --argjson project_id "$project_id" \
           --arg playbook "$APME_PLAYBOOK" \
-          --arg extra_vars "$extra_vars" \
+          --rawfile extra_vars "$extra_vars_file" \
           '{execution_environment: $ee_id, project: $project_id, playbook: $playbook, extra_vars: $extra_vars}')" \
         "${AAP_API}/job_templates/${template_id}/" >/dev/null 2>&1
       _apme_info "Job template already exists (ID: ${template_id})"
@@ -338,7 +347,7 @@ apme_launch_job() {
 apme_deploy_via_aap() {
   local vars_file="$1"
   local defaults_file="$2"
-  local repo_root org_id project_id ee_id extra_vars template_id job_id
+  local repo_root org_id project_id ee_id extra_vars_file template_id job_id
 
   repo_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -361,13 +370,16 @@ apme_deploy_via_aap() {
     fi
   fi
 
-  extra_vars=$(apme_build_extra_vars "$vars_file" "$defaults_file")
+  extra_vars_file=$(mktemp)
+  trap 'rm -f "$extra_vars_file"' RETURN
+  apme_build_extra_vars "$vars_file" "$defaults_file" >"$extra_vars_file"
+  apme_sanitize_extra_vars_file "$extra_vars_file"
 
   project_id=$(apme_ensure_project "$org_id")
   apme_sync_project "$project_id"
 
   ee_id=$(apme_ensure_execution_environment "$org_id")
-  template_id=$(apme_ensure_job_template "$org_id" "$project_id" "$ee_id" "$extra_vars")
+  template_id=$(apme_ensure_job_template "$org_id" "$project_id" "$ee_id" "$extra_vars_file")
 
   _apme_info "Launching APME deployment job in AAP (no local Python required)..."
   job_id=$(apme_launch_job "$template_id")

--- a/addons/apme-eap/lib/aap-deploy.sh
+++ b/addons/apme-eap/lib/aap-deploy.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# AAP REST API helpers — run APME playbooks as Controller jobs (no local Python/ansible).
+
+APME_PROJECT_NAME="${APME_PROJECT_NAME:-APME EAP (aap-demo)}"
+APME_TEMPLATE_NAME="${APME_TEMPLATE_NAME:-APME | Deploy Portal}"
+APME_PLAYBOOK="${APME_PLAYBOOK:-addons/apme-eap/playbooks/deploy_apme_portal.yml}"
+APME_EE_NAME="${APME_EE_NAME:-APME Portal EE}"
+APME_EE_IMAGE="${APME_EE_IMAGE:-quay.io/ansible-product-demos/apd-ee-26:latest}"
+
+_apme_info() { info "$@" >&2; }
+_apme_warn() { warn "$@" >&2; }
+
+apme_init_aap_api() {
+  local ns="${AAP_NAMESPACE:-aap-operator}"
+  local route
+
+  route=$(kubectl get route aap -n "$ns" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+  if [ -z "$route" ]; then
+    route=$(kubectl get route -n "$ns" -o jsonpath='{.items[0].spec.host}' 2>/dev/null || echo "")
+  fi
+  if [ -z "$route" ]; then
+    die "AAP route not found in namespace ${ns}"
+  fi
+
+  AAP_UI_URL="https://${route}"
+  AAP_API="${AAP_UI_URL}/api/controller/v2"
+  AAP_USERNAME="${AAP_USERNAME:-admin}"
+  export AAP_UI_URL AAP_API AAP_USERNAME
+}
+
+apme_default_org_id() {
+  curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    "${AAP_API}/organizations/?name=Default" 2>&1 \
+    | jq -r '.results[0].id // empty'
+}
+
+apme_discover_scm() {
+  local repo_root="${1:-}"
+
+  if [ -n "${APME_PROJECT_SCM_URL:-}" ]; then
+    APME_SCM_URL="$APME_PROJECT_SCM_URL"
+    APME_SCM_BRANCH="${APME_PROJECT_SCM_BRANCH:-main}"
+    return 0
+  fi
+
+  if [ -z "$repo_root" ]; then
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  fi
+
+  if ! git -C "$repo_root" rev-parse --is-inside-work-tree &>/dev/null; then
+    return 1
+  fi
+
+  APME_SCM_URL=$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null || echo "")
+  APME_SCM_BRANCH=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+
+  case "$APME_SCM_URL" in
+    git@github.com:*)
+      APME_SCM_URL="https://github.com/${APME_SCM_URL#git@github.com:}"
+      APME_SCM_URL="${APME_SCM_URL%.git}"
+      ;;
+    ssh://git@github.com/*)
+      APME_SCM_URL="${APME_SCM_URL#ssh://git@github.com/}"
+      APME_SCM_URL="https://github.com/${APME_SCM_URL%.git}"
+      ;;
+  esac
+
+  [ -n "$APME_SCM_URL" ]
+}
+
+apme_create_cluster_token() {
+  local ns="${AAP_NAMESPACE:-aap-operator}"
+  local sa="apme-deployer"
+  local binding="apme-deployer-admin"
+
+  kubectl get serviceaccount "$sa" -n "$ns" &>/dev/null \
+    || kubectl create serviceaccount "$sa" -n "$ns" &>/dev/null
+
+  kubectl get clusterrolebinding "$binding" &>/dev/null \
+    || kubectl create clusterrolebinding "$binding" \
+      --clusterrole=cluster-admin \
+      --serviceaccount="${ns}:${sa}" &>/dev/null
+
+  kubectl create token "$sa" -n "$ns" --duration=8760h
+}
+
+apme_internal_aap_host() {
+  local ns="${AAP_NAMESPACE:-aap-operator}"
+  if kubectl get svc aap -n "$ns" &>/dev/null; then
+    echo "http://aap.${ns}.svc.cluster.local"
+    return 0
+  fi
+  echo "${AAP_HOST}"
+}
+
+apme_build_extra_vars() {
+  local vars_file="$1"
+  local defaults_file="$2"
+  local cluster_token internal_aap
+
+  cluster_token=$(apme_create_cluster_token)
+  internal_aap=$(apme_internal_aap_host)
+
+  # Single YAML document (AWX extra_vars); later keys override earlier ones.
+  {
+    sed '/^---[[:space:]]*$/d' "$defaults_file"
+    sed '/^---[[:space:]]*$/d' "$vars_file"
+    cat <<EOF
+openshift_api_url: "https://kubernetes.default.svc:443"
+openshift_validate_certs: false
+openshift_token: "${cluster_token}"
+aap_host: "${internal_aap}"
+aap_validate_certs: false
+EOF
+  }
+}
+
+apme_ensure_project() {
+  local org_id="$1"
+  local project_id payload result
+
+  payload=$(jq -n \
+    --arg name "$APME_PROJECT_NAME" \
+    --arg url "$APME_SCM_URL" \
+    --arg branch "$APME_SCM_BRANCH" \
+    --argjson org "$org_id" \
+    '{
+      name: $name,
+      description: "aap-demo apme-eap playbooks (Git SCM)",
+      scm_type: "git",
+      scm_url: $url,
+      scm_branch: $branch,
+      scm_update_on_launch: true,
+      organization: $org
+    }')
+
+  result=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    -X POST -H "Content-Type: application/json" \
+    -d "$payload" "${AAP_API}/projects/" 2>&1)
+
+  project_id=$(echo "$result" | jq -r '.id // empty' 2>/dev/null)
+
+  if [ -z "$project_id" ]; then
+    project_id=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+      "${AAP_API}/projects/?name=$(jq -rn --arg n "$APME_PROJECT_NAME" '$n|@uri')" 2>&1 \
+      | jq -r --argjson org "$org_id" \
+        '[.results[] | select(.summary_fields.organization.id == $org)] | .[0].id // empty')
+    if [ -n "$project_id" ]; then
+      curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+        -X PATCH -H "Content-Type: application/json" \
+        -d "$(jq -n \
+          --arg url "$APME_SCM_URL" \
+          --arg branch "$APME_SCM_BRANCH" \
+          '{scm_url: $url, scm_branch: $branch, scm_update_on_launch: true}')" \
+        "${AAP_API}/projects/${project_id}/" >/dev/null 2>&1
+      _apme_info "Project already exists (ID: ${project_id})"
+    else
+      die "Failed to create AAP project: $result"
+    fi
+  else
+    _apme_info "Project created (ID: ${project_id})"
+  fi
+
+  printf '%s\n' "$project_id"
+}
+
+apme_sync_project() {
+  local project_id="$1"
+  local update_id status i
+
+  update_id=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    -X POST "${AAP_API}/projects/${project_id}/update/" 2>&1 \
+    | jq -r '.id // empty' 2>/dev/null)
+
+  if [ -z "$update_id" ]; then
+    _apme_warn "Could not trigger project sync — using cached project content"
+    return 0
+  fi
+
+  _apme_info "Syncing project (update ID: ${update_id})..."
+  for i in $(seq 1 60); do
+    status=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+      "${AAP_API}/project_updates/${update_id}/" 2>&1 \
+      | jq -r '.status // "unknown"' 2>/dev/null)
+    case "$status" in
+      successful)
+        _apme_info "Project sync complete"
+        return 0
+        ;;
+      failed | error | canceled)
+        die "Project sync failed (status: ${status})"
+        ;;
+    esac
+    sleep 3
+  done
+  die "Project sync timed out"
+}
+
+apme_ensure_execution_environment() {
+  local org_id="$1"
+  local ee_id payload result
+
+  ee_id=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    "${AAP_API}/execution_environments/?name=$(jq -rn --arg n "$APME_EE_NAME" '$n|@uri')" 2>&1 \
+    | jq -r --argjson org "$org_id" \
+      '[.results[] | select(.summary_fields.organization.id == $org)] | .[0].id // empty')
+
+  if [ -n "$ee_id" ]; then
+    curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+      -X PATCH -H "Content-Type: application/json" \
+      -d "$(jq -n --arg image "$APME_EE_IMAGE" '{image: $image, pull: "missing"}')" \
+      "${AAP_API}/execution_environments/${ee_id}/" >/dev/null 2>&1
+    _apme_info "Execution environment exists (ID: ${ee_id})"
+    printf '%s\n' "$ee_id"
+    return 0
+  fi
+
+  payload=$(jq -n \
+    --arg name "$APME_EE_NAME" \
+    --arg image "$APME_EE_IMAGE" \
+    --argjson org "$org_id" \
+    '{name: $name, description: "APME deployment EE (helm/oc/ansible)", image: $image, organization: $org, pull: "missing"}')
+
+  result=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    -X POST -H "Content-Type: application/json" \
+    -d "$payload" "${AAP_API}/execution_environments/" 2>&1)
+
+  ee_id=$(echo "$result" | jq -r '.id // empty' 2>/dev/null)
+  [ -n "$ee_id" ] || die "Failed to create execution environment: $result"
+  _apme_info "Execution environment created (ID: ${ee_id})"
+  printf '%s\n' "$ee_id"
+}
+
+apme_ensure_job_template() {
+  local org_id="$1" project_id="$2" ee_id="$3" extra_vars="$4"
+  local template_id payload result
+
+  payload=$(jq -n \
+    --arg name "$APME_TEMPLATE_NAME" \
+    --arg desc "Deploy APME portal via aap-demo apme-eap addon" \
+    --arg extra_vars "$extra_vars" \
+    --arg playbook "$APME_PLAYBOOK" \
+    --argjson project_id "$project_id" \
+    --argjson ee_id "$ee_id" \
+    --argjson org_id "$org_id" \
+    '{
+      name: $name,
+      description: $desc,
+      job_type: "run",
+      inventory: 1,
+      project: $project_id,
+      playbook: $playbook,
+      ask_variables_on_launch: false,
+      organization: $org_id,
+      execution_environment: $ee_id,
+      extra_vars: $extra_vars
+    }')
+
+  result=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    -X POST -H "Content-Type: application/json" \
+    -d "$payload" "${AAP_API}/job_templates/" 2>&1)
+
+  template_id=$(echo "$result" | jq -r '.id // empty' 2>/dev/null)
+
+  if [ -z "$template_id" ]; then
+    template_id=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+      "${AAP_API}/job_templates/?name=$(jq -rn --arg n "$APME_TEMPLATE_NAME" '$n|@uri')" 2>&1 \
+      | jq -r --argjson org "$org_id" \
+        '[.results[] | select(.summary_fields.organization.id == $org)] | .[0].id // empty')
+    if [ -n "$template_id" ]; then
+      curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+        -X PATCH -H "Content-Type: application/json" \
+        -d "$(jq -n \
+          --argjson ee_id "$ee_id" \
+          --argjson project_id "$project_id" \
+          --arg playbook "$APME_PLAYBOOK" \
+          --arg extra_vars "$extra_vars" \
+          '{execution_environment: $ee_id, project: $project_id, playbook: $playbook, extra_vars: $extra_vars}')" \
+        "${AAP_API}/job_templates/${template_id}/" >/dev/null 2>&1
+      _apme_info "Job template already exists (ID: ${template_id})"
+    else
+      die "Failed to create job template: $result"
+    fi
+  else
+    _apme_info "Job template created (ID: ${template_id})"
+  fi
+
+  printf '%s\n' "$template_id"
+}
+
+apme_monitor_job() {
+  local job_id="$1"
+  local max_wait="${2:-120}"
+
+  for i in $(seq 1 "$max_wait"); do
+    local job_status status elapsed
+    job_status=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+      "${AAP_API}/jobs/${job_id}/" 2>&1)
+    status=$(echo "$job_status" | jq -r '.status // "unknown"' 2>/dev/null)
+    elapsed=$(echo "$job_status" | jq -r '.elapsed // 0' 2>/dev/null)
+
+    case "$status" in
+      successful)
+        echo ""
+        _apme_info "APME deployment job completed (ID: ${job_id})"
+        return 0
+        ;;
+      failed | error | canceled)
+        echo ""
+        die "APME deployment job failed (ID: ${job_id}). View: ${AAP_UI_URL}/#/jobs/playbook/${job_id}/output"
+        ;;
+    esac
+    printf "\r  Job status: %-12s | Elapsed: %3ss | Waiting... %2d/%s" "$status" "$elapsed" "$i" "$max_wait"
+    sleep 5
+  done
+
+  echo ""
+  _apme_warn "Job still running after $((max_wait * 5))s — check AAP UI: ${AAP_UI_URL}/#/jobs/playbook/${job_id}/output"
+  return 2
+}
+
+apme_launch_job() {
+  local template_id="$1"
+  local job_id result
+
+  result=$(curl -sk -u "${AAP_USERNAME}:${AAP_PASSWORD}" \
+    -X POST -H "Content-Type: application/json" \
+    -d '{}' "${AAP_API}/job_templates/${template_id}/launch/" 2>&1)
+
+  job_id=$(echo "$result" | jq -r '.id // empty' 2>/dev/null)
+  [ -n "$job_id" ] || die "Failed to launch job: $result"
+
+  _apme_info "Job launched (ID: ${job_id})"
+  _apme_info "View in AAP: ${AAP_UI_URL}/#/jobs/playbook/${job_id}/output"
+  printf '%s\n' "$job_id"
+}
+
+apme_deploy_via_aap() {
+  local vars_file="$1"
+  local defaults_file="$2"
+  local repo_root org_id project_id ee_id extra_vars template_id job_id
+
+  repo_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+  if ! command -v jq &>/dev/null; then
+    die "jq is required for AAP-based deployment. Install: winget install jqlang.jq"
+  fi
+
+  apme_init_aap_api
+  org_id=$(apme_default_org_id)
+  [ -n "$org_id" ] || die "Default organization not found in AAP"
+
+  if ! apme_discover_scm "$repo_root"; then
+    die "Cannot determine Git SCM URL. Set APME_PROJECT_SCM_URL and APME_PROJECT_SCM_BRANCH, or run from a git clone with origin."
+  fi
+  _apme_info "Project SCM: ${APME_SCM_URL} (branch: ${APME_SCM_BRANCH})"
+  if git -C "$repo_root" rev-parse --is-inside-work-tree &>/dev/null; then
+    if ! git -C "$repo_root" diff --quiet HEAD -- addons/apme-eap 2>/dev/null \
+      || [ -n "$(git -C "$repo_root" status --porcelain -- addons/apme-eap 2>/dev/null)" ]; then
+      _apme_warn "Local apme-eap changes are not in Git. Commit and push, or AAP will run playbooks from the remote branch."
+    fi
+  fi
+
+  extra_vars=$(apme_build_extra_vars "$vars_file" "$defaults_file")
+
+  project_id=$(apme_ensure_project "$org_id")
+  apme_sync_project "$project_id"
+
+  ee_id=$(apme_ensure_execution_environment "$org_id")
+  template_id=$(apme_ensure_job_template "$org_id" "$project_id" "$ee_id" "$extra_vars")
+
+  _apme_info "Launching APME deployment job in AAP (no local Python required)..."
+  job_id=$(apme_launch_job "$template_id")
+  apme_monitor_job "$job_id" 120
+}

--- a/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/create_api_token.yml
+++ b/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/create_api_token.yml
@@ -26,7 +26,7 @@
 
 - name: Create write-scope API token in AAP  # noqa: var-naming[no-role-prefix]
   ansible.builtin.uri:
-    url: "{{ aap_host_normalized }}/api/gateway/v1/tokens/"
+    url: "{{ aap_api_host_normalized }}/api/gateway/v1/tokens/"
     method: POST
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"

--- a/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/create_oauth_app.yml
+++ b/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/create_oauth_app.yml
@@ -26,7 +26,7 @@
 - name: Check if OAuth application exists in AAP  # noqa: var-naming[no-role-prefix]
   ansible.builtin.uri:
     url: >-
-      {{ aap_host_normalized }}/api/gateway/v1/applications/?name={{
+      {{ aap_api_host_normalized }}/api/gateway/v1/applications/?name={{
       aap_apme_prerequisites_oauth_application_name | urlencode }}&organization__name={{
       aap_organization | urlencode }}
     method: GET
@@ -83,7 +83,7 @@
 
 - name: Delete unusable OAuth application from AAP  # noqa: var-naming[no-role-prefix]
   ansible.builtin.uri:
-    url: "{{ aap_host_normalized }}/api/gateway/v1/applications/{{ existing_oauth_app.id }}/"
+    url: "{{ aap_api_host_normalized }}/api/gateway/v1/applications/{{ existing_oauth_app.id }}/"
     method: DELETE
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"
@@ -100,7 +100,7 @@
 
 - name: Look up AAP organization for OAuth application creation  # noqa: var-naming[no-role-prefix]
   ansible.builtin.uri:
-    url: "{{ aap_host_normalized }}/api/gateway/v1/organizations/?name={{ aap_organization | urlencode }}"
+    url: "{{ aap_api_host_normalized }}/api/gateway/v1/organizations/?name={{ aap_organization | urlencode }}"
     method: GET
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"
@@ -123,7 +123,7 @@
 
 - name: Create OAuth application in AAP  # noqa: var-naming[no-role-prefix]
   ansible.builtin.uri:
-    url: "{{ aap_host_normalized }}/api/gateway/v1/applications/"
+    url: "{{ aap_api_host_normalized }}/api/gateway/v1/applications/"
     method: POST
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"

--- a/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/main.yml
+++ b/addons/apme-eap/playbooks/roles/aap_apme_prerequisites/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Normalize AAP host URL  # noqa: var-naming[no-role-prefix]
   ansible.builtin.set_fact:
     aap_host_normalized: "{{ aap_host | regex_replace('/$', '') }}"
+    aap_api_host_normalized: "{{ (aap_api_host | default(aap_host)) | regex_replace('/$', '') }}"
 
 - name: Set OAuth redirect URI  # noqa: var-naming[no-role-prefix]
   ansible.builtin.set_fact:

--- a/addons/apme-eap/playbooks/roles/apme_helm_values/tasks/main.yml
+++ b/addons/apme-eap/playbooks/roles/apme_helm_values/tasks/main.yml
@@ -97,6 +97,10 @@
     namespace: openshift-ingress
     label_selectors:
       - ingresscontroller.operator.openshift.io/owning-ingresscontroller=default
+    api_key: "{{ openshift_token | default(omit) }}"
+    kubeconfig: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') | default(omit) }}"
+    host: "{{ openshift_api_url }}"
+    validate_certs: "{{ openshift_validate_certs | default(false) }}"
   register: router_service
   when: is_nip_io_domain
 

--- a/addons/apme-eap/playbooks/roles/apme_helm_values/tasks/main.yml
+++ b/addons/apme-eap/playbooks/roles/apme_helm_values/tasks/main.yml
@@ -150,7 +150,19 @@
     path: "{{ apme_portal_helm_values_path }}"
     regexp: '(?s)          github:\n          - host: github\.com\n            token: \$\{GITHUB_TOKEN\}\n            apps:\n            - appId: \$\{GITHUB_APP_ID\}\n              clientId: \$\{GITHUB_APP_CLIENT_ID\}\n              clientSecret: \$\{GITHUB_APP_CLIENT_SECRET\}\n              privateKey: \|\n                \$\{GITHUB_APP_PRIVATE_KEY\}\n'  # yamllint disable-line rule:line-length
     replace: '          # GitHub integration disabled (configure_github_secrets: false)\n'
-  when: not (configure_github_secrets | default(false))
+  when: not (configure_github_secrets | default(false) | bool)
+
+# Token-only GitHub (PAT, no App) still interpolates ${GITHUB_APP_ID}. An empty
+# appId makes Backstage fail scaffolder/catalog/auth startup, so Helm wait hangs
+# until portal_helm_install_timeout (30m) while readiness stays 503.
+- name: Strip GitHub App block for token-only GitHub integration  # noqa: var-naming[no-role-prefix]
+  ansible.builtin.replace:
+    path: "{{ apme_portal_helm_values_path }}"
+    regexp: '(?s)            token: \$\{GITHUB_TOKEN\}\n            apps:\n            - appId: \$\{GITHUB_APP_ID\}\n              clientId: \$\{GITHUB_APP_CLIENT_ID\}\n              clientSecret: \$\{GITHUB_APP_CLIENT_SECRET\}\n              privateKey: \|\n                \$\{GITHUB_APP_PRIVATE_KEY\}\n'  # yamllint disable-line rule:line-length
+    replace: "            token: ${GITHUB_TOKEN}\n"
+  when:
+    - configure_github_secrets | default(false) | bool
+    - github_app_id is not defined or (github_app_id | default('') | length) == 0
 
 - name: Remove GitHub auth provider (catalog integration only, not sign-in)  # noqa: var-naming[no-role-prefix]
   ansible.builtin.replace:
@@ -163,7 +175,7 @@
     path: "{{ apme_portal_helm_values_path }}"
     regexp: '(?s)                      github:\n                      - host: github\.com\n                        name: github-acme-scm\n                        orgs:\n                        - name: acme-scm\n                          branches:\n                          - main\n                          - master\n                          crawlDepth: 5\n                          apme:\n                            enabled: true\n                            scanOnRegister: false\n                          schedule:\n                            frequency:\n                              minutes: 30\n                            timeout:\n                              minutes: 30\n'  # yamllint disable-line rule:line-length
     replace: '                      # GitHub catalog provider disabled (configure_github_secrets: false)\n                      github: []\n'  # yamllint disable-line rule:line-length
-  when: not (configure_github_secrets | default(false))
+  when: not (configure_github_secrets | default(false) | bool)
 
 - name: Read rendered Helm values  # noqa: var-naming[no-role-prefix]
   ansible.builtin.slurp:

--- a/addons/local-cache/README.md
+++ b/addons/local-cache/README.md
@@ -32,6 +32,9 @@ Each image is saved as `<md5>.tar` plus a `<md5>.ref` sidecar with the original 
 - CRC cluster running with AAP deployed (for **save**)
 - CRC cluster running (for **load**)
 - SSH access to the CRC VM (port 2222)
+- `jq` or a real Python 3 (to parse `crictl images` JSON). On Windows, Git Bash often
+  finds a Microsoft Store `python3` stub that is not an interpreter — install jq:
+  `winget install jqlang.jq`
 - ~30 GB free disk space for a full AAP image set
 
 ## Notes

--- a/addons/local-cache/deploy.sh
+++ b/addons/local-cache/deploy.sh
@@ -42,6 +42,59 @@ _ssh() {
   ssh -p "$CRC_SSH_PORT" "${CRC_SSH_OPTS[@]}" core@127.0.0.1 "$@"
 }
 
+# Real Python (skip the Windows Store alias that prints "Python was not found")
+_python_cmd() {
+  local cmd
+  for cmd in python3 python; do
+    if command -v "$cmd" >/dev/null 2>&1 && "$cmd" -c 'import json' >/dev/null 2>&1; then
+      echo "$cmd"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Parse crictl images JSON on stdin → "size digest" lines for Red Hat / k8s.io images.
+# Windows jq.exe / python print CRLF; strip CR so skopeo refs stay valid.
+_parse_crictl_images() {
+  local parsed
+  if command -v jq >/dev/null 2>&1; then
+    parsed=$(jq -r '
+      [.images[]?
+       | .size as $s
+       | (.repoDigests // [])[]
+       | select(contains("registry.redhat.io") or contains("registry.k8s.io"))
+       | {size: ($s // 0), digest: .}]
+      | unique_by(.digest)[]
+      | "\(.size) \(.digest)"
+    ') || return $?
+  else
+    local py
+    if py=$(_python_cmd); then
+      parsed=$("$py" -c "
+import sys, json
+data = json.loads(sys.stdin.read() or '{}')
+seen = set()
+registries = ['registry.redhat.io', 'registry.k8s.io']
+for img in data.get('images', []):
+    for digest in img.get('repoDigests') or []:
+        if any(r in digest for r in registries) and digest not in seen:
+            seen.add(digest)
+            size = img.get('size', '0')
+            print(f'{size} {digest}')
+") || return $?
+    else
+      echo "ERROR: jq or Python 3 is required to parse the CRC image list." >&2
+      echo "  Windows Store python3 is not a real interpreter — install jq instead:" >&2
+      echo "    winget install jqlang.jq" >&2
+      echo "  macOS: brew install jq" >&2
+      echo "  Linux: install jq or python3" >&2
+      return 1
+    fi
+  fi
+  printf '%s' "$parsed" | tr -d '\r'
+}
+
 # --- Clear ---
 if [ "$ACTION" = "--delete" ] || [ "$ACTION" = "delete" ] || [ "$ACTION" = "clear" ]; then
   if [ -d "$CACHE_DIR" ]; then
@@ -120,23 +173,20 @@ if [ "$ACTION" = "save" ] || [ "$ACTION" = "deploy" ]; then
   mkdir -p "$CACHE_DIR"
 
   # Get all Red Hat / registry.k8s.io images from CRI-O
-  all_images=$(_ssh "sudo crictl images -o json" 2>/dev/null | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-seen = set()
-registries = ['registry.redhat.io', 'registry.k8s.io']
-for img in data.get('images', []):
-    for digest in img.get('repoDigests', []):
-        if any(r in digest for r in registries):
-            if digest not in seen:
-                seen.add(digest)
-                # size in bytes
-                size = img.get('size', '0')
-                print(f'{size} {digest}')
-" 2>/dev/null || true)
+  images_json=$(_ssh "sudo crictl images -o json") || {
+    echo "ERROR: Failed to list images from CRC VM (SSH or crictl failed)"
+    echo "  Is the cluster running? Try: aap-demo status"
+    exit 1
+  }
+
+  if ! all_images=$(printf '%s' "$images_json" | _parse_crictl_images); then
+    exit 1
+  fi
 
   if [ -z "$all_images" ]; then
-    echo "No images found in CRC VM"
+    echo "No registry.redhat.io / registry.k8s.io images found in CRC VM"
+    echo "  Deploy AAP first: aap-demo deploy"
+    echo "  Then re-run: aap-demo enable local-cache"
     exit 1
   fi
 
@@ -161,6 +211,7 @@ for img in data.get('images', []):
   skipped=0
   failed=0
   while IFS=' ' read -r img_size img_ref; do
+    img_ref="${img_ref%$'\r'}"
     [ -z "$img_ref" ] && continue
 
     # Safe filename

--- a/addons/product-demos-base/lib.sh
+++ b/addons/product-demos-base/lib.sh
@@ -477,14 +477,16 @@ print(p.get_project_path() or '')
     return 1
   fi
 
-  if ! kubectl exec -i -n "$NAMESPACE" "$task_pod" -- \
-    tee "${project_dir}/${dest_name}" <"$src" >/dev/null 2>&1; then
+  local dest_path="${project_dir}/${dest_name}"
+  # Git Bash rewrites Unix paths (e.g. /var/lib/awx/...) before kubectl sees them.
+  if ! MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 kubectl exec -i -n "$NAMESPACE" "$task_pod" -- \
+    tee "$dest_path" <"$src" >/dev/null 2>&1; then
     echo "  ⚠ Failed to copy ${dest_name} into ${project_dir}" >&2
     return 1
   fi
 
-  if [ -n "$verify_pattern" ] && ! kubectl exec -n "$NAMESPACE" "$task_pod" -- \
-    grep -q "$verify_pattern" "${project_dir}/${dest_name}" 2>/dev/null; then
+  if [ -n "$verify_pattern" ] && ! MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 kubectl exec -n "$NAMESPACE" "$task_pod" -- \
+    grep -q "$verify_pattern" "$dest_path" 2>/dev/null; then
     echo "  ⚠ Overlay verification failed for ${dest_name} (missing: ${verify_pattern})" >&2
     return 1
   fi

--- a/docs/adr/010-cross-platform-cli.md
+++ b/docs/adr/010-cross-platform-cli.md
@@ -50,9 +50,11 @@ AapDemo.psm1
 | create, deploy, status | ✓ | ✓ |
 | diagnose | ✓ | ✓ |
 | diagnose --ai | ✓ (claude CLI) | Delegates to Git Bash |
-| enable mcp-server | ✓ | ✓ |
-| enable portal | ✓ | Limited / Git Bash |
-| test, watch | ✓ | Git Bash delegation |
+| enable mcp-server | ✓ | ✓ (native) |
+| enable portal | ✓ | ✓ (native Helm) |
+| enable setup-pah | ✓ | ✓ (native) |
+| enable product-demos, registry, devspaces | ✓ | ✓ (Git Bash delegation) |
+| test, watch | ✓ | test: Git Bash; watch: native |
 | ingress CA trust | `ingress-ca-trust.sh` | `Install-AapIngressCaTrust` |
 
 PowerShell uses **native CRC/OpenShift operations** for the critical path; Git Bash is optional for advanced commands.

--- a/docs/adr/021-local-cache-addon.md
+++ b/docs/adr/021-local-cache-addon.md
@@ -87,6 +87,15 @@ additional presets are reintroduced later.
   resolves preset in order: `CRC_PRESET` env var → `CRC_PRESET` in `~/.aap-demo/config` →
   `crc config get preset` → default `microshift`. Avoids mis-parsing CRC's "not set"
   message (which mentions openshift as CRC's default, not aap-demo's).
+- **JSON parsing**: Save lists images from `crictl images -o json`. Parsing uses `jq`
+  first, then a real Python 3 interpreter. On Windows, Git Bash often resolves `python3`
+  to the Microsoft Store stub (`Python was not found`), which is not an interpreter —
+  treat that as missing and require jq (`winget install jqlang.jq`). Do not swallow
+  parser failures as "no images found".
+- **CRLF from Windows jq**: Native `jq.exe` emits `\r\n`. `read` keeps the trailing `\r`
+  on the image reference, so `skopeo copy containers-storage:'...sha256:...\r'` fails and
+  the image is skipped. The last line often has no CR (command substitution), so exactly
+  one image can save. Strip CR from parsed output and from each `img_ref`.
 
 ## Consequences
 

--- a/includes/olm-catalog-signature.sh
+++ b/includes/olm-catalog-signature.sh
@@ -31,7 +31,7 @@ resolve_aap_ocp_version() {
     echo "${BASH_REMATCH[1]}"
     return 0
   fi
-  _cluster_version=$(kubectl get clusterversion version \
+  _cluster_version=$(oc get clusterversion version \
     -o jsonpath='{.status.desired.version}' 2>/dev/null || echo "")
   if [[ "$_cluster_version" =~ ^([0-9]+\.[0-9]+) ]]; then
     echo "${BASH_REMATCH[1]}"
@@ -119,7 +119,7 @@ else:
 
 catalog_pod_container_waiting() {
   local _catalog_ns="$1"
-  kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     -o jsonpath='{range .items[0].status.containerStatuses[*].state.waiting}{.reason}{": "}{.message}{"\n"}{end}' \
     2>/dev/null || echo ""
 }
@@ -127,7 +127,7 @@ catalog_pod_container_waiting() {
 catalog_pod_has_image_pull_backoff() {
   local _catalog_ns="$1"
   local _pod_status _waiting
-  _pod_status=$(kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  _pod_status=$(oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
   if [ "$_pod_status" = "ImagePullBackOff" ] || [ "$_pod_status" = "ErrImagePull" ]; then
     return 0
@@ -139,19 +139,19 @@ catalog_pod_has_image_pull_backoff() {
 catalog_pod_has_signature_pull_failure() {
   local _catalog_ns="$1"
   local _pod _waiting _phase
-  _pod=$(kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  _pod=$(oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
   if [ -z "$_pod" ]; then
     return 1
   fi
-  _phase=$(kubectl get pod "$_pod" -n "$_catalog_ns" \
+  _phase=$(oc get pod "$_pod" -n "$_catalog_ns" \
     -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
   _waiting=$(catalog_pod_container_waiting "$_catalog_ns")
   if echo "$_waiting" | grep -q "SignatureValidationFailed"; then
     return 0
   fi
   if catalog_pod_has_image_pull_backoff "$_catalog_ns"; then
-    kubectl get events -n "$_catalog_ns" --field-selector "involvedObject.name=${_pod}" \
+    oc get events -n "$_catalog_ns" --field-selector "involvedObject.name=${_pod}" \
       2>/dev/null | grep -q "SignatureValidationFailed"
     return $?
   fi
@@ -167,7 +167,7 @@ report_catalog_signature_failure() {
 
 catalog_pod_wait_reason() {
   local _catalog_ns="$1"
-  kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     -o jsonpath='{range .items[0].status.conditions[?(@.type=="PodScheduled")]}{.reason}{": "}{.message}{"\n"}{end}{range .items[0].status.containerStatuses[*].state.waiting}{.reason}{": "}{.message}{"\n"}{end}' \
     2>/dev/null | head -3
 }
@@ -182,7 +182,7 @@ maybe_recover_catalog_pull() {
     fi
   fi
   echo "  Restarting catalog pod..."
-  kubectl delete pod -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+  oc delete pod -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
     --wait=false >/dev/null 2>&1 || true
 }
 
@@ -219,13 +219,13 @@ wait_for_catalog_ready() {
   _pod_restart_attempted=0
   _signature_fix_attempted=0
   for _i in $(seq 1 "$((_timeout / 5))"); do
-    _status=$(kubectl get catalogsource redhat-operators -n "$_catalog_ns" \
+    _status=$(oc get catalogsource redhat-operators -n "$_catalog_ns" \
       -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
     if [ "$_status" = "READY" ]; then
       echo ""
       return 0
     fi
-    _pod_status=$(kubectl get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
+    _pod_status=$(oc get pods -n "$_catalog_ns" -l olm.catalogSource=redhat-operators \
       -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Pending")
     # Pod phase stays Pending while the container reports ImagePullBackOff.
     if catalog_pod_has_image_pull_backoff "$_catalog_ns"; then

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,7 +1,8 @@
 # aap-demo on Windows (PowerShell)
 
-Install and run [aap-demo](../README.md) on Windows using PowerShell. All commands
-run natively in PowerShell; only `diagnose --ai` uses Git Bash.
+Install and run [aap-demo](../README.md) on Windows using PowerShell. Core cluster
+and deploy commands run natively; bash-delegated addons and `aap-demo test` use
+Git Bash when installed.
 
 ## Requirements
 
@@ -11,7 +12,7 @@ run natively in PowerShell; only `diagnose --ai` uses Git Bash.
 | **OpenShift Local (`crc`)** | [Download](https://console.redhat.com/openshift/create/local). Hyper-V enabled. |
 | **OpenShift CLI (`oc`)**    | Installed by `install.ps1` via winget when missing.                             |
 | **Red Hat pull secret**     | [Download](https://console.redhat.com/openshift/install/pull-secret)            |
-| **Git for Windows**         | Optional. Only needed for `diagnose --ai`.                                      |
+| **Git for Windows**         | Required for bash-delegated addons, `aap-demo test`, and `diagnose --ai`. Installed via winget by `install.ps1` when missing. |
 | **OpenSSH client**          | Used during `create` to configure the cluster VM (`ssh` on PATH).               |
 
 `kubectl` is **not** required on Windows — all commands use `oc` exclusively.
@@ -86,7 +87,7 @@ All commands run in PowerShell. Run `aap-demo help` for the full list.
 | `aap-demo idle true` / `false` | Scale AAP down/up                                                  |
 | `aap-demo kubeconfig`          | Sync kubeconfig (context: `aap-demo`)                              |
 | `aap-demo ssh`                 | SSH into CRC VM                                                    |
-| `aap-demo enable` / `disable`  | Enable or disable addons                                           |
+| `aap-demo enable` / `disable`  | Enable or disable addons (see [Addons](#addons))                   |
 | `aap-demo must-gather`         | Collect diagnostic bundle                                          |
 | `aap-demo redhat-status`       | Check Red Hat registry status                                      |
 | `aap-demo config`              | Show or set `~/.aap-demo/config` values                            |
@@ -94,6 +95,26 @@ All commands run in PowerShell. Run `aap-demo help` for the full list.
 | `aap-demo help`                | Show command help                                                  |
 
 `aap-demo diagnose --ai` delegates to Git Bash for Claude-assisted analysis.
+
+## Addons
+
+Run `aap-demo enable` with no arguments to list addons and their status.
+
+| Addon | Windows mechanism |
+| ----- | ----------------- |
+| `portal` | Native (Helm) |
+| `mcp-server` | Native (`oc apply`) |
+| `setup-pah` | Native (Pulp API) — or `aap-demo setup-pah` |
+| `ao-eap`, `apme-eap`, `local-cache` | Git Bash (`addons/*/deploy.sh`) |
+| `product-demos`, `product-demo-satellite` | Git Bash |
+| `registry`, `devspaces` | Git Bash (enable directly; not shown in default list) |
+| `product-demo-linux`, `product-demo-windows`, etc. | Git Bash (direct enable) |
+
+`local-cache` subcommands (bash): `aap-demo enable local-cache load` and
+`aap-demo enable local-cache clear`.
+
+Bash-delegated addons require **Git for Windows** with `bash` on PATH. Re-run
+`.\powershell\install.ps1` to install Git via winget when missing.
 
 ## Environment variables
 
@@ -159,7 +180,7 @@ Re-run from the repo directory:
 
 Do not move or delete the cloned repo after install — the launcher points at it.
 
-### Git Bash required for diagnose --ai
+### Git Bash required for addons or test
 
 Re-run the installer (it installs Git for Windows via winget when missing), then
 open a new PowerShell window:
@@ -168,7 +189,11 @@ open a new PowerShell window:
 .\powershell\install.ps1
 ```
 
-Most commands (`create`, `deploy`, `destroy`, …) do not need Git Bash.
+Core commands (`create`, `deploy`, `destroy`, …) do not need Git Bash. These do:
+
+- Bash-delegated addons (`ao-eap`, `apme-eap`, `local-cache`, `product-demos`, `registry`, `devspaces`, …)
+- `aap-demo test` (ATF interop tests)
+- `aap-demo diagnose --ai`
 
 ### `oc` or `crc` not found
 
@@ -280,8 +305,9 @@ Then run commands with `pwsh` instead of `powershell`.
 ```
 aap-demo (launcher in ~/.local/bin)
   └── powershell/aap-demo.ps1
-        └── powershell/native/AapDemo.psm1  (all commands)
-              └── diagnose --ai  →  Git Bash (when needed)
+        └── powershell/native/AapDemo.psm1
+              ├── portal, mcp-server, setup-pah  →  native PowerShell
+              └── other addons, test, diagnose --ai  →  Git Bash (when needed)
 ```
 
 ## Updating

--- a/powershell/aap-demo.ps1
+++ b/powershell/aap-demo.ps1
@@ -267,8 +267,9 @@ try {
     'enable' {
 
       $addon = if ($cli.Positional.Count -gt 0) { $cli.Positional[0] } else { $null }
+      $scriptArgs = if ($cli.Positional.Count -gt 1) { @($cli.Positional[1..($cli.Positional.Count - 1)]) } else { @() }
 
-      $params = @{}
+      $params = @{ ScriptArgs = $scriptArgs }
       if ($addon) { $params.Addon = $addon }
       if ($cli.Namespace) { $params.Namespace = $cli.Namespace }
       Invoke-AapDemoEnable @params
@@ -278,8 +279,9 @@ try {
     'disable' {
 
       $addon = if ($cli.Positional.Count -gt 0) { $cli.Positional[0] } else { $null }
+      $scriptArgs = if ($cli.Positional.Count -gt 1) { @($cli.Positional[1..($cli.Positional.Count - 1)]) } else { @() }
 
-      $params = @{}
+      $params = @{ ScriptArgs = $scriptArgs }
       if ($addon) { $params.Addon = $addon }
       if ($cli.Namespace) { $params.Namespace = $cli.Namespace }
       Invoke-AapDemoDisable @params

--- a/powershell/aap-demo.ps1
+++ b/powershell/aap-demo.ps1
@@ -200,6 +200,8 @@ try {
 
     'stop' { Invoke-AapDemoStop }
 
+    'start' { Invoke-AapDemoStart }
+
     'destroy' { Invoke-AapDemoDestroy -Reset:$cli.Reset }
 
     'clean' {

--- a/powershell/install.ps1
+++ b/powershell/install.ps1
@@ -40,6 +40,57 @@ function Test-CommandExists {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Install-GitBash {
+  if (Test-CommandExists 'bash') {
+    Write-Ok 'Git Bash (bash) already on PATH'
+    return
+  }
+
+  if (-not (Test-CommandExists 'winget')) {
+    Write-Warn 'Git Bash not found and winget is unavailable'
+    Write-Info 'Some addons and aap-demo test require bash — install Git for Windows'
+    return
+  }
+
+  Write-Info 'Installing Git for Windows via winget (provides bash for addon scripts)...'
+  $wingetArgs = @(
+    'install', '--id', 'Git.Git', '-e', '--source', 'winget',
+    '--accept-package-agreements', '--accept-source-agreements'
+  )
+  if ($Quiet) { $wingetArgs += '--disable-interactivity' }
+
+  try {
+    & winget @wingetArgs
+    if ($LASTEXITCODE -ne 0) {
+      Write-Warn "winget install Git.Git failed (exit $LASTEXITCODE)"
+      return
+    }
+  } catch {
+    Write-Warn "Could not install Git via winget: $($_.Exception.Message)"
+    return
+  }
+
+  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $env:Path = @($machinePath, $userPath) -join ';'
+
+  if (Test-CommandExists 'bash') {
+    Write-Ok 'Git Bash installed via winget'
+  } else {
+    Write-Warn 'Git installed but bash is not on PATH yet — open a new PowerShell window'
+  }
+}
+
+function Write-GitBashAddonHint {
+  if (Test-CommandExists 'bash') { return }
+
+  Write-Warn 'Git Bash not on PATH — some features need bash:'
+  Write-Info '- Bash-delegated addons: ao-eap, apme-eap, local-cache, product-demos, registry, devspaces, ...'
+  Write-Info '- aap-demo test (ATF interop tests)'
+  Write-Info '- aap-demo diagnose --ai'
+  Write-Info 'Install: winget install --id Git.Git -e --source winget'
+}
+
 function Install-Oc {
   if (Test-CommandExists 'oc') {
     Write-Ok 'oc already on PATH'
@@ -172,6 +223,7 @@ function Install-AapDemo {
   }
 
   Install-Oc
+  Install-GitBash
 
   $checks = Test-Prerequisites
   if ($checks.Missing.Count -gt 0) {
@@ -218,6 +270,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "%USERPROFILE%\.local\bin\aa
 
   Install-OperatorSdk
   Ensure-PullSecretHint
+  Write-GitBashAddonHint
 
   Write-Host ''
   Write-Host 'Done.' -ForegroundColor Green
@@ -228,7 +281,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "%USERPROFILE%\.local\bin\aa
   Write-Info '  aap-demo deploy'
   Write-Host ''
   Write-Info 'Notes:'
-  Write-Info '- All commands run in PowerShell.'
+  Write-Info '- Core commands (create, deploy, status, ...) run natively in PowerShell.'
+  Write-Info '- Bash-delegated addons and aap-demo test require Git Bash (bash on PATH).'
   Write-Info '- OpenShift Local on Windows needs Hyper-V enabled.'
   Write-Info '- Kubeconfig default: %USERPROFILE%\.crc\machines\crc\kubeconfig'
   Write-Host ''

--- a/powershell/install.ps1
+++ b/powershell/install.ps1
@@ -40,10 +40,34 @@ function Test-CommandExists {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-GitBashInstalled {
+  $candidates = @(
+    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+    (Join-Path $env:ProgramFiles 'Git\usr\bin\bash.exe')
+  )
+  if (${env:ProgramFiles(x86)}) {
+    $candidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe')
+  }
+  foreach ($path in $candidates) {
+    if ($path -and (Test-Path -LiteralPath $path)) { return $true }
+  }
+
+  $bash = Get-Command bash -ErrorAction SilentlyContinue
+  if ($bash -and $bash.Source -notmatch '\\Windows\\System32\\bash\.exe$') {
+    return $true
+  }
+  return $false
+}
+
 function Install-GitBash {
-  if (Test-CommandExists 'bash') {
-    Write-Ok 'Git Bash (bash) already on PATH'
+  if (Test-GitBashInstalled) {
+    Write-Ok 'Git Bash already installed'
     return
+  }
+
+  $wslStub = Join-Path $env:SystemRoot 'System32\bash.exe'
+  if ((Test-Path -LiteralPath $wslStub) -and (Test-CommandExists 'bash')) {
+    Write-Warn 'bash on PATH is the WSL stub — Git for Windows is required for addons'
   }
 
   if (-not (Test-CommandExists 'winget')) {
@@ -82,7 +106,7 @@ function Install-GitBash {
 }
 
 function Write-GitBashAddonHint {
-  if (Test-CommandExists 'bash') { return }
+  if (Test-GitBashInstalled) { return }
 
   Write-Warn 'Git Bash not on PATH — some features need bash:'
   Write-Info '- Bash-delegated addons: ao-eap, apme-eap, local-cache, product-demos, registry, devspaces, ...'

--- a/powershell/native/AapDemo.psm1
+++ b/powershell/native/AapDemo.psm1
@@ -40,6 +40,8 @@ Export-ModuleMember -Function @(
 
   'Invoke-AapDemoStop'
 
+  'Invoke-AapDemoStart'
+
   'Invoke-AapDemoDestroy'
 
   'Invoke-AapDemoClean'

--- a/powershell/native/Private/Addons.ps1
+++ b/powershell/native/Private/Addons.ps1
@@ -36,19 +36,27 @@ function Test-AapAddonUsesBash {
 function Assert-AapBashAvailable {
   param([string]$Addon = $null)
 
-  if (Get-Command bash -ErrorAction SilentlyContinue) { return }
+  if (Test-AapGitBashAvailable) { return }
 
   $bashAddons = Get-AapBashDelegatedAddons
   $addonList = if ($bashAddons.Count -gt 0) { $bashAddons -join ', ' } else { '(see addons/ in repo)' }
   $prefix = if ($Addon) { "Addon '$Addon'" } else { 'This command' }
+  $wslStub = Join-Path $env:SystemRoot 'System32\bash.exe'
+  $wslNote = if ((Test-Path -LiteralPath $wslStub) -and (Get-Command bash -ErrorAction SilentlyContinue)) {
+@"
+
+Note: bash on PATH resolves to the WSL stub ($wslStub).
+aap-demo requires Git for Windows, not WSL.
+"@
+  } else { '' }
 
   throw @"
-$prefix requires Git Bash (bash on PATH).
+$prefix requires Git Bash (Git for Windows).
 
 Install Git for Windows:
   winget install --id Git.Git -e --source winget
 
-Then open a new PowerShell window.
+Then open a new PowerShell window.$wslNote
 
 Bash-delegated addons: $addonList
 Also requires bash: aap-demo test
@@ -75,7 +83,7 @@ exec oc "$@"
     Set-Content -LiteralPath $kubectlBash -Value $kubectlContent -Encoding ascii -NoNewline
   }
 
-    $kubectlCmd = Join-Path $shimDir 'kubectl.cmd'
+  $kubectlCmd = Join-Path $shimDir 'kubectl.cmd'
   if (-not (Test-Path -LiteralPath $kubectlCmd)) {
     Set-Content -LiteralPath $kubectlCmd -Value "@echo off`r`noc %*" -Encoding ascii
   }
@@ -91,6 +99,8 @@ function Invoke-AapAddonDeployScript {
     [string[]]$ScriptArgs = @()
   )
 
+  if ($null -eq $ScriptArgs) { $ScriptArgs = @() }
+
   Assert-AapBashAvailable -Addon $Addon
 
   $deploySh = Join-Path $Script:AapDemoRepoRoot "addons/$Addon/deploy.sh"
@@ -100,8 +110,12 @@ function Invoke-AapAddonDeployScript {
 
   Initialize-AapBashAddonEnvironment
 
-  $bash = Get-Command bash -ErrorAction Stop
-  & $bash.Source $deploySh @ScriptArgs
+  $bashPath = Get-AapGitBashExecutable
+  if (-not $bashPath) {
+    throw "Git Bash not found. Install Git for Windows: winget install --id Git.Git -e --source winget"
+  }
+
+  & $bashPath $deploySh @ScriptArgs
   if ($LASTEXITCODE -ne 0) {
     throw "Addon '$Addon' deploy failed (exit code: $LASTEXITCODE)"
   }
@@ -149,18 +163,10 @@ function Invoke-AapDeployMcpServerAddon {
     Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
   }
 
-  $mcpRoute = "aap-mcp-$Namespace.apps.127.0.0.1.nip.io"
-  $aapRoute = "aap-$Namespace.apps.127.0.0.1.nip.io"
   Write-AapStep 'AAP MCP Server deployed'
-  Write-Host ''
-  Write-Host "  MCP Endpoint: https://$mcpRoute/mcp"
-  Write-Host "  AAP Instance: https://$aapRoute"
   Write-Host ''
   Write-Host "  Status:  oc get ansiblemcpserver -n $Namespace"
   Write-Host "  Logs:    oc logs -n $Namespace -l app.kubernetes.io/name=aap-mcp-server"
-  Write-Host ''
-  Write-Host '  Connect your MCP client to:'
-  Write-Host "    https://$mcpRoute/mcp"
   Write-Host ''
 }
 
@@ -182,6 +188,8 @@ function Invoke-AapAddonEnable {
     [string]$Namespace = $Script:AapDemoDefaultNamespace,
     [string[]]$ScriptArgs = @()
   )
+
+  if ($null -eq $ScriptArgs) { $ScriptArgs = @() }
 
   switch ($Addon) {
     'mcp-server' { Invoke-AapDeployMcpServerAddon -Namespace $Namespace }
@@ -211,39 +219,255 @@ function Get-AapAddonEnableCommand {
   return "aap-demo enable $Addon"
 }
 
-function Get-AapAddonStatusLabel {
+function Get-AapAoEapAdminPassword {
+  $aoNs = 'automation-orchestrator'
+  foreach ($secretName in @(
+    'automation-orchestrator-initial-admin-password',
+    'automation-orchestrator-admin-password'
+  )) {
+    $password = Get-AapSecretPassword -Namespace $aoNs -SecretName $secretName
+    if ($password) { return $password }
+  }
+
+  $secrets = Invoke-AapOcCapture @('get', 'secret', '-n', $aoNs, '-o', 'name')
+  if ($secrets.ExitCode -ne 0 -or -not $secrets.Output) { return $null }
+  foreach ($line in $secrets.Lines) {
+    if ($line -notmatch 'admin-password') { continue }
+    $secretName = ($line -replace '^secret/', '').Trim()
+    $password = Get-AapSecretPassword -Namespace $aoNs -SecretName $secretName
+    if ($password) { return $password }
+  }
+  return $null
+}
+
+function Get-AapAoEapRouteHost {
+  return Get-AapRouteHost -Namespace 'automation-orchestrator'
+}
+
+function Get-AapAapAccessEntry {
+  param([Parameter(Mandatory)][string]$Namespace)
+
+  $password = Get-AapAdminPassword -Namespace $Namespace
+  if (-not $password) { return $null }
+
+  $routeHost = Get-AapRouteHost -Namespace $Namespace
+  return [pscustomobject]@{
+    Title = "AAP ($Namespace)"
+    Url = if ($routeHost) { "https://$routeHost" } else { $null }
+    Username = 'admin'
+    Password = $password
+    PasswordHint = $null
+    ProgressNote = $null
+  }
+}
+
+function Get-AapAoEapAccessEntry {
+  if ((Invoke-AapOcQuiet @('get', 'namespace', 'automation-orchestrator')) -ne 0) {
+    return $null
+  }
+
+  $routeHost = Get-AapAoEapRouteHost
+  $password = Get-AapAoEapAdminPassword
+
+  return [pscustomobject]@{
+    Title = 'Automation Orchestrator (ao)'
+    Url = if ($routeHost) { "https://$routeHost" } else { $null }
+    Username = 'admin'
+    Password = $password
+    PasswordHint = if ($password) { $null } else {
+      'oc get secret -n automation-orchestrator -o name | Select-String admin-password'
+    }
+    ProgressNote = if (-not $routeHost -and -not $password) {
+      '(deployment may still be in progress)'
+    } else { $null }
+  }
+}
+
+function Get-AapApmeEapAccessEntry {
+  $apmeNs = 'apme'
+  if ((Invoke-AapOcQuiet @('get', 'namespace', $apmeNs)) -ne 0) { return $null }
+
+  $routeHost = Get-AapRouteHost -Namespace $apmeNs -RouteName 'redhat-rhaap-portal'
+  if (-not $routeHost) { return $null }
+
+  $aapPassword = Get-AapAdminPassword -Namespace $Script:AapDemoDefaultNamespace
+  return [pscustomobject]@{
+    Title = 'APME Portal (apme-eap)'
+    Url = "https://$routeHost"
+    Username = 'admin'
+    Password = $aapPassword
+    PasswordHint = if ($aapPassword) { $null } else {
+      'Uses AAP OAuth — retrieve AAP admin password from the AAP entry above'
+    }
+    Notes = @('Sign in with AAP admin credentials (AAP OAuth)')
+  }
+}
+
+function Get-AapMcpServerAccessEntry {
+  param([string]$Namespace = $Script:AapDemoDefaultNamespace)
+
+  $mcpHost = Get-AapMcpServerRouteHost -Namespace $Namespace
+  if (-not $mcpHost) { return $null }
+
+  $aapHost = Get-AapRouteHost -Namespace $Namespace
+  $notes = @('Connect your MCP client to the endpoint above')
+  if ($aapHost) {
+    $notes += "Authenticate with AAP credentials at https://$aapHost"
+  }
+
+  return [pscustomobject]@{
+    Title = 'AAP MCP Server'
+    Url = "https://$mcpHost/mcp"
+    Username = $null
+    Password = $null
+    PasswordHint = $null
+    Notes = $notes
+  }
+}
+
+function Get-AapPortalAccessEntry {
+  param([string]$Namespace = $Script:AapDemoDefaultNamespace)
+
+  $portalHost = Get-AapPortalRouteHost -AapNamespace $Namespace
+  if (-not $portalHost) { return $null }
+
+  $password = Get-AapAdminPassword -Namespace $Namespace
+  return [pscustomobject]@{
+    Title = 'Developer Portal (portal)'
+    Url = "https://$portalHost"
+    Username = 'admin'
+    Password = $password
+    PasswordHint = if ($password) { $null } else {
+      "oc get secret -n $Namespace aap-admin-password -o jsonpath='{.data.password}'"
+    }
+    Notes = @('Sign in with AAP admin credentials when the portal prompts you')
+  }
+}
+
+function Get-AapAddonAccessEntries {
   param(
     [Parameter(Mandatory)][string]$Addon,
-    [string]$Namespace = $Script:AapDemoDefaultNamespace,
-    [Parameter(Mandatory)][bool]$Enabled
+    [string]$Namespace = $Script:AapDemoDefaultNamespace
   )
-
-  if (-not $Enabled) { return 'disabled' }
 
   switch ($Addon) {
     'mcp-server' {
-      $mcpHost = Get-AapMcpServerRouteHost -Namespace $Namespace
-      if ($mcpHost) { return "https://$mcpHost/mcp" }
-      return 'not-deployed'
+      $entry = Get-AapMcpServerAccessEntry -Namespace $Namespace
+      $entries = @()
+      if ($entry) { $entries += $entry }
+      $aapEntry = Get-AapAapAccessEntry -Namespace $Namespace
+      if ($aapEntry -and $aapEntry.Password) { $entries += $aapEntry }
+      return $entries
     }
     'portal' {
-      $portalHost = Get-AapPortalRouteHost -AapNamespace $Namespace
-      if ($portalHost) { return "https://$portalHost" }
-      return 'not-deployed'
+      $entry = Get-AapPortalAccessEntry -Namespace $Namespace
+      if ($entry) { return @($entry) }
+      return @()
     }
     'ao' {
-      $aoNs = 'automation-orchestrator'
-      $routeResult = Invoke-AapOcCapture @(
-        'get', 'routes', '-n', $aoNs,
-        '-o', 'jsonpath={.items[0].spec.host}'
-      )
-      if ($routeResult.ExitCode -eq 0 -and $routeResult.Output.Trim()) {
-        return "https://$($routeResult.Output.Trim())"
-      }
-      if ((Invoke-AapOcQuiet @('get', 'namespace', $aoNs)) -eq 0) { return 'deployed' }
-      return 'not-deployed'
+      $entry = Get-AapAoEapAccessEntry
+      if ($entry) { return @($entry) }
+      return @()
     }
-    default { return $null }
+    'ao-eap' {
+      $entry = Get-AapAoEapAccessEntry
+      if ($entry) { return @($entry) }
+      return @()
+    }
+    'apme-eap' {
+      $entry = Get-AapApmeEapAccessEntry
+      if ($entry) { return @($entry) }
+      return @()
+    }
+    default { return @() }
+  }
+}
+
+function Get-AapDeployedAccessEntries {
+  param([string]$Namespace = $Script:AapDemoDefaultNamespace)
+
+  $entries = @()
+  $aapNsResult = Invoke-AapOcCapture @('get', 'aap', '-A', '--no-headers')
+  $aapNamespaces = if ($aapNsResult.ExitCode -eq 0 -and $aapNsResult.Output -notmatch '^No resources found') {
+    $aapNsResult.Lines | ForEach-Object { ($_ -split '\s+')[0] } | Sort-Object -Unique
+  } else { @() }
+
+  foreach ($ns in $aapNamespaces) {
+    $entry = Get-AapAapAccessEntry -Namespace $ns
+    if ($entry) { $entries += $entry }
+  }
+
+  $aoEntry = Get-AapAoEapAccessEntry
+  if ($aoEntry) { $entries += $aoEntry }
+
+  return $entries
+}
+
+function Write-AapAccessEntry {
+  param($Entry)
+
+  if (-not $Entry) { return }
+  if ($Entry.Title) { Write-Host $Entry.Title }
+  if ($Entry.Url) { Write-Host "  URL:      $($Entry.Url)" }
+  if ($Entry.Username) { Write-Host "  Username: $($Entry.Username)" }
+  if ($Entry.Password) {
+    Write-Host "  Password: $($Entry.Password)"
+  } elseif ($Entry.PasswordHint) {
+    Write-Host "  Password: $($Entry.PasswordHint)"
+  }
+  if ($Entry.ProgressNote) { Write-Host "  $($Entry.ProgressNote)" }
+  $notes = @()
+  if ($null -ne $Entry.PSObject.Properties['Notes']) {
+    $notes = @($Entry.Notes)
+  }
+  foreach ($note in $notes) {
+    if ($note) { Write-Host "  $note" }
+  }
+  Write-Host ''
+}
+
+function Write-AapCredentialsStatus {
+  param([string]$Namespace = $Script:AapDemoDefaultNamespace)
+
+  $entries = @(Get-AapDeployedAccessEntries -Namespace $Namespace)
+  if ($entries.Count -eq 0) { return }
+
+  Write-Host ''
+  Write-Host 'Credentials:'
+  Write-Host '------------'
+  foreach ($entry in $entries) {
+    Write-AapAccessEntry -Entry $entry
+  }
+}
+
+function Write-AapAddonAccessInfo {
+  param(
+    [Parameter(Mandatory)][string]$Addon,
+    [string]$Namespace = $Script:AapDemoDefaultNamespace
+  )
+
+  if ($Addon -eq 'portal') { return }
+
+  $entries = @(Get-AapDeployedAccessEntries -Namespace $Namespace)
+  foreach ($addonEntry in @(Get-AapAddonAccessEntries -Addon $Addon -Namespace $Namespace)) {
+    $duplicate = $false
+    foreach ($existing in $entries) {
+      if ($existing.Title -eq $addonEntry.Title) {
+        $duplicate = $true
+        break
+      }
+    }
+    if (-not $duplicate) {
+      $entries += $addonEntry
+    }
+  }
+  if ($entries.Count -eq 0) { return }
+
+  Write-Host ''
+  Write-Host 'Credentials:'
+  Write-Host '------------'
+  foreach ($entry in $entries) {
+    Write-AapAccessEntry -Entry $entry
   }
 }
 

--- a/powershell/native/Private/Addons.ps1
+++ b/powershell/native/Private/Addons.ps1
@@ -1,6 +1,89 @@
+# Addons listed in `aap-demo enable` (matches bash AVAILABLE_ADDONS).
 $Script:AapAvailableAddons = @(
-  'mcp-server', 'portal', 'setup-pah', 'ao', 'apme-eap', 'local-cache'
+  'mcp-server', 'portal', 'setup-pah', 'ao', 'apme-eap', 'local-cache',
+  'product-demos', 'product-demo-satellite'
 )
+
+# Implemented natively in PowerShell (no Git Bash).
+$Script:AapNativeAddons = @('mcp-server', 'portal', 'setup-pah')
+
+function Get-AapBashDelegatedAddons {
+  $addonsDir = Join-Path $Script:AapDemoRepoRoot 'addons'
+  if (-not (Test-Path -LiteralPath $addonsDir)) { return @() }
+
+  return @(
+    Get-ChildItem -LiteralPath $addonsDir -Directory |
+      Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'deploy.sh') } |
+      ForEach-Object { $_.Name } |
+      Where-Object { $_ -notin $Script:AapNativeAddons }
+  )
+}
+
+function Test-AapAddonExists {
+  param([Parameter(Mandatory)][string]$Addon)
+
+  if ($Addon -in $Script:AapNativeAddons) { return $true }
+
+  $deploySh = Join-Path $Script:AapDemoRepoRoot "addons/$Addon/deploy.sh"
+  return Test-Path -LiteralPath $deploySh
+}
+
+function Test-AapAddonUsesBash {
+  param([Parameter(Mandatory)][string]$Addon)
+  return ($Addon -notin $Script:AapNativeAddons) -and (Test-AapAddonExists -Addon $Addon)
+}
+
+function Assert-AapBashAvailable {
+  param([string]$Addon = $null)
+
+  if (Get-Command bash -ErrorAction SilentlyContinue) { return }
+
+  $bashAddons = Get-AapBashDelegatedAddons
+  $addonList = if ($bashAddons.Count -gt 0) { $bashAddons -join ', ' } else { '(see addons/ in repo)' }
+  $prefix = if ($Addon) { "Addon '$Addon'" } else { 'This command' }
+
+  throw @"
+$prefix requires Git Bash (bash on PATH).
+
+Install Git for Windows:
+  winget install --id Git.Git -e --source winget
+
+Then open a new PowerShell window.
+
+Bash-delegated addons: $addonList
+Also requires bash: aap-demo test
+"@
+}
+
+function Initialize-AapBashAddonEnvironment {
+  Sync-AapKubeconfig -Quiet
+  Initialize-AapKubeEnvironment
+
+  $kube = Get-AapKubeconfigPath
+  if ($kube) { $env:KUBECONFIG = $kube }
+
+  $shimDir = Join-Path $Script:AapDemoConfigDir 'bin'
+  New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
+
+  $kubectlBash = Join-Path $shimDir 'kubectl'
+  $kubectlContent = @'
+#!/usr/bin/env bash
+exec oc "$@"
+'@
+  if (-not (Test-Path -LiteralPath $kubectlBash) -or
+      (Get-Content -LiteralPath $kubectlBash -Raw) -ne $kubectlContent) {
+    Set-Content -LiteralPath $kubectlBash -Value $kubectlContent -Encoding ascii -NoNewline
+  }
+
+    $kubectlCmd = Join-Path $shimDir 'kubectl.cmd'
+  if (-not (Test-Path -LiteralPath $kubectlCmd)) {
+    Set-Content -LiteralPath $kubectlCmd -Value "@echo off`r`noc %*" -Encoding ascii
+  }
+
+  if ($env:Path -notlike "*$shimDir*") {
+    $env:Path = "$shimDir;$env:Path"
+  }
+}
 
 function Invoke-AapAddonDeployScript {
   param(
@@ -8,16 +91,16 @@ function Invoke-AapAddonDeployScript {
     [string[]]$ScriptArgs = @()
   )
 
+  Assert-AapBashAvailable -Addon $Addon
+
   $deploySh = Join-Path $Script:AapDemoRepoRoot "addons/$Addon/deploy.sh"
   if (-not (Test-Path -LiteralPath $deploySh)) {
     throw "Addon '$Addon' has no deploy.sh"
   }
 
-  $bash = Get-Command bash -ErrorAction SilentlyContinue
-  if (-not $bash) {
-    throw "Addon '$Addon' requires bash (Git Bash or WSL). Install Git for Windows or use Linux/macOS."
-  }
+  Initialize-AapBashAddonEnvironment
 
+  $bash = Get-Command bash -ErrorAction Stop
   & $bash.Source $deploySh @ScriptArgs
   if ($LASTEXITCODE -ne 0) {
     throw "Addon '$Addon' deploy failed (exit code: $LASTEXITCODE)"
@@ -96,13 +179,15 @@ function Invoke-AapRemoveMcpServerAddon {
 function Invoke-AapAddonEnable {
   param(
     [Parameter(Mandatory)][string]$Addon,
-    [string]$Namespace = $Script:AapDemoDefaultNamespace
+    [string]$Namespace = $Script:AapDemoDefaultNamespace,
+    [string[]]$ScriptArgs = @()
   )
 
   switch ($Addon) {
     'mcp-server' { Invoke-AapDeployMcpServerAddon -Namespace $Namespace }
     'portal' { Invoke-AapDeployPortalAddon -Namespace $Namespace }
-    default { Invoke-AapAddonDeployScript -Addon $Addon }
+    'setup-pah' { Invoke-AapDemoSetupPah -Namespace $Namespace }
+    default { Invoke-AapAddonDeployScript -Addon $Addon -ScriptArgs $ScriptArgs }
   }
 }
 
@@ -146,6 +231,18 @@ function Get-AapAddonStatusLabel {
       if ($portalHost) { return "https://$portalHost" }
       return 'not-deployed'
     }
+    'ao' {
+      $aoNs = 'automation-orchestrator'
+      $routeResult = Invoke-AapOcCapture @(
+        'get', 'routes', '-n', $aoNs,
+        '-o', 'jsonpath={.items[0].spec.host}'
+      )
+      if ($routeResult.ExitCode -eq 0 -and $routeResult.Output.Trim()) {
+        return "https://$($routeResult.Output.Trim())"
+      }
+      if ((Invoke-AapOcQuiet @('get', 'namespace', $aoNs)) -eq 0) { return 'deployed' }
+      return 'not-deployed'
+    }
     default { return $null }
   }
 }
@@ -153,12 +250,16 @@ function Get-AapAddonStatusLabel {
 function Invoke-AapAddonDisable {
   param(
     [Parameter(Mandatory)][string]$Addon,
-    [string]$Namespace = $Script:AapDemoDefaultNamespace
+    [string]$Namespace = $Script:AapDemoDefaultNamespace,
+    [string[]]$ScriptArgs = @()
   )
 
   switch ($Addon) {
     'mcp-server' { Invoke-AapRemoveMcpServerAddon -Namespace $Namespace }
     'portal' { Invoke-AapRemovePortalAddon -Namespace $Namespace }
-    default { Invoke-AapAddonDeployScript -Addon $Addon -ScriptArgs @('--delete') }
+    'setup-pah' {
+      Write-AapWarn 'setup-pah has no cluster resources to remove (credentials remain in ~/.aap-demo/)'
+    }
+    default { Invoke-AapAddonDeployScript -Addon $Addon -ScriptArgs (@('--delete') + $ScriptArgs) }
   }
 }

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -1,63 +1,113 @@
 function Invoke-AapDemoEnable {
   param(
     [string]$Addon = $null,
-    [string]$Namespace = $Script:AapDemoDefaultNamespace
+    [string]$Namespace = $Script:AapDemoDefaultNamespace,
+    [string[]]$ScriptArgs = @()
   )
 
   if (-not $Addon) {
-    Write-Host 'Usage: aap-demo enable <addon>'
+    Write-Host 'Usage: aap-demo enable <addon> [options]'
     Write-Host ''
     Write-Host 'Available addons:'
     $saved = @(Get-AapAddonsList)
     foreach ($a in $Script:AapAvailableAddons) {
       $status = 'available'
       if ($saved -contains $a) { $status = 'enabled' }
-      elseif (-not (Test-Path -LiteralPath (Join-Path $Script:AapDemoRepoRoot "addons/$a"))) {
+      elseif (-not (Test-AapAddonExists -Addon $a)) {
         $status = 'not found'
       }
-      Write-Host ("  {0,-15} ({1})" -f $a, $status)
+      Write-Host ("  {0,-25} ({1})" -f $a, $status)
     }
+    Write-Host ''
+    Write-Host 'Direct-enable addons (not listed above):'
+    Write-Host '  product-demos-base, product-demo-linux, product-demo-windows,'
+    Write-Host '  product-demo-network, product-demo-cloud, product-demo-openshift,'
+    Write-Host '  registry, devspaces'
+    Write-Host ''
+    Write-Host 'local-cache subcommands: load, clear'
     return
   }
 
   $Addon = Resolve-AapAddonName $Addon
 
-  if ($Addon -notin $Script:AapAvailableAddons) {
+  if (-not (Test-AapAddonExists -Addon $Addon)) {
     throw "Unknown addon: $Addon`nAvailable: $($Script:AapAvailableAddons -join ', ')"
   }
 
-  Write-Host "Enabling addon: $Addon"
-  Invoke-AapEnsureClusterReady
-  Invoke-AapAddonEnable -Addon $Addon -Namespace $Namespace
-  Add-AapAddon $Addon
-  $addons = (Get-AapAddonsList) -join ','
-  Write-AapStep "Saved to config: ADDONS=$addons"
+  if (Test-AapAddonUsesBash -Addon $Addon) {
+    Assert-AapBashAvailable -Addon $Addon
+  }
+
+  $skipSave = $false
+  $skipCluster = $false
+  if ($Addon -eq 'local-cache') {
+    switch ($ScriptArgs[0]) {
+      'load' {
+        $skipSave = $true
+        Write-Host 'Loading cached container images...'
+      }
+      'clear' {
+        $skipSave = $true
+        $skipCluster = $true
+        Write-Host 'Clearing local image cache...'
+      }
+      default { Write-Host "Enabling addon: $Addon" }
+    }
+  } else {
+    Write-Host "Enabling addon: $Addon"
+  }
+
+  if (-not $skipCluster) {
+    Invoke-AapEnsureClusterReady
+  }
+
+  Invoke-AapAddonEnable -Addon $Addon -Namespace $Namespace -ScriptArgs $ScriptArgs
+
+  if (-not $skipSave) {
+    Add-AapAddon $Addon
+    $addons = (Get-AapAddonsList) -join ','
+    Write-AapStep "Saved to config: ADDONS=$addons"
+  }
 }
 
 function Invoke-AapDemoDisable {
   param(
     [string]$Addon = $null,
-    [string]$Namespace = $Script:AapDemoDefaultNamespace
+    [string]$Namespace = $Script:AapDemoDefaultNamespace,
+    [string[]]$ScriptArgs = @()
   )
 
   if (-not $Addon) {
-    Write-Host 'Usage: aap-demo disable <addon>'
+    Write-Host 'Usage: aap-demo disable <addon> [options]'
     Write-Host ''
     Write-Host "Available addons: $($Script:AapAvailableAddons -join ', ')"
+    Write-Host ''
+    Write-Host 'Addon options:'
+    Write-Host '  apme-eap: --purge-creds   Remove saved GitHub credentials and private key'
     return
   }
 
   $Addon = Resolve-AapAddonName $Addon
 
-  if ($Addon -notin $Script:AapAvailableAddons) {
+  if (-not (Test-AapAddonExists -Addon $Addon)) {
     throw "Unknown addon: $Addon"
   }
 
+  if (Test-AapAddonUsesBash -Addon $Addon) {
+    Assert-AapBashAvailable -Addon $Addon
+  }
+
   Write-Host "Disabling addon: $Addon"
-  Invoke-AapEnsureClusterReady
-  Invoke-AapAddonDisable -Addon $Addon -Namespace $Namespace
+  if ($Addon -ne 'setup-pah') {
+    Invoke-AapEnsureClusterReady
+  }
+  Invoke-AapAddonDisable -Addon $Addon -Namespace $Namespace -ScriptArgs $ScriptArgs
   Remove-AapAddon $Addon
-  Write-AapStep 'Removed from config'
+  if ($Addon -eq 'setup-pah') {
+    Write-AapStep 'Removed from config (PAH credentials remain in ~/.aap-demo/)'
+  } else {
+    Write-AapStep 'Removed from config'
+  }
 }
 
 function Write-AapClusterInfo {

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -5,6 +5,8 @@ function Invoke-AapDemoEnable {
     [string[]]$ScriptArgs = @()
   )
 
+  if ($null -eq $ScriptArgs) { $ScriptArgs = @() }
+
   if (-not $Addon) {
     Write-Host 'Usage: aap-demo enable <addon> [options]'
     Write-Host ''
@@ -41,7 +43,8 @@ function Invoke-AapDemoEnable {
   $skipSave = $false
   $skipCluster = $false
   if ($Addon -eq 'local-cache') {
-    switch ($ScriptArgs[0]) {
+    $subcmd = if ($ScriptArgs.Count -gt 0) { $ScriptArgs[0] } else { $null }
+    switch ($subcmd) {
       'load' {
         $skipSave = $true
         Write-Host 'Loading cached container images...'
@@ -68,6 +71,13 @@ function Invoke-AapDemoEnable {
     $addons = (Get-AapAddonsList) -join ','
     Write-AapStep "Saved to config: ADDONS=$addons"
   }
+
+  try {
+    Write-AapAddonAccessInfo -Addon $Addon -Namespace $Namespace
+  } catch {
+    Write-AapWarn "Could not display login info: $($_.Exception.Message)"
+    Write-Host '  Run: aap-demo status'
+  }
 }
 
 function Invoke-AapDemoDisable {
@@ -76,6 +86,8 @@ function Invoke-AapDemoDisable {
     [string]$Namespace = $Script:AapDemoDefaultNamespace,
     [string[]]$ScriptArgs = @()
   )
+
+  if ($null -eq $ScriptArgs) { $ScriptArgs = @() }
 
   if (-not $Addon) {
     Write-Host 'Usage: aap-demo disable <addon> [options]'

--- a/powershell/native/Private/Commands.ps1
+++ b/powershell/native/Private/Commands.ps1
@@ -60,7 +60,7 @@ function Invoke-AapDemoDisable {
   Write-AapStep 'Removed from config'
 }
 
-function Write-AapClusterSummary {
+function Write-AapClusterInfo {
   param([string]$Namespace = $Script:AapDemoDefaultNamespace)
 
   Initialize-AapKubeEnvironment
@@ -94,7 +94,44 @@ function Invoke-AapDemoStop {
   if (-not (Invoke-AapCrcStop)) {
     throw 'crc stop failed'
   }
-  Write-Host 'To restart: aap-demo deploy'
+  Write-Host 'To restart: aap-demo start'
+}
+
+function Invoke-AapDemoStart {
+  Write-Host ''
+  Write-Host 'aap-demo start - Starting CRC cluster...' -ForegroundColor Cyan
+
+  $crc = Get-AapCrcStatus
+  switch ([string]$crc.crcStatus) {
+    'Running' {
+      Write-AapStep 'CRC cluster is already running'
+    }
+    'Unknown' {
+      throw 'No cluster found. Run: aap-demo create'
+    }
+    default {
+      if (-not (Invoke-AapCrcStart)) {
+        throw 'crc start failed'
+      }
+    }
+  }
+
+  Sync-AapKubeconfig -Quiet
+  Initialize-AapKubeEnvironment
+
+  $routeDomain = Get-AapRouteDomain
+  if (Test-AapCoreDnsConfigured) {
+    Write-AapStep "CoreDNS already configured for $routeDomain"
+  } else {
+    Write-AapStep "Configuring CoreDNS for $routeDomain..."
+    Set-AapCoreDns -RouteDomain $routeDomain
+    Write-AapStep 'CoreDNS configured'
+  }
+
+  Write-Host ''
+  Write-AapStep 'CRC cluster started'
+  Write-Host "Run 'aap-demo status' to check cluster health"
+  Write-Host ''
 }
 
 function Invoke-AapDemoDestroy {
@@ -146,7 +183,7 @@ function Invoke-AapDemoClean {
   Write-Host ''
   Write-Host 'WARNING: AAP CLEANUP - DESTRUCTIVE OPERATION!' -ForegroundColor Red
   Write-Host ''
-  Write-AapClusterSummary -Namespace $Namespace
+  Write-AapClusterInfo -Namespace $Namespace
   Write-Host ''
 
   $aapResult = Invoke-AapOcCapture @('get', 'aap', '-n', $Namespace, '--no-headers')
@@ -483,7 +520,7 @@ function Invoke-AapDemoMustGather {
   Write-Host "To share: tar czf must-gather.tar.gz $DestDir"
 }
 
-function Write-AapClusterSummary {
+function Invoke-AapDemoRedeploy {
   [CmdletBinding()]
   param(
     [string]$Namespace = $Script:AapDemoDefaultNamespace,

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -157,7 +157,15 @@ function Invoke-AapEnsureCluster {
 
   Initialize-AapKubeEnvironment
   if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
-    throw 'oc cannot connect to cluster'
+    try {
+      Sync-AapKubeconfig -Quiet
+      Initialize-AapKubeEnvironment
+    } catch {
+      # Fall through to connection check below.
+    }
+    if ((Invoke-AapOcQuiet @('cluster-info')) -ne 0) {
+      throw 'oc cannot connect to cluster'
+    }
   }
 }
 

--- a/powershell/native/Private/Create.ps1
+++ b/powershell/native/Private/Create.ps1
@@ -161,6 +161,31 @@ function Invoke-AapEnsureCluster {
   }
 }
 
+function Get-AapRouteDomain {
+  $routeDomain = 'apps.crc.testing'
+  try {
+    $line = Invoke-AapCrcSsh 'grep -h baseDomain /etc/microshift/config.d/99-aap-demo-dns.yaml /etc/microshift/config.yaml 2>/dev/null | head -1' -AllowFailure
+    if ($line -match 'baseDomain:\s*(\S+)') {
+      $routeDomain = "apps.$($Matches[1])"
+    } elseif ($line) {
+      $field = ($line.Trim() -split '\s+')[-1]
+      if ($field) { $routeDomain = "apps.$field" }
+    }
+  } catch {
+    # openshift preset or SSH unavailable — use default apps.crc.testing
+  }
+  return $routeDomain
+}
+
+function Test-AapCoreDnsConfigured {
+  $result = Invoke-AapOcCapture @(
+    'get', 'configmap', 'dns-default', '-n', 'openshift-dns',
+    '-o', 'jsonpath={.data.Corefile}'
+  )
+  if ($result.ExitCode -ne 0 -or -not $result.Output) { return $false }
+  return $result.Output -match 'router-internal-default'
+}
+
 function Set-AapCoreDns {
   param([Parameter(Mandatory)][string]$RouteDomain)
 

--- a/powershell/native/Private/Deploy.ps1
+++ b/powershell/native/Private/Deploy.ps1
@@ -129,6 +129,7 @@ function Invoke-AapDemoDeploy {
   Write-AapStep 'AAP CR applied - reconciliation in progress'
   Write-Host ''
   Write-Host '  Monitor: aap-demo watch'
+  Write-Host '  Login:   aap-demo status (once deployment completes)'
   Write-Host '  Or:      aap-demo status'
   Write-AapSetupPahReminder
 }

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -1242,6 +1242,17 @@ function Remove-AapStaleCrcKubeEntries {
   }
 }
 
+function Test-AapOcClusterInfoKube {
+  param([Parameter(Mandatory)][string]$KubeConfig)
+  $prev = $env:KUBECONFIG
+  try {
+    $env:KUBECONFIG = $KubeConfig
+    return (Invoke-AapOcQuiet @('cluster-info')) -eq 0
+  } finally {
+    $env:KUBECONFIG = $prev
+  }
+}
+
 function Sync-AapKubeconfig {
   [CmdletBinding()]
   param(
@@ -1261,6 +1272,21 @@ function Sync-AapKubeconfig {
   $ctxName = 'aap-demo'
   $tempKube = [System.IO.Path]::GetTempFileName()
   Copy-Item -LiteralPath $crcKube -Destination $tempKube -Force
+
+  # CRC kubeconfig can be stale after MicroShift wipe/restart (nip.io setup).
+  if (-not (Test-AapOcClusterInfoKube -KubeConfig $tempKube)) {
+    $kubeadmin = Invoke-AapCrcSsh 'sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig' -AllowFailure
+    if (-not $kubeadmin) {
+      throw 'Could not fetch kubeconfig from cluster (CRC and kubeadmin sources failed)'
+    }
+    Set-Content -LiteralPath $tempKube -Value $kubeadmin -Encoding ascii
+    if (-not (Test-AapOcClusterInfoKube -KubeConfig $tempKube)) {
+      throw 'Fetched kubeconfig is not valid for cluster access'
+    }
+    if (-not $Quiet) {
+      Write-AapStep 'Refreshed credentials from MicroShift kubeadmin kubeconfig'
+    }
+  }
 
   try {
     $config = Get-AapOcConfigJson -KubeConfig $tempKube

--- a/powershell/native/Private/Helpers.ps1
+++ b/powershell/native/Private/Helpers.ps1
@@ -41,6 +41,34 @@ function Test-AapCommand {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Get-AapGitBashExecutable {
+  $candidates = @(
+    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+    (Join-Path $env:ProgramFiles 'Git\usr\bin\bash.exe')
+  )
+  if (${env:ProgramFiles(x86)}) {
+    $candidates += (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe')
+  }
+  foreach ($path in $candidates) {
+    if ($path -and (Test-Path -LiteralPath $path)) {
+      return $path
+    }
+  }
+
+  $bash = Get-Command bash -ErrorAction SilentlyContinue
+  if (-not $bash) { return $null }
+
+  $source = $bash.Source
+  if ($source -match '\\Windows\\System32\\bash\.exe$') {
+    return $null
+  }
+  return $source
+}
+
+function Test-AapGitBashAvailable {
+  return [bool](Get-AapGitBashExecutable)
+}
+
 function Update-AapSessionPath {
   $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
   $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
@@ -1018,6 +1046,45 @@ function Get-AapOcFirstListName {
   return ($line -split '\s+', 2)[0]
 }
 
+function Get-AapSecretPassword {
+  param(
+    [Parameter(Mandatory)][string]$Namespace,
+    [Parameter(Mandatory)][string]$SecretName,
+    [string]$Field = 'password'
+  )
+
+  $pwResult = Invoke-AapOcCapture @(
+    'get', 'secret', $SecretName, '-n', $Namespace,
+    '-o', "jsonpath={.data.$Field}"
+  )
+  if ($pwResult.ExitCode -ne 0 -or -not $pwResult.Output.Trim()) { return $null }
+  try {
+    return [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($pwResult.Output.Trim())
+    )
+  } catch {
+    return $null
+  }
+}
+
+function Get-AapRouteHost {
+  param(
+    [Parameter(Mandatory)][string]$Namespace,
+    [string]$RouteName = $null
+  )
+
+  $args = @('get', 'route')
+  if ($RouteName) {
+    $args += $RouteName
+    $args += @('-n', $Namespace, '-o', 'jsonpath={.spec.host}')
+  } else {
+    $args += @('-n', $Namespace, '-o', 'jsonpath={.items[0].spec.host}')
+  }
+  $result = Invoke-AapOcCapture $args
+  if ($result.ExitCode -ne 0 -or -not $result.Output.Trim()) { return $null }
+  return $result.Output.Trim()
+}
+
 function Get-AapAdminPassword {
   param([Parameter(Mandatory)][string]$Namespace)
 
@@ -1037,15 +1104,8 @@ function Get-AapAdminPassword {
   )
 
   foreach ($secretName in ($secretNames | Select-Object -Unique)) {
-    $pwResult = Invoke-AapOcCapture @(
-      'get', 'secret', $secretName, '-n', $Namespace,
-      '-o', 'jsonpath={.data.password}'
-    )
-    if ($pwResult.ExitCode -eq 0 -and $pwResult.Output.Trim()) {
-      return [Text.Encoding]::UTF8.GetString(
-        [Convert]::FromBase64String($pwResult.Output.Trim())
-      )
-    }
+    $password = Get-AapSecretPassword -Namespace $Namespace -SecretName $secretName
+    if ($password) { return $password }
   }
   return $null
 }

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -121,6 +121,32 @@ function Invoke-AapDemoStatus {
   }
   if (-not $foundCred) { Write-Host '  (no admin password secret found yet)' }
 
+  $aoNs = 'automation-orchestrator'
+  if ((Get-AapAddonsList) -contains 'ao-eap' -or (Invoke-AapOcQuiet @('get', 'namespace', $aoNs)) -eq 0) {
+    $aoSecrets = Invoke-AapOcCapture @('get', 'secret', '-n', $aoNs, '-o', 'name')
+    $aoSecretName = $null
+    if ($aoSecrets.ExitCode -eq 0 -and $aoSecrets.Output) {
+      $aoSecretName = @($aoSecrets.Lines | Where-Object { $_ -match 'admin-password' } | Select-Object -First 1)
+      if ($aoSecretName) { $aoSecretName = ($aoSecretName -replace '^secret/', '').Trim() }
+    }
+    if ($aoSecretName) {
+      $aoPwResult = Invoke-AapOcCapture @(
+        'get', 'secret', $aoSecretName, '-n', $aoNs, '-o', 'jsonpath={.data.password}'
+      )
+      $aoPw = if ($aoPwResult.ExitCode -eq 0) { $aoPwResult.Output.Trim() } else { '' }
+      if ($aoPw) {
+        $aoDecoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($aoPw))
+        if (-not $foundCred) {
+          Write-Host ''
+          Write-Host 'Credentials:'
+          Write-Host '------------'
+        }
+        Write-Host ("  {0,-20} admin / {1}" -f "${aoNs}:", $aoDecoded)
+        $foundCred = $true
+      }
+    }
+  }
+
   Write-AapCollectionSourcesStatus
 
   $savedAddons = @(Get-AapAddonsList)
@@ -136,7 +162,12 @@ function Invoke-AapDemoStatus {
       $enabled = (Invoke-AapOcQuiet @('get', 'namespace', 'apme')) -eq 0
     }
     $state = if ($enabled) { 'enabled' } else { 'disabled' }
-    Write-Host ("  {0,-15} {1}" -f $a, $state)
+    $label = Get-AapAddonStatusLabel -Addon $a -Namespace $Namespace -Enabled:$enabled
+    if ($label) {
+      Write-Host ("  {0,-25} {1}" -f $a, $label)
+    } else {
+      Write-Host ("  {0,-25} {1}" -f $a, $state)
+    }
   }
   Write-Host ''
 }
@@ -176,10 +207,9 @@ STATUS:
     must-gather     Collect diagnostic bundle
 
 ADDONS:
-    enable portal   Enable Self-Service Portal (Helm; auto-detects arm64 vs amd64)
-                    Requires: AAP 2.6+, Helm 3.10+, Red Hat pull secret
-    enable mcp-server  Enable MCP server for AI assistants
-    disable <name>  Disable an addon (portal, mcp-server)
+    enable <addon>  Enable an addon (portal, mcp-server, setup-pah, product-demos, ...)
+    disable <name>  Disable an addon
+                    Bash-delegated addons require Git for Windows (bash on PATH)
 
 NOTES:
     Requires oc and crc on PATH. OpenShift Local needs Hyper-V.

--- a/powershell/native/Private/Status.ps1
+++ b/powershell/native/Private/Status.ps1
@@ -99,55 +99,7 @@ function Invoke-AapDemoStatus {
   if ($routes) { $routes | ForEach-Object { Write-Host $_ } }
   else { Write-Host '  (no routes found)' }
 
-  Write-Host ''
-  Write-Host 'Credentials:'
-  Write-Host '------------'
-  $aapNsResult = Invoke-AapOcCapture @('get', 'aap', '-A', '--no-headers')
-  $aapNs = if ($aapNsResult.ExitCode -eq 0 -and $aapNsResult.Output -notmatch '^No resources found') {
-    $aapNsResult.Lines | ForEach-Object { ($_ -split '\s+')[0] } | Sort-Object -Unique
-  } else { @() }
-  $foundCred = $false
-  foreach ($ns in $aapNs) {
-    foreach ($secretName in @('aap-admin-password', 'myaap-admin-password', 'aap-controller-admin-password')) {
-      $pwResult = Invoke-AapOcCapture @('get', 'secret', $secretName, '-n', $ns, '-o', 'jsonpath={.data.password}')
-      $pw = if ($pwResult.ExitCode -eq 0) { $pwResult.Output.Trim() } else { '' }
-      if ($pw) {
-        $decoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($pw))
-        Write-Host ("  {0,-20} admin / {1}" -f "${ns}:", $decoded)
-        $foundCred = $true
-        break
-      }
-    }
-  }
-  if (-not $foundCred) { Write-Host '  (no admin password secret found yet)' }
-
-  $aoNs = 'automation-orchestrator'
-  if ((Get-AapAddonsList) -contains 'ao-eap' -or (Invoke-AapOcQuiet @('get', 'namespace', $aoNs)) -eq 0) {
-    $aoSecrets = Invoke-AapOcCapture @('get', 'secret', '-n', $aoNs, '-o', 'name')
-    $aoSecretName = $null
-    if ($aoSecrets.ExitCode -eq 0 -and $aoSecrets.Output) {
-      $aoSecretName = @($aoSecrets.Lines | Where-Object { $_ -match 'admin-password' } | Select-Object -First 1)
-      if ($aoSecretName) { $aoSecretName = ($aoSecretName -replace '^secret/', '').Trim() }
-    }
-    if ($aoSecretName) {
-      $aoPwResult = Invoke-AapOcCapture @(
-        'get', 'secret', $aoSecretName, '-n', $aoNs, '-o', 'jsonpath={.data.password}'
-      )
-      $aoPw = if ($aoPwResult.ExitCode -eq 0) { $aoPwResult.Output.Trim() } else { '' }
-      if ($aoPw) {
-        $aoDecoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($aoPw))
-        if (-not $foundCred) {
-          Write-Host ''
-          Write-Host 'Credentials:'
-          Write-Host '------------'
-        }
-        Write-Host ("  {0,-20} admin / {1}" -f "${aoNs}:", $aoDecoded)
-        $foundCred = $true
-      }
-    }
-  }
-
-  Write-AapCollectionSourcesStatus
+  Write-AapCredentialsStatus -Namespace $Namespace
 
   $savedAddons = @(Get-AapAddonsList)
   Write-Host ''
@@ -162,12 +114,7 @@ function Invoke-AapDemoStatus {
       $enabled = (Invoke-AapOcQuiet @('get', 'namespace', 'apme')) -eq 0
     }
     $state = if ($enabled) { 'enabled' } else { 'disabled' }
-    $label = Get-AapAddonStatusLabel -Addon $a -Namespace $Namespace -Enabled:$enabled
-    if ($label) {
-      Write-Host ("  {0,-25} {1}" -f $a, $label)
-    } else {
-      Write-Host ("  {0,-25} {1}" -f $a, $state)
-    }
+    Write-Host ("  {0,-15} {1}" -f $a, $state)
   }
   Write-Host ''
 }


### PR DESCRIPTION
## Summary
- Fix PowerShell `redeploy`/`start` and expand addon allowlists so Windows matches bash lifecycle commands.
- Run `apme-eap` as an AAP Controller job on Windows (no local Python), with token-only GitHub Helm values so the portal can become Ready.
- Install `ao-eap` `aapctl` on the CRC VM (no Windows binary), and fix Git Bash issues in local-cache and product-demos overlays.

## Test plan
- [ ] `aap-demo start` after `stop` restores CRC and CoreDNS on Windows
- [ ] `aap-demo redeploy` cleans and redeploys without recursion
- [ ] `aap-demo enable ao-eap` installs aapctl on the CRC VM and reaches a route
- [ ] `aap-demo enable apme-eap` with a PAT (no GitHub App) completes Helm wait
- [ ] `aap-demo enable local-cache` / `product-demos` succeed under Git Bash
- [ ] `aap-demo status` after enable shows access details for AAP, AO, and APME

Made with [Cursor](https://cursor.com)