### PR TITLE
fix(wire): portable jq chunking for MCP tool bulk-enable

### DIFF
--- a/includes/addon-wire.sh
+++ b/includes/addon-wire.sh
@@ -585,10 +585,13 @@ wire_ao_enable_all_tools() {
     return 0
   fi
 
-  echo "$tool_ids_json" | jq -c '[_nwise(50)] | .[]' | while read -r chunk; do
-    wire_ao_api PATCH "/integrations/${integration_id}/tools/bulk_update" \
-      "$(jq -n --argjson ids "$chunk" '{tool_ids: $ids, enabled: true}')" >/dev/null 2>&1 || true
-  done
+  # Portable chunking (_nwise is missing from some jq builds, e.g. Fedora jq 1.8.1).
+  echo "$tool_ids_json" | jq -c --argjson n 50 \
+    '. as $arr | [range(0; ($arr | length); $n) as $i | $arr[$i:$i+$n]] | .[]' \
+    | while read -r chunk; do
+      wire_ao_api PATCH "/integrations/${integration_id}/tools/bulk_update" \
+        "$(jq -n --argjson ids "$chunk" '{tool_ids: $ids, enabled: true}')" >/dev/null 2>&1 || true
+    done
 }
 
 wire_ao_ensure_integration() {


### PR DESCRIPTION
## Summary

Follow-up to #114. During Linux server testing, `aap-demo enable ao` logged:

```
jq: error: _nwise/1 is not defined at <top-level>, line 1, column 2
```

Fedora/RHEL `jq` 1.8.1 does not define `_nwise`, so `wire_ao_enable_all_tools` failed to bulk-enable MCP tools during AO wiring. Integrations still created, but MCP tools may remain disabled.

Replaces `[_nwise(50)]` with a portable `range`/`slice` expression that works on macOS and Linux jq builds.

## Test plan

- [ ] On Fedora/RHEL with `jq` 1.8.x: `echo '[1,2,3,4,5]' | jq -c --argjson n 2 '. as $arr | [range(0; ($arr | length); $n) as $i | $arr[$i:$i+$n]] | .[]'` chunks correctly
- [ ] `aap-demo wire` on a cluster with AO + MCP: no jq error; MCP tools enabled on integration

Made with [Cursor](https://cursor.com)